### PR TITLE
ci: fix golangci-lint action compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,10 +46,9 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
-          install-mode: goinstall
+          version: v2.12
           args: --timeout=3m
 
   build:

--- a/docs/ci-fix-note.md
+++ b/docs/ci-fix-note.md
@@ -1,0 +1,1 @@
+CI fix note: align golangci-lint action with the current official action/runtime by using golangci-lint-action@v9 and a pinned v2.12 binary install. Test/build/Helm/security jobs remain unchanged.

--- a/docs/ci-fix-note.md
+++ b/docs/ci-fix-note.md
@@ -1,1 +1,0 @@
-CI fix note: align golangci-lint action with the current official action/runtime by using golangci-lint-action@v9 and a pinned v2.12 binary install. Test/build/Helm/security jobs remain unchanged.


### PR DESCRIPTION
Fix the failing lint job by aligning the GitHub Action with the current golangci-lint v2 workflow.\n\nChanges:\n- golangci/golangci-lint-action v6 → v9\n- pin golangci-lint to v2.12 instead of mutable latest\n- use the action default binary installation mode\n\nTest/build/Helm/security jobs are unchanged.