### PR TITLE
feat(production): real health semantics, probes, HA defaults, drop hostPID

### DIFF
--- a/charts/nfs-quota-agent/templates/deployment.yaml
+++ b/charts/nfs-quota-agent/templates/deployment.yaml
@@ -39,11 +39,23 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- if .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if .Values.podAntiAffinity.enabled }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: {{ .Values.podAntiAffinity.weight }}
+              podAffinityTerm:
+                topologyKey: {{ .Values.podAntiAffinity.topologyKey }}
+                labelSelector:
+                  matchLabels:
+                    {{- include "nfs-quota-agent.selectorLabels" . | nindent 20 }}
       {{- end }}
+      {{- if .Values.hostPID }}
       hostPID: true
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ include "nfs-quota-agent.image" . }}
@@ -101,6 +113,38 @@ spec:
               containerPort: {{ (split ":" .Values.webUI.addr)._1 | default 8080 }}
               protocol: TCP
             {{- end }}
+          {{- if .Values.config.metricsAddr }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: metrics
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: metrics
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: metrics
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- end }}
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/charts/nfs-quota-agent/values.yaml
+++ b/charts/nfs-quota-agent/values.yaml
@@ -105,6 +105,42 @@ tolerations:
 
 affinity: {}
 
+# Soft pod anti-affinity to spread replicas across nodes when
+# replicaCount > 1. Off by default to preserve existing single-replica
+# behavior. Ignored when `affinity` above is set (that raw override wins).
+# Kept "preferred" rather than "required": this agent is usually pinned via
+# nodeSelector to NFS server nodes, and a hard requirement would leave
+# extra replicas permanently unschedulable if only one such node exists.
+podAntiAffinity:
+  enabled: false
+  topologyKey: kubernetes.io/hostname
+  weight: 100
+
+# Liveness/readiness/startup probes, served by the metrics port's /health
+# and /ready endpoints. /ready also backs the startup probe: liveness and
+# readiness are disabled by Kubernetes until it succeeds, so the startup
+# probe's own budget (failureThreshold * periodSeconds) is the real grace
+# period for slow NFS mounts and the agent's initial quota sync.
+probes:
+  startup:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30 # ~5m room for a slow NFS mount + initial sync
+  liveness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
 resources:
   limits:
     cpu: 100m
@@ -112,6 +148,14 @@ resources:
   requests:
     cpu: 50m
     memory: 64Mi
+
+# Share the host PID namespace. Off by default: the agent never inspects
+# host processes (it resolves paths inside the container's own mount
+# namespace via findmnt/df against the hostPath-mounted export), so this
+# grants visibility of every host process — combined with `privileged: true`
+# below, for zero functional benefit. Set to true only if a specific
+# deployment genuinely needs it.
+hostPID: false
 
 # Security context for the container
 # Privileged is required for xfs_quota/setquota commands
@@ -139,6 +183,12 @@ metrics:
 
 # Pod disruption budget configuration
 podDisruptionBudget:
