### PR TITLE
fix(agent): keep the applied-quota cache consistent with what is on disk

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -454,18 +454,46 @@ func (a *QuotaAgent) syncAllQuotas(ctx context.Context) error {
 	a.mu.Unlock()
 
 	syncedCount := 0
+	live := make(map[string]struct{}, len(pvList.Items))
 	for _, pv := range pvList.Items {
-		if a.shouldProcessPV(&pv) {
-			if err := a.ensureQuota(ctx, &pv); err != nil {
-				slog.Error("Failed to ensure quota for PV", "pv", pv.Name, "error", err)
-			} else {
-				syncedCount++
-			}
+		if !a.shouldProcessPV(&pv) {
+			continue
+		}
+		if nfsPath := a.getNFSPath(&pv); nfsPath != "" {
+			live[a.nfsPathToLocal(nfsPath)] = struct{}{}
+		}
+		if err := a.ensureQuota(ctx, &pv); err != nil {
+			slog.Error("Failed to ensure quota for PV", "pv", pv.Name, "error", err)
+		} else {
+			syncedCount++
 		}
 	}
 
+	a.pruneAppliedQuotas(live)
+
 	slog.Debug("Quota sync completed", "synced", syncedCount, "total", len(pvList.Items))
 	return nil
+}
+
+// pruneAppliedQuotas drops cache entries for paths no longer backed by a PV.
+//
+// The watch removes an entry when it sees a Deleted event, but a watch that
+// reconnects restarts from the current resourceVersion, so deletions that
+// happened while it was down are never delivered. Nothing else purged those
+// entries, which both inflated the applied-quota metric and — because
+// ensureQuota returns early on a cache hit — could skip applying a quota to a
+// path that a later PV reused. The full list this sync just walked is the
+// authority on what still exists.
+func (a *QuotaAgent) pruneAppliedQuotas(live map[string]struct{}) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for path := range a.appliedQuotas {
+		if _, ok := live[path]; !ok {
+			delete(a.appliedQuotas, path)
+			slog.Debug("Dropped applied-quota cache entry with no matching PV", "path", path)
+		}
+	}
 }
 
 // shouldProcessPV checks if this PV should be processed by the agent

--- a/internal/agent/cache_consistency_test.go
+++ b/internal/agent/cache_consistency_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/dasomel/nfs-quota-agent/internal/ui"
+)
+
+// RemoveOrphan deletes the path's quota, so leaving the path in appliedQuotas
+// would make ensureQuota's cache-hit shortcut skip a PV that later reuses it,
+// silently leaving that volume unenforced.
+func TestRemoveOrphanClearsAppliedQuotaCache(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	a := newTestAgent(t, client)
+
+	orphanPath := filepath.Join(a.nfsBasePath, "pvc-recycled")
+	if err := os.MkdirAll(orphanPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	const capacity int64 = 5 * 1024 * 1024 * 1024
+	a.mu.Lock()
+	a.appliedQuotas[orphanPath] = capacity
+	a.mu.Unlock()
+
+	// fsType empty keeps RemoveOrphan away from removeQuotaForPath, which is
+	// exercised elsewhere; the cache clearing is what matters here.
+	if err := a.RemoveOrphan(ui.OrphanInfo{Path: orphanPath, DirName: "pvc-recycled"}); err != nil {
+		t.Fatalf("RemoveOrphan: %v", err)
+	}
+
+	a.mu.Lock()
+	got, still := a.appliedQuotas[orphanPath]
+	a.mu.Unlock()
+	if still {
+		t.Fatalf("appliedQuotas still records %s = %d after RemoveOrphan; a PV reusing this path would be skipped", orphanPath, got)
+	}
+}
+
+// A watch that reconnects restarts from the current resourceVersion, so
+// deletions during the outage never arrive. The periodic full list is the only
+// thing that can notice, so it has to prune.
+func TestSyncAllQuotasPrunesEntriesWithoutPV(t *testing.T) {
+	pv := newBoundPV("pv-live", "/exports/pv-live", 1)
+	client := fake.NewSimpleClientset(pv)
+	a := newTestAgent(t, client)
+	// newBoundPV builds a native NFS PV with no provisioned-by annotation,
+	// so shouldProcessPV only accepts it with processAllNFS on.
+	a.SetProcessAllNFS(true)
+
+	withFakeRunner(t, &fakeRunner{})
+
+	livePath := a.nfsPathToLocal("/exports/pv-live")
+	stalePath := filepath.Join(a.nfsBasePath, "pv-deleted-while-watch-was-down")
+
+	a.mu.Lock()
+	a.appliedQuotas[livePath] = 1
+	a.appliedQuotas[stalePath] = 42
+	a.mu.Unlock()
+
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas: %v", err)
+	}
+
+	a.mu.Lock()
+	_, staleKept := a.appliedQuotas[stalePath]
+	_, liveKept := a.appliedQuotas[livePath]
+	a.mu.Unlock()
+
+	if staleKept {
+		t.Errorf("entry for %s survived the sync although no PV backs it", stalePath)
+	}
+	if !liveKept {
+		t.Errorf("entry for %s was pruned although its PV is still listed", livePath)
+	}
+}
+
+// Pruning must key off the PV list, not off whether the quota was applied
+// successfully, or a transient apply failure would evict a live path.
+func TestSyncAllQuotasKeepsLivePathWhenApplyFails(t *testing.T) {
+	pv := newBoundPV("pv-failing", "/exports/pv-failing", 1)
+	client := fake.NewSimpleClientset(pv)
+	a := newTestAgent(t, client)
+	a.SetProcessAllNFS(true)
+
+	livePath := a.nfsPathToLocal("/exports/pv-failing")
+	if err := os.MkdirAll(livePath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	withFakeRunner(t, &fakeRunner{
+		fn: func(name string, args ...string) ([]byte, error) {
+			return nil, os.ErrPermission
+		},
+	})
+
+	a.mu.Lock()
+	a.appliedQuotas[livePath] = 1
+	a.mu.Unlock()
+
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas: %v", err)
+	}
+
+	a.mu.Lock()
+	_, kept := a.appliedQuotas[livePath]
+	a.mu.Unlock()
+	if !kept {
+		t.Error("a live PV's cache entry was pruned because its quota apply failed")
+	}
+}

