### PR TITLE
fix(chart): enforce single instance, drop anti-affinity and unused RBAC

### DIFF
--- a/charts/nfs-quota-agent/templates/clusterrole.yaml
+++ b/charts/nfs-quota-agent/templates/clusterrole.yaml
@@ -9,14 +9,6 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "patch"]
-  # PVC read for additional info
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch"]
-  # StorageClass read for provisioner info
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
   # Namespace read for policy annotations
   - apiGroups: [""]
     resources: ["namespaces"]

--- a/charts/nfs-quota-agent/templates/deployment.yaml
+++ b/charts/nfs-quota-agent/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+{{- fail "nfs-quota-agent must run as a single instance per NFS server node. It writes host state (/etc/projects, /etc/projid) with no leader election and no file locking, and quota.AppendToFile reads-then-appends, so concurrent instances corrupt those files and can assign one project ID to two paths. Scheduling constraints cannot make this safe: replicas pinned by nodeSelector to a single NFS-server node land together on that node. To manage additional NFS servers, install a separate release per node rather than raising replicaCount. See docs/security.md." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,19 +42,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
-        {{- toYaml .Values.affinity | nindent 8 }}
-      {{- else if .Values.podAntiAffinity.enabled }}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: {{ .Values.podAntiAffinity.weight }}
-              podAffinityTerm:
-                topologyKey: {{ .Values.podAntiAffinity.topologyKey }}
-                labelSelector:
-                  matchLabels:
-                    {{- include "nfs-quota-agent.selectorLabels" . | nindent 20 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.hostPID }}
       hostPID: true

--- a/charts/nfs-quota-agent/values.yaml
+++ b/charts/nfs-quota-agent/values.yaml
@@ -1,5 +1,10 @@
 # Default values for nfs-quota-agent
 
+# Must stay 1. This agent owns host state on the NFS server node
+# (/etc/projects, /etc/projid) and has neither leader election nor file
+# locking, so a second instance corrupts that state rather than adding
+# availability. Values above 1 are rejected at render time. To cover more
+# than one NFS server, install a separate release per node.
 replicaCount: 1
 
 image:
@@ -104,17 +109,6 @@ tolerations:
     effect: "NoSchedule"
 
 affinity: {}
-
-# Soft pod anti-affinity to spread replicas across nodes when
-# replicaCount > 1. Off by default to preserve existing single-replica
-# behavior. Ignored when `affinity` above is set (that raw override wins).
-# Kept "preferred" rather than "required": this agent is usually pinned via
-# nodeSelector to NFS server nodes, and a hard requirement would leave
-# extra replicas permanently unschedulable if only one such node exists.
-podAntiAffinity:
-  enabled: false
-  topologyKey: kubernetes.io/hostname
-  weight: 100
 
 # Liveness/readiness/startup probes, served by the metrics port's /health
 # and /ready endpoints. /ready also backs the startup probe: liveness and

--- a/docs/security.md
+++ b/docs/security.md
@@ -124,15 +124,15 @@ The agent uses a cluster-scoped `ClusterRole` defined in [clusterrole.yaml](../c
 | API Group | Resource | Verbs | Justification in Code | RBAC Scope Assessment |
 | :--- | :--- | :--- | :--- | :--- |
 | `""` | `persistentvolumes` | `get`, `list`, `watch`, `update`, `patch` | `syncAllQuotas` lists PVs ([agent.go](../internal/agent/agent.go)); `updateQuotaStatus` updates `nfs.io/quota-status` annotation ([agent.go](../internal/agent/agent.go)). | Tightly scoped. `update`/`patch` is strictly required for writing quota status annotations. |
-| `""` | `persistentvolumeclaims` | `get`, `list`, `watch` | **None found.** No `PersistentVolumeClaims(...)` client call exists anywhere in `internal/` or `cmd/`. Claim identity is read from `pv.Spec.ClaimRef`, which is part of the PV object already retrieved. | **Unused — candidate for removal.** |
-| `storage.k8s.io` | `storageclasses` | `get`, `list`, `watch` | **None found.** No `StorageClasses(...)` client call and no reference to `storageClassName` exists. Provisioner matching compares `pv.Spec.CSI.Driver` against the configured name directly ([agent.go](../internal/agent/agent.go)), never consulting the StorageClass. | **Unused — candidate for removal.** |
-| `""` | `namespaces` | `get`, `list`, `watch` | `Namespaces().Get` / `.List` for policy annotations ([policy.go](../internal/policy/policy.go), [policy.go](../internal/policy/policy.go)). | Read-only. Used. |
-| `""` | `limitranges` | `get`, `list`, `watch` | `LimitRanges().List` for default PVC storage limits ([policy.go](../internal/policy/policy.go), [policy.go](../internal/policy/policy.go)). | Read-only. Used. |
-| `""` | `resourcequotas` | `get`, `list`, `watch` | `ResourceQuotas().List` for namespace storage caps ([policy.go](../internal/policy/policy.go), [policy.go](../internal/policy/policy.go)). | Read-only. Used. |
+| `""` | `namespaces` | `get`, `list`, `watch` | `Namespaces().Get` / `.List` for policy annotations ([policy.go](../internal/policy/policy.go)). | Read-only. Used. |
+| `""` | `limitranges` | `get`, `list`, `watch` | `LimitRanges().List` for default PVC storage limits ([policy.go](../internal/policy/policy.go)). | Read-only. Used. |
+| `""` | `resourcequotas` | `get`, `list`, `watch` | `ResourceQuotas().List` for namespace storage caps ([policy.go](../internal/policy/policy.go)). | Read-only. Used. |
 
-*Verdict*: No wildcard (`*`) verbs and no `delete` on cluster resources, and the only write access is `update`/`patch` on PVs for the status annotation — so the footprint is narrow in kind. It is **not** minimal in extent: two of the six rules (`persistentvolumeclaims`, `storageclasses`) grant cluster-wide read access that no code path exercises. Removing them costs nothing today.
+*Verdict*: The four remaining rules correspond exactly to the four resources the code actually calls — `PersistentVolumes`, `Namespaces`, `LimitRanges`, `ResourceQuotas`. No wildcard (`*`) verbs, no `delete`, and the only write access is `update`/`patch` on PVs for the status annotation.
 
-Note that `persistentvolumeclaims` read access is cluster-wide and PVCs are namespaced user-facing objects, so this grant is more meaningful than its unused status suggests — it lets a compromised agent enumerate every claim in the cluster. Verify against your own fork before removing, in case a downstream change added a consumer.
+Two rules were removed as verifiably unused: `storageclasses` (provisioner matching compares `pv.Spec.CSI.Driver` against the configured name directly, never consulting the StorageClass) and `persistentvolumeclaims` (claim identity comes from `pv.Spec.ClaimRef` on the PV object already retrieved). The latter mattered more than "unused" suggests — PVCs are namespaced, user-facing objects, and the grant was cluster-wide read, so a compromised agent could enumerate every claim in the cluster.
+
+If you maintain a fork that added a consumer for either, re-add the corresponding rule; removing a grant the code never exercises cannot break upstream behavior.
 
 ---
 
@@ -165,6 +165,13 @@ Granting a `privileged` namespace exception exposes only the designated NFS serv
 ---
 
 ## 6. Operational Hardening Guidance
+
+0. **Single Instance Per NFS Server Node** (enforced, not advisory):
+   The agent owns host state — `/etc/projects` and `/etc/projid` — and has **no leader election and no file locking**. `AppendToFile` ([project.go](../internal/quota/project.go)) reads the file, checks whether the key is present, then appends; two instances racing that sequence both observe the key as absent and both append. Project-ID allocation reads the existing IDs for collision avoidance and is exposed to the same race, so two agents can map one ID to two different paths.
+
+   Scheduling constraints cannot make this safe. Replicas are pinned by `nodeSelector` to NFS-server nodes, so on the common single-NFS-server topology every replica lands on the same node and contends for the same files. Pod anti-affinity was therefore removed rather than left as a `preferred` rule that implies a guarantee it cannot provide.
+
+   The chart rejects `replicaCount > 1` at render time. To manage several NFS servers, **install a separate release per node** — each one owns its own host's state. `replicaCount: 0` remains allowed for deliberate scale-down.
 
 1. **Dedicated Node Isolation**:
    Always run `nfs-quota-agent` on dedicated NFS server nodes. Apply node taints (e.g., `nfs-server=true:NoSchedule`) and matching tolerations to prevent tenant workloads from co-locating on the NFS node.


### PR DESCRIPTION
Follow-up to #21, addressing the two open questions left on #4.

## 1. `replicaCount > 1` is a corruption risk, not HA

The agent owns host state on the NFS server node — `/etc/projects` and `/etc/projid` — and has **no leader election and no file locking** (`grep` for `flock` / `LOCK_EX` / `leaderelection` returns nothing). `quota.AppendToFile` does:

```go
data, err := os.ReadFile(filename)   // read
// ... check whether the key is already present ...
f, err := os.OpenFile(filename, os.O_APPEND|...)  // then append
```

Two instances racing that sequence both observe the key as absent and both append. Project-ID allocation reads the existing IDs for collision avoidance and races identically, so two agents can map **one project ID to two different paths**.

**Scheduling cannot make this safe**, which is why the pod anti-affinity added in #21 is removed rather than promoted to `required`. Replicas are pinned by `nodeSelector` to NFS-server nodes; on the usual single-NFS-server topology, every replica lands on that one node and contends for the same files. A `preferred` rule there implies a guarantee it cannot deliver — worse than having none. The raw `affinity` passthrough is untouched.

The chart now **fails at render time**:

```
$ helm template ./charts/nfs-quota-agent --set replicaCount=2
Error: execution error at (nfs-quota-agent/templates/deployment.yaml:2:4):
nfs-quota-agent must run as a single instance per NFS server node. It writes
host state (/etc/projects, /etc/projid) with no leader election and no file
locking... To manage additional NFS servers, install a separate release per
node rather than raising replicaCount.
```

`replicaCount: 0` remains allowed for deliberate scale-down. Covering several NFS servers means **one release per node**, each owning its own host's state.

This is a guard, not the end state — converting the chart to a DaemonSet with `nodeSelector` would let Kubernetes enforce one-per-node structurally instead of a template check. That is a breaking resource-kind change, so it is deliberately left to a separate PR and a release note.

## 2. Unused ClusterRole rules removed

| Removed | Why it was never needed |
|---|---|
| `storageclasses` | Provisioner matching compares `pv.Spec.CSI.Driver` against the configured name directly; no `StorageClasses(...)` call and no `storageClassName` reference exists anywhere. |
| `persistentvolumeclaims` | Claim identity comes from `pv.Spec.ClaimRef` on the PV already retrieved; no `PersistentVolumeClaims(...)` call exists. |

The remaining four rules now correspond **exactly** to the four resources the code actually calls:

```
$ grep -rhoE "CoreV1\(\)\.[A-Za-z]+\(|StorageV1\(\)\.[A-Za-z]+\(" internal/ cmd/ | sort -u
CoreV1().LimitRanges(
CoreV1().Namespaces(
CoreV1().PersistentVolumes(
CoreV1().ResourceQuotas(
```

`persistentvolumeclaims` was the one worth removing: PVCs are namespaced, user-facing objects and the grant was **cluster-wide read**, so a compromised agent could enumerate every claim in the cluster. Removing a grant the code never exercises cannot break upstream behavior; a fork that added a consumer would re-add its own rule.

## Verification

```
helm template ...                          renders (6 docs, parses via yaml.safe_load_all)
helm template ... --set replicaCount=2     fails with the explanation above
helm template ... --set replicaCount=0     allowed
helm lint --strict                         0 failed
grep -rn podAntiAffinity charts/           no residue
go build ./... / go test ./...             all 12 packages ok
golangci-lint run --timeout=3m             0 issues
```

`docs/security.md` gains the single-instance constraint as an enforced item (the guard's error message points there) and its RBAC section is updated to reflect the four remaining rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)