-  enabled: false
-  minAvailable: 1
+  enabled: true
+  # maxUnavailable, not minAvailable: with the default replicaCount: 1, a
+  # minAvailable: 1 PDB would require the sole replica to stay available at
+  # all times, which permanently blocks voluntary node drains/maintenance.
+  # maxUnavailable: 1 explicitly permits that one replica to be evicted.
+  # If you raise replicaCount, maxUnavailable: 1 still caps disruption to
+  # one pod at a time rather than requiring a rethink of the default.
+  maxUnavailable: 1
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,185 @@
+# Security Threat Model and Privilege Analysis
+
+This document provides a security threat model and minimum-privilege assessment for `nfs-quota-agent`. All statements and privilege requirements are grounded in empirical codebase analysis of the Helm chart and Go package sources.
+
+## 1. Why Privileges Are Required
+
+`nfs-quota-agent` operates on the NFS server node to manage XFS, ext4, and Btrfs filesystem project quotas for Kubernetes `PersistentVolume` resources. The table below lists every security privilege and host mount configured in [deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml), the internal operations requiring it, and the operational impact if omitted.
+
+| Privilege / Mount | Location in Code / Helm Chart | Specific Code Operation Requiring It | Consequence If Omitted / Disabled | Status / Verdict |
+| :--- | :--- | :--- | :--- | :--- |
+| `privileged: true` | [values.yaml](../charts/nfs-quota-agent/values.yaml)<br>[deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml) | Issuing `quotactl`, `xfsctl`, `FS_IOC_SETFLAGS` (`chattr +P`), and Btrfs qgroup ioctls via external binaries (`xfs_quota`, `setquota`, `chattr`, `btrfs`). | Quota binaries fail with `EPERM` (Operation not permitted) or `EACCES` when attempting filesystem ioctls. | Required unless replaced by explicit capabilities. |
+| `hostPID: true` | [deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml) | **None.** Code inspection reveals zero references to `/proc`, host PIDs, process inspection, or `nsenter`. | None. No code path relies on the host PID namespace. | **UNNECESSARY. Candidate for removal.** |
+| `/data` (`nfsExport.hostPath`) | [deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml)<br>[deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml) | `os.Stat` checks in [agent.go](../internal/agent/agent.go), `filepath.WalkDir` in [ext4.go](../internal/quota/ext4.go), and `GetDirSize` in [dir.go](../internal/status/dir.go). | Agent cannot stat PVC export paths or apply project directory attributes. | Required. |
+| `/dev` hostPath mount | [deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml)<br>[deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml) | `xfs_quota`, `setquota`, `findmnt`, and `df` inspect block device nodes in `/dev` to identify backing filesystem devices. | `xfs_quota` and `setquota` fail to map mount paths to underlying block devices. | Required, but scope can be narrowed. |
+| `/etc/projects` hostPath mount | [deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml)<br>[deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml) | `AddProject`, `RemoveLineFromFile`, and `ReadProjectsFile` in [project.go](../internal/quota/project.go) write/read `projectID:path` entries. | XFS/ext4 project quota mapping fails; host filesystem utilities lose project path metadata. | Required for XFS & ext4. |
+| `/etc/projid` hostPath mount | [deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml)<br>[deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml) | `AddProject`, `RemoveLineFromFile`, `ReadProjidFile`, and `loadExistingProjectIDs` in [agent.go](../internal/agent/agent.go) write/read `projectName:projectID` entries. | Project ID generation and collision resolution against existing host IDs fail. | Required for XFS & ext4. |
+| `/var/log/nfs-quota-agent` | [deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml)<br>[deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml) | Persists structured JSON audit logs emitted by `audit.Logger` in [logger.go](../internal/audit/logger.go). | Audit logs are lost when the container restarts. | Optional (enabled via `audit.enabled`). |
+| `/var/lib/nfs-quota-agent` | [deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml)<br>[deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml) | Persists historical usage snapshots in `history.Store` in [store.go](../internal/history/store.go). | Usage history trend data is lost on container restart. | Optional (enabled via `history.enabled`). |
+
+---
+
+## 2. Minimum-Privilege Alternatives
+
+### Evaluation of Linux Capabilities vs. `privileged: true`
+Full `privileged: true` grants all Linux capabilities and disables seccomp/AppArmor isolation. A least-privilege configuration should replace `privileged: true` with targeted Linux capabilities:
+
+1. **`CAP_SYS_ADMIN`**: Required for executing `quotactl()` syscalls, XFS ioctls (`XFS_IOC_FSSETDM`), `chattr +P` (`FS_IOC_SETFLAGS`), and Btrfs qgroup ioctls.
+2. **`CAP_DAC_OVERRIDE` & `CAP_FOWNER`**: Required to traverse, inspect, and set project attributes across directories owned by arbitrary UID/GID combinations on the exported NFS share.
+3. **`CAP_SYS_RESOURCE`**: Required on certain kernel configurations to override system-wide quota resource limits.
+
+#### Proposed Non-Privileged `securityContext`
+```yaml
+securityContext:
+  privileged: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - SYS_ADMIN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SYS_RESOURCE
+  readOnlyRootFilesystem: false  # Needs write access to /etc/projects, /etc/projid, and log paths
+  runAsNonRoot: false            # Host quota ioctls and /etc file writes require UID 0
+```
+
+*Verdict*: Granular capability dropping is theoretically viable. However, external binaries such as `xfs_quota` and `btrfs` may perform device identification against host mount namespaces. If running in an unprivileged container namespace, `xfs_quota` may fail unless the container shares mount contexts or raw device access. Empirical host kernel testing is required before enforcing `privileged: false` in production releases.
+
+### Analysis of `hostPID: true`
+*Verdict*: **Not Load-Bearing.** `hostPID: true` is set on line 46 of [deployment.yaml](../charts/nfs-quota-agent/templates/deployment.yaml). A thorough search of all Go source files confirms zero interactions with host process tables, `/proc`, or process namespace operations. Removing `hostPID: true` reduces container blast radius with zero functional regression.
+
+### Narrowing the `/dev` Mount
+*Verdict*: **Viable.** Mounting the entire host `/dev` directory (`hostPath: /dev`) exposes all host block devices, serial ports, pseudo-terminals, and device nodes (e.g., `/dev/mem`, `/dev/kmem`). Where the NFS export resides on a known host disk (e.g., `/dev/sda1` or `/dev/nvme0n1p1`), the volume mount should be constrained to that explicit device node using `hostPath.type: BlockDevice`.
+
+---
+
+## 3. Threat Model
+
+### Attack Surfaces and Blast Radius
+
+```
++-----------------------------------------------------------------------------------+
+| Kubernetes Control Plane / User Space                                            |
+|                                                                                   |
+|  [ Hostile User ] ---> Creates PV/PVC ---> [ PV Annotation: nfs.io/project-name ] |
+|                                                              |                    |
++--------------------------------------------------------------|--------------------+
+                                                               v
++-----------------------------------------------------------------------------------+
+| Agent Container Boundary                                                          |
+|                                                                                   |
+|  [ validateQuotaArg ] ---> Cleans Input ---> [ CommandRunner: exec.Command ]      |
+|                                                              |                    |
+|  [ Host Path Mapping ] ---> pvpath.ToLocal                   v                    |
+|                                                     [ Host Binaries ]             |
+|                                                (xfs_quota / setquota / btrfs)     |
++--------------------------------------------------------------|--------------------+
+                                                               v
++-----------------------------------------------------------------------------------+
+| Host NFS Server Node Boundary                                                     |
+|                                                                                   |
+|  [ /data Mount ] ------------> /export Directory Tree                             |
+|  [ /etc/projects, projid ] ---> Host Quota Filesystem Metadata                    |
+|  [ Kernel Filesystem ] -------> Block Device & Quota Subsystems (ioctl)           |
++-----------------------------------------------------------------------------------+
+```
+
+#### Vector 1: Compromised Agent Container
+* **Attacker Capability**: Execution of arbitrary shell commands or code inside the `nfs-quota-agent` container.
+* **Blast Radius under Current Config (`privileged: true`, `hostPID: true`, `hostPath: /dev`)**: High. The attacker can access all host block devices in `/dev`, inspect host processes via `hostPID`, and execute raw kernel exploits to achieve full host node compromise.
+* **Blast Radius under Hardened Config**: Medium-Low. With `hostPID: false`, narrowed `/dev`, and capability dropping, attacker reach is confined to modifying files on the mounted `/data` NFS export and altering host `/etc/projects` and `/etc/projid` files.
+
+#### Vector 2: Malicious PV Annotations (`nfs.io/project-name`) Reaching Binary `argv`
+* **Attacker Input Source**: Untrusted metadata in `pv.Annotations["nfs.io/project-name"]` parsed in [agent.go](../internal/agent/agent.go).
+* **Validation Defense**: Inputs are checked by `validateQuotaArg()` in [validate.go](../internal/quota/validate.go):
+  ```go
+  func validateQuotaArg(kind, value string) error {
+      if value == "" { return fmt.Errorf(...) }
+      for _, r := range value {
+          if unicode.IsSpace(r) || r == '\'' || r == '"' || unicode.IsControl(r) {
+              return fmt.Errorf(...)
+          }
+      }
+      return nil
+  }
+  ```
+* **Execution Safety**: All binary invocations pass through `CommandRunner` in [runner.go](../internal/quota/runner.go) using `exec.Command(name, args...)`. Arguments are passed as discrete strings to the `execve()` system call without subshell invocation (`sh -c`).
+* **Security Assessment**: Robust against command injection, shell metacharacter manipulation, and argument splitting.
+
+#### Vector 3: Malicious PersistentVolume Path Traversal
+* **Attacker Input Source**: Malicious `spec.nfs.path` or CSI `subDir` attribute containing relative path components (e.g., `/data/../../etc`).
+* **Path Conversion Logic**: [pvpath.go](../internal/pvpath/pvpath.go) converts NFS paths via `filepath.Join`.
+* **Identified Vulnerability Gap**:
+  While `cleanup.go:L162` explicitly enforces root containment using `pvpath.Contains(basePath, cleanPath)`, [agent.go](../internal/agent/agent.go) calls `a.nfsPathToLocal(nfsPath)` without checking `pvpath.Contains`. If a crafted PV path evaluates to `/etc`, `ensureQuota` will attempt to stat and apply project quota logic to host directories outside the intended `/export` root.
+  *Remediation*: Add `if !pvpath.Contains(a.nfsBasePath, localPath)` guard in `agent.go:ensureQuota`.
+
+---
+
+## 4. RBAC Surface Analysis
+
+The agent uses a cluster-scoped `ClusterRole` defined in [clusterrole.yaml](../charts/nfs-quota-agent/templates/clusterrole.yaml).
+
+| API Group | Resource | Verbs | Justification in Code | RBAC Scope Assessment |
+| :--- | :--- | :--- | :--- | :--- |
+| `""` | `persistentvolumes` | `get`, `list`, `watch`, `update`, `patch` | `syncAllQuotas` lists PVs ([agent.go](../internal/agent/agent.go)); `updateQuotaStatus` updates `nfs.io/quota-status` annotation ([agent.go](../internal/agent/agent.go)). | Tightly scoped. `update`/`patch` is strictly required for writing quota status annotations. |
+| `""` | `persistentvolumeclaims` | `get`, `list`, `watch` | **None found.** No `PersistentVolumeClaims(...)` client call exists anywhere in `internal/` or `cmd/`. Claim identity is read from `pv.Spec.ClaimRef`, which is part of the PV object already retrieved. | **Unused — candidate for removal.** |
+| `storage.k8s.io` | `storageclasses` | `get`, `list`, `watch` | **None found.** No `StorageClasses(...)` client call and no reference to `storageClassName` exists. Provisioner matching compares `pv.Spec.CSI.Driver` against the configured name directly ([agent.go](../internal/agent/agent.go)), never consulting the StorageClass. | **Unused — candidate for removal.** |
+| `""` | `namespaces` | `get`, `list`, `watch` | `Namespaces().Get` / `.List` for policy annotations ([policy.go](../internal/policy/policy.go), [policy.go](../internal/policy/policy.go)). | Read-only. Used. |
+| `""` | `limitranges` | `get`, `list`, `watch` | `LimitRanges().List` for default PVC storage limits ([policy.go](../internal/policy/policy.go), [policy.go](../internal/policy/policy.go)). | Read-only. Used. |
+| `""` | `resourcequotas` | `get`, `list`, `watch` | `ResourceQuotas().List` for namespace storage caps ([policy.go](../internal/policy/policy.go), [policy.go](../internal/policy/policy.go)). | Read-only. Used. |
+
+*Verdict*: No wildcard (`*`) verbs and no `delete` on cluster resources, and the only write access is `update`/`patch` on PVs for the status annotation — so the footprint is narrow in kind. It is **not** minimal in extent: two of the six rules (`persistentvolumeclaims`, `storageclasses`) grant cluster-wide read access that no code path exercises. Removing them costs nothing today.
+
+Note that `persistentvolumeclaims` read access is cluster-wide and PVCs are namespaced user-facing objects, so this grant is more meaningful than its unused status suggests — it lets a compromised agent enumerate every claim in the cluster. Verify against your own fork before removing, in case a downstream change added a consumer.
+
+---
+
+## 5. Pod Security Admission (PSA) Compliance
+
+Because the agent requires `hostPath` volumes (`/data`, `/dev`, `/etc/projects`, `/etc/projid`) and root/capability execution, the deployment **cannot** satisfy Kubernetes `restricted` or `baseline` Pod Security Admission standards.
+
+It requires the **`privileged`** PSA profile.
+
+### Recommended Namespace Security Policy Manifest
+Cluster operators should deploy the agent into a dedicated namespace labeled with `privileged` PSA enforcement:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nfs-quota-agent
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+```
+
+### Risk Isolation for Cluster Operators
+Granting a `privileged` namespace exception exposes only the designated NFS server node to risk, provided `nodeSelector` pinning is configured:
+* The agent is constrained to NFS nodes via `nodeSelector: nfs-server: "true"` ([values.yaml](../charts/nfs-quota-agent/values.yaml)).
+* General application workloads running on worker nodes cannot leverage the agent's privilege context.
+
+---
+
+## 6. Operational Hardening Guidance
+
+1. **Dedicated Node Isolation**:
+   Always run `nfs-quota-agent` on dedicated NFS server nodes. Apply node taints (e.g., `nfs-server=true:NoSchedule`) and matching tolerations to prevent tenant workloads from co-locating on the NFS node.
+2. **Restrict PV Creation Access**:
+   Ensure Kubernetes RBAC prevents regular users from creating or patching `PersistentVolume` objects directly. PV creation must be restricted to automated CSI provisioners.
+3. **Path Traversal Sanity Gate**:
+   Implement an admission webhook or Kyverno rule validating that `spec.nfs.path` and CSI `subDir` attributes do not contain `..` directory traversal sequences.
+4. **Audit Logging & Monitoring**:
+   * Enable agent audit logging via `--enable-audit` ([values.yaml](../charts/nfs-quota-agent/values.yaml)).
+   * Monitor Prometheus metrics for `QuotaStatusFailed` conditions.
+   * Configure host-level `auditd` monitoring on `/etc/projects` and `/etc/projid` to detect unauthorized out-of-band modifications.
+
+---
+
+## 7. Unverified / Needs Confirmation
+
+1. **Empirical Capability Testing**: Verification whether `privileged: false` with `SYS_ADMIN`, `DAC_OVERRIDE`, `FOWNER`, `SYS_RESOURCE` fully succeeds for `xfs_quota` and `btrfs` without host mount namespace access requires testing on live RHEL/XFS and Ubuntu/ext4 kernel nodes.
+2. **`/dev` Granular Device Mount**: Confirming whether `xfs_quota` operates correctly when mounted with only specific block device nodes (e.g., `/dev/sda1`) rather than host `/dev` depends on system `libxcmd` storage device enumeration behaviors.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -87,7 +87,28 @@ type QuotaAgent struct {
 	enablePolicy    bool
 	defaultQuota    int64
 	enforceMaxQuota bool
+
+	// Health/readiness state, read by the metrics server's /health and
+	// /ready handlers. Kept on a dedicated mutex, separate from mu, so
+	// probe reads never contend with quota-application work.
+	healthMu                sync.RWMutex
+	lastHeartbeat           time.Time // updated once per Run() loop iteration; liveness proof of life
+	fsDetected              bool
+	quotaAvailable          bool
+	initialSyncDone         bool
+	consecutiveSyncFailures int
+	lastSyncErr             error
 }
+
+// livenessStallMultiplier controls how many syncInterval periods may pass
+// without a heartbeat before liveness reports not-ok. It must be generous:
+// too tight and a legitimately slow sync (many PVs) trips a restart loop.
+const livenessStallMultiplier = 4
+
+// readinessSyncFailureThreshold is the number of consecutive sync failures
+// after which readiness flips to not-ready. A single transient failure
+// (e.g. one missed API call) should not pull the instance out of service.
+const readinessSyncFailureThreshold = 3
 
 // NewQuotaAgent creates a new QuotaAgent
 func NewQuotaAgent(client kubernetes.Interface, nfsBasePath, nfsServerPath, provisionerName string) *QuotaAgent {
@@ -183,12 +204,117 @@ func (a *QuotaAgent) AppliedQuotaCount() int {
 	return len(a.appliedQuotas)
 }
 
+// recordHeartbeat marks the periodic sync loop as having made progress.
+// Called once at Run() start and once per loop iteration; liveness compares
+// its age against syncInterval, never against Kubernetes API or NFS state.
+func (a *QuotaAgent) recordHeartbeat() {
+	a.healthMu.Lock()
+	a.lastHeartbeat = time.Now()
+	a.healthMu.Unlock()
+}
+
+// setFilesystemDetected records whether detectFilesystemType succeeded.
+func (a *QuotaAgent) setFilesystemDetected(v bool) {
+	a.healthMu.Lock()
+	a.fsDetected = v
+	a.healthMu.Unlock()
+}
+
+// setQuotaAvailable records whether checkQuotaAvailable succeeded.
+func (a *QuotaAgent) setQuotaAvailable(v bool) {
+	a.healthMu.Lock()
+	a.quotaAvailable = v
+	a.healthMu.Unlock()
+}
+
+// recordSyncResult records the outcome of a syncAllQuotas attempt (initial
+// or periodic). Consecutive failures accumulate and flip readiness to
+// not-ready once they cross readinessSyncFailureThreshold; a success resets
+// the counter so a single transient failure doesn't pull the instance out
+// of service.
+func (a *QuotaAgent) recordSyncResult(err error) {
+	a.healthMu.Lock()
+	defer a.healthMu.Unlock()
+	a.initialSyncDone = true
+	if err != nil {
+		a.consecutiveSyncFailures++
+		a.lastSyncErr = err
+		return
+	}
+	a.consecutiveSyncFailures = 0
+	a.lastSyncErr = nil
+}
+
+// LivenessOK reports whether the agent's main loop is making progress. It
+// deliberately does not consult the Kubernetes API or the NFS mount: a
+// probe wired to it must not restart-loop on a transient outage that a
+// restart cannot fix. Before the first loop iteration completes it reports
+// ok, since startup work (filesystem detection, initial sync) legitimately
+// takes time.
+func (a *QuotaAgent) LivenessOK() (bool, string) {
+	a.healthMu.RLock()
+	hb := a.lastHeartbeat
+	interval := a.syncInterval
+	a.healthMu.RUnlock()
+
+	if hb.IsZero() {
+		return true, "starting"
+	}
+	if interval <= 0 {
+		return true, "ok"
+	}
+	threshold := interval * livenessStallMultiplier
+	if age := time.Since(hb); age > threshold {
+		return false, fmt.Sprintf("sync loop stalled: last heartbeat %s ago (threshold %s)", age.Round(time.Second), threshold)
+	}
+	return true, "ok"
+}
+
+// ReadinessOK reports whether this instance can enforce quotas right now:
+// filesystem type detected, quota subsystem available, base path present,
+// and the initial sync completed without a run of consecutive failures. It
+// reads live state, so it flips back to not-ready if sync starts failing
+// repeatedly after having been ready. An agent with zero PVs to manage is
+// legitimately ready, so this never consults AppliedQuotaCount.
+func (a *QuotaAgent) ReadinessOK() (bool, string) {
+	a.healthMu.RLock()
+	fsDetected := a.fsDetected
+	quotaAvailable := a.quotaAvailable
+	initialSyncDone := a.initialSyncDone
+	failures := a.consecutiveSyncFailures
+	lastErr := a.lastSyncErr
+	a.healthMu.RUnlock()
+
+	if !fsDetected {
+		return false, "filesystem type not detected"
+	}
+	if !quotaAvailable {
+		return false, "quota subsystem not available"
+	}
+	if _, err := os.Stat(a.nfsBasePath); err != nil {
+		return false, fmt.Sprintf("base path not accessible: %v", err)
+	}
+	if !initialSyncDone {
+		return false, "initial quota sync not yet completed"
+	}
+	if failures >= readinessSyncFailureThreshold {
+		return false, fmt.Sprintf("quota sync failing: %d consecutive failures (last error: %v)", failures, lastErr)
+	}
+	return true, "ok"
+}
+
 // Run starts the quota agent
 func (a *QuotaAgent) Run(ctx context.Context) error {
+	// Mark the process alive before any startup work, so liveness is
+	// generous during (potentially slow) filesystem/quota detection rather
+	// than reporting not-started as a stall.
+	a.recordHeartbeat()
+
 	// Detect filesystem type
 	if err := a.detectFilesystemType(); err != nil {
 		return fmt.Errorf("failed to detect filesystem type: %w", err)
 	}
+	a.setFilesystemDetected(true)
 
 	slog.Info("Starting NFS Quota Agent",
 		"nfsBasePath", a.nfsBasePath,
@@ -202,6 +328,7 @@ func (a *QuotaAgent) Run(ctx context.Context) error {
 	if err := a.checkQuotaAvailable(); err != nil {
 		return fmt.Errorf("quota not available: %w", err)
 	}
+	a.setQuotaAvailable(true)
 
 	// Load existing projects
 	if err := a.loadProjects(); err != nil {
@@ -211,6 +338,9 @@ func (a *QuotaAgent) Run(ctx context.Context) error {
 	// Initial sync
 	if err := a.syncAllQuotas(ctx); err != nil {
 		slog.Error("Initial quota sync failed", "error", err)
+		a.recordSyncResult(err)
+	} else {
+		a.recordSyncResult(nil)
 	}
 
 	// Start watching PVs
@@ -236,8 +366,12 @@ func (a *QuotaAgent) Run(ctx context.Context) error {
 			slog.Info("Quota agent shutting down")
 			return nil
 		case <-ticker.C:
+			a.recordHeartbeat()
 			if err := a.syncAllQuotas(ctx); err != nil {
 				slog.Error("Periodic quota sync failed", "error", err)
+				a.recordSyncResult(err)
+			} else {
+				a.recordSyncResult(nil)
 			}
 		}
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -731,3 +731,118 @@ func TestCollectHistoryStopsOnContextCancel(t *testing.T) {
 		t.Fatalf("collectHistory did not stop after context cancellation")
 	}
 }
+
+func TestLivenessOK_BeforeFirstHeartbeat(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.SetSyncInterval(time.Second)
+
+	ok, reason := a.LivenessOK()
+	if !ok {
+		t.Fatalf("LivenessOK before any heartbeat should be ok, got reason %q", reason)
+	}
+}
+
+func TestLivenessOK_FreshHeartbeat(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.SetSyncInterval(time.Minute)
+	a.recordHeartbeat()
+
+	ok, reason := a.LivenessOK()
+	if !ok {
+		t.Fatalf("LivenessOK with a fresh heartbeat should be ok, got reason %q", reason)
+	}
+}
+
+func TestLivenessOK_StalledHeartbeat(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.SetSyncInterval(time.Millisecond)
+	a.healthMu.Lock()
+	a.lastHeartbeat = time.Now().Add(-time.Hour)
+	a.healthMu.Unlock()
+
+	ok, reason := a.LivenessOK()
+	if ok {
+		t.Fatalf("LivenessOK should not be ok when heartbeat is far older than the threshold")
+	}
+	if !strings.Contains(reason, "stalled") {
+		t.Fatalf("reason = %q, want it to mention the stall", reason)
+	}
+}
+
+func TestReadinessOK_ProgressesThroughStartup(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+
+	if ok, reason := a.ReadinessOK(); ok || reason != "filesystem type not detected" {
+		t.Fatalf("ReadinessOK before startup = (%v, %q), want (false, filesystem type not detected)", ok, reason)
+	}
+
+	a.setFilesystemDetected(true)
+	if ok, reason := a.ReadinessOK(); ok || reason != "quota subsystem not available" {
+		t.Fatalf("ReadinessOK after fs detection = (%v, %q), want (false, quota subsystem not available)", ok, reason)
+	}
+
+	a.setQuotaAvailable(true)
+	if ok, reason := a.ReadinessOK(); ok || reason != "initial quota sync not yet completed" {
+		t.Fatalf("ReadinessOK after quota available = (%v, %q), want (false, initial quota sync not yet completed)", ok, reason)
+	}
+
+	a.recordSyncResult(nil)
+	if ok, reason := a.ReadinessOK(); !ok {
+		t.Fatalf("ReadinessOK after a completed sync should be ready, got reason %q", reason)
+	}
+}
+
+func TestReadinessOK_ZeroAppliedQuotasIsReady(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.setFilesystemDetected(true)
+	a.setQuotaAvailable(true)
+	a.recordSyncResult(nil)
+
+	if got := a.AppliedQuotaCount(); got != 0 {
+		t.Fatalf("expected zero applied quotas, got %d", got)
+	}
+	if ok, reason := a.ReadinessOK(); !ok {
+		t.Fatalf("an agent with zero PVs to manage should be ready, got reason %q", reason)
+	}
+}
+
+func TestReadinessOK_FlipsBackAfterRepeatedSyncFailures(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.setFilesystemDetected(true)
+	a.setQuotaAvailable(true)
+	a.recordSyncResult(nil)
+
+	for i := 0; i < readinessSyncFailureThreshold; i++ {
+		a.recordSyncResult(errors.New("list PVs failed"))
+	}
+
+	ok, reason := a.ReadinessOK()
+	if ok {
+		t.Fatalf("ReadinessOK should flip to not-ready after %d consecutive sync failures", readinessSyncFailureThreshold)
+	}
+	if !strings.Contains(reason, "consecutive failures") {
+		t.Fatalf("reason = %q, want it to mention consecutive failures", reason)
+	}
+
+	// A subsequent success resets the streak.
+	a.recordSyncResult(nil)
+	if ok, reason := a.ReadinessOK(); !ok {
+		t.Fatalf("ReadinessOK should recover after a successful sync, got reason %q", reason)
+	}
+}
+
+func TestReadinessOK_BasePathNotAccessible(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.setFilesystemDetected(true)
+	a.setQuotaAvailable(true)
+	a.recordSyncResult(nil)
+	a.nfsBasePath = filepath.Join(t.TempDir(), "does-not-exist")
+
+	ok, reason := a.ReadinessOK()
+	if ok {
+		t.Fatalf("ReadinessOK should fail when the base path is not accessible")
+	}
+	if !strings.Contains(reason, "base path not accessible") {
+		t.Fatalf("reason = %q, want it to mention the base path", reason)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -36,6 +36,16 @@ import (
 type AgentInfo interface {
 	BasePath() string
 	AppliedQuotaCount() int
+	// LivenessOK reports whether the agent process is alive and making
+	// progress. It must be independent of the Kubernetes API and the NFS
+	// mount so /health never restart-loops on a transient outage a restart
+	// wouldn't fix. reason is a short, human-readable explanation.
+	LivenessOK() (ok bool, reason string)
+	// ReadinessOK reports whether this instance can enforce quotas right
+	// now (filesystem detected, quota subsystem available, base path
+	// present, initial sync completed and not repeatedly failing). It
+	// reflects live state, so it can flip back to not-ready after startup.
+	ReadinessOK() (ok bool, reason string)
 }
 
 // Collector collects quota metrics for Prometheus
@@ -56,8 +66,8 @@ func StartServer(addr string, agent AgentInfo, version string) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/metrics", collector.handleMetrics)
-	mux.HandleFunc("/health", handleHealth)
-	mux.HandleFunc("/ready", handleReady)
+	mux.HandleFunc("/health", collector.handleHealth)
+	mux.HandleFunc("/ready", collector.handleReady)
 
 	slog.Info("Starting metrics server", "addr", addr)
 	if err := http.ListenAndServe(addr, mux); err != nil {
@@ -178,12 +188,29 @@ func (c *Collector) updateMetrics() {
 	c.lastUpdate = time.Now()
 }
 
-func handleHealth(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	fmt.Fprint(w, "ok")
+// handleHealth serves the liveness probe: is the process wedged? It never
+// consults the Kubernetes API or the NFS mount (see AgentInfo.LivenessOK).
+func (c *Collector) handleHealth(w http.ResponseWriter, r *http.Request) {
+	ok, reason := c.agent.LivenessOK()
+	writeProbeResult(w, ok, reason)
 }
 
-func handleReady(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	fmt.Fprint(w, "ok")
+// handleReady serves the readiness probe: can this instance enforce quotas
+// right now? Reflects live state, so it can go non-ready after startup.
+func (c *Collector) handleReady(w http.ResponseWriter, r *http.Request) {
+	ok, reason := c.agent.ReadinessOK()
+	writeProbeResult(w, ok, reason)
+}
+
+// writeProbeResult writes a plain-text probe response: 200 with "ok" (or a
+// short status) when healthy, 503 with the failing reason otherwise.
+// Kubernetes probes only look at the status code; the body is for humans.
+func writeProbeResult(w http.ResponseWriter, ok bool, reason string) {
+	status := http.StatusOK
+	if !ok {
+		status = http.StatusServiceUnavailable
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(status)
+	fmt.Fprintln(w, reason)
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -30,10 +30,29 @@ import (
 type fakeAgent struct {
 	basePath     string
 	appliedCount int
+
+	liveOK      bool
+	liveReason  string
+	readyOK     bool
+	readyReason string
 }
 
 func (f *fakeAgent) BasePath() string       { return f.basePath }
 func (f *fakeAgent) AppliedQuotaCount() int { return f.appliedCount }
+
+func (f *fakeAgent) LivenessOK() (bool, string) {
+	if f.liveReason == "" && f.liveOK {
+		return true, "ok"
+	}
+	return f.liveOK, f.liveReason
+}
+
+func (f *fakeAgent) ReadinessOK() (bool, string) {
+	if f.readyReason == "" && f.readyOK {
+		return true, "ok"
+	}
+	return f.readyOK, f.readyReason
+}
 
 func TestHandleMetrics_Basic(t *testing.T) {
 	dir := t.TempDir()
@@ -147,28 +166,58 @@ func TestHandleMetrics_RecomputesWhenStale(t *testing.T) {
 	}
 }
 
-func TestHandleHealth(t *testing.T) {
+func TestHandleHealth_Live(t *testing.T) {
+	c := &Collector{agent: &fakeAgent{liveOK: true}}
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
-	handleHealth(w, req)
+	c.handleHealth(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
-	if w.Body.String() != "ok" {
-		t.Fatalf("body = %q, want ok", w.Body.String())
+	if got := strings.TrimSpace(w.Body.String()); got != "ok" {
+		t.Fatalf("body = %q, want ok", got)
 	}
 }
 
-func TestHandleReady(t *testing.T) {
+func TestHandleHealth_Stalled(t *testing.T) {
+	c := &Collector{agent: &fakeAgent{liveOK: false, liveReason: "sync loop stalled: last heartbeat 5m0s ago (threshold 2m0s)"}}
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	c.handleHealth(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "stalled") {
+		t.Fatalf("body = %q, want it to name the stall reason", w.Body.String())
+	}
+}
+
+func TestHandleReady_Ready(t *testing.T) {
+	c := &Collector{agent: &fakeAgent{readyOK: true}}
 	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
 	w := httptest.NewRecorder()
-	handleReady(w, req)
+	c.handleReady(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
-	if w.Body.String() != "ok" {
-		t.Fatalf("body = %q, want ok", w.Body.String())
+	if got := strings.TrimSpace(w.Body.String()); got != "ok" {
+		t.Fatalf("body = %q, want ok", got)
+	}
+}
+
+func TestHandleReady_NotReady(t *testing.T) {
+	c := &Collector{agent: &fakeAgent{readyOK: false, readyReason: "initial quota sync not yet completed"}}
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	w := httptest.NewRecorder()
+	c.handleReady(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "initial quota sync") {
+		t.Fatalf("body = %q, want it to name the failing check", w.Body.String())
 	}
 }


### PR DESCRIPTION
Addresses most of #4.

## The gap

`/health` and `/ready` were **both unconditional `200 ok`** (`internal/metrics/metrics.go:181-189`), so a probe wired to either would report a wedged agent as healthy. The chart had **no probes at all** — zero `readinessProbe`/`livenessProbe`/`startupProbe` blocks. `podDisruptionBudget.enabled` was `false` despite `templates/pdb.yaml` already existing.

## Health semantics

The two endpoints now mean genuinely different things:

**Readiness** — this instance can enforce quotas *right now*: filesystem type detected, quota subsystem available, base path stat-able, initial sync completed, fewer than 3 consecutive sync failures. It reads live state, so it drops back to not-ready when syncing starts failing and recovers when it succeeds. It deliberately **ignores `AppliedQuotaCount()`** — an agent with no PVs to manage is legitimately ready.

**Liveness** — the process is not wedged, judged *only* from a heartbeat stamped by the sync loop. It touches neither the Kubernetes API nor the NFS mount, because a liveness probe that trips on a transient API outage causes a restart loop that fixes nothing.

The useful consequence: a **hung NFS mount** blocks readiness (`os.Stat` on the base path) but never liveness — the pod is pulled from service without being restart-looped. Both endpoints return the failing check as the response body.

## Verified against a real socket

Handler unit tests alone don't prove the mux wiring, so the endpoints were driven through `StartServer` over a real bound port:

```
not-ready  /ready  -> 503 "initial quota sync not yet completed"
alive      /health -> 200 "ok"
ready      /ready  -> 200 "ok"
stalled    /health -> 503 "sync loop stalled"
```

## Chart

- `startupProbe` / `livenessProbe` / `readinessProbe`, each individually configurable, and omitted entirely when `config.metricsAddr` is empty. Startup gates on `/ready` with a 5-minute budget (30 × 10s) for slow NFS mounts; liveness and readiness use `initialDelaySeconds: 0` since Kubernetes suppresses them until startup succeeds.
- **PDB enabled by default, with `maxUnavailable: 1` rather than `minAvailable: 1`.** At the shipped `replicaCount: 1`, `minAvailable: 1` requires the sole replica to stay up forever and **blocks every node drain permanently**. `maxUnavailable: 1` permits evicting it while still capping disruption if replicas are raised later.
- Soft (`preferred`) pod anti-affinity, off by default. Never `required`: replicas are pinned by `nodeSelector` to NFS-server nodes, so a hard rule would leave replica 2+ permanently Pending when only one node qualifies. An explicit `affinity` value still wins unchanged.

## Security: `hostPID: true` dropped

`deployment.yaml` **hardcoded** `hostPID: true` — not exposed in `values.yaml`, so operators could not turn it off. Nothing in `internal/` or `cmd/` reads `/proc`, shells out to `nsenter`, or inspects host processes; the only grep hits are unrelated flag names. `findmnt`/`df` resolve against the *mount* namespace, which `hostPID` does not affect.

It granted visibility of every host process, alongside `privileged: true`, for **zero functional benefit**. Now configurable, defaulting to `false`, rendering nothing unless explicitly enabled.

> ⚠️ **Behavior change for existing users.** Anyone genuinely depending on it can set `hostPID: true`.

## `docs/security.md`

Per-privilege rationale, minimum-privilege alternatives (a candidate capability set replacing blanket `privileged`, flagged as needing real kernel testing rather than asserted), the threat model, the PSA profile this chart requires with a ready-to-apply namespace manifest, and an "Unverified" section for what could not be confirmed from code alone.

It also records **two ClusterRole rules that no code path exercises** — `storageclasses` (provisioner matching compares `pv.Spec.CSI.Driver` directly) and `persistentvolumeclaims` (claim identity comes from `pv.Spec.ClaimRef`). Documented, **not removed** — a downstream consumer may exist. See the issue comment.

## Verification

```
gofmt -l .                          (no output)
go build ./... / go vet ./...       OK
go test ./...                       all 12 packages ok
golangci-lint run --timeout=3m      0 issues
helm lint --strict                  0 failed
helm template | grep -c hostPID     0   (1 with --set hostPID=true)
```

## Not covered

Rolling-upgrade/eviction tests and the Kubernetes 1.35/1.36 compatibility matrix need a live cluster. `Chart.yaml`'s `version: 0.3.0` vs `appVersion: "0.2.2"` drift is left to whoever cuts the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)