--- a/internal/agent/orphan.go
+++ b/internal/agent/orphan.go
@@ -225,6 +225,14 @@ func (a *QuotaAgent) RemoveOrphan(orphan ui.OrphanInfo) error {
 		return fmt.Errorf("failed to remove directory: %w", err)
 	}
 
+	// The quota this path had is gone, so appliedQuotas must forget it too.
+	// ensureQuota returns early when appliedQuotas already records the
+	// requested capacity for a path; leaving a stale entry here means a PV
+	// that later lands on this same path is skipped and never gets a quota.
+	a.mu.Lock()
+	delete(a.appliedQuotas, orphan.Path)
+	a.mu.Unlock()
+
 	a.orphanMu.Lock()
 	delete(a.orphanLastSeen, orphan.Path)
 	a.orphanMu.Unlock()


### PR DESCRIPTION
Found while analysing #12. Fixes one concrete bug and closes the one real gap that issue contains.

## The shortcut that makes this matter

`ensureQuota` returns early when the cache already records the requested capacity:

```go
if existingQuota, exists := a.appliedQuotas[localPath]; exists && existingQuota == capacityBytes {
    return nil
}
```

That is only safe while `appliedQuotas` agrees with the filesystem. Two paths let them diverge, and in both the result is the same: **a PV is skipped and silently left with no quota** — the same failure class as #9, reached differently.

## 1. `RemoveOrphan` cleared the quota but not the cache

`RemoveOrphan` (`internal/agent/orphan.go`) calls `removeQuotaForPath` and `os.RemoveAll`, then updates `orphanLastSeen` — but never `appliedQuotas`. `orphan.go` contained no reference to it at all.

So after auto-cleanup removes a path, the agent still believes that path has a quota. Recreating a PVC that resolves to the same subdirectory — routine with deterministic `subDir` naming — hits the shortcut and skips applying. Auto-cleanup is off by default (`--enable-auto-cleanup`), which bounds exposure but does not remove it.

## 2. Cache entries could outlive their path entirely

The watch drops an entry on a `Deleted` event, but a reconnecting watch resumes from the **current** resourceVersion, so deletions during the outage are never delivered — and `syncAllQuotas` only iterated live PVs, never pruning.

On its own this is harmless: nothing removed the quota, so the on-disk state still matches. It becomes a real gap when something *does* remove it out of band — an operator running `nfs-quota-agent cleanup --force` on the node while the daemon runs, which edits `/etc/projects` in a separate process the agent's cache knows nothing about. Then the stale entry reproduces exactly the silent skip above.

The periodic sync already lists every PV, so it now prunes entries with no PV behind them. Pruning keys off **the PV list, not a successful apply**, so a transient apply failure cannot evict a live path.

## On the rest of #12

Analysed and deliberately not implemented here:

- **`resourceVersion` tracking + 410 Gone handling** — for adds, updates and annotation changes the 30s resync already recovers them, so this buys *latency*, not correctness. Worth doing, not urgent.
- **A reconciliation work queue** — `ensureQuota` holds `a.mu` for its whole body, so the watch handler and the periodic sync are already strictly serialized. With the DaemonSet change there is exactly one instance per node, so there is no concurrency left for a queue to protect. It would be about ordering and retry, not safety.
- **Retry/backoff** — a failed `ensureQuota` is logged and retried only at the next 30s sync. Bounded, but no backoff.

## Verification

```
gofmt -l .                        (no output)
go build ./... / go vet ./...     OK
go test ./...                     all 12 packages ok
golangci-lint run --timeout=3m    0 issues
```

Three new tests. Confirmed they actually catch the bugs by reverting each fix in turn:

```
--- FAIL: TestRemoveOrphanClearsAppliedQuotaCache
--- FAIL: TestSyncAllQuotasPrunesEntriesWithoutPV
```

## Note

`nfs_quota_applied_total` no longer counts entries seeded from `/etc/projects` with no PV behind them, so it reports **PV-backed quotas** rather than known project paths. That matches the metric's name, but it is a visible change to the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)