### PR TITLE
fix(quota): fsync host project files and make a mid-rewrite crash recoverable

### DIFF
--- a/charts/nfs-quota-agent/templates/daemonset.yaml
+++ b/charts/nfs-quota-agent/templates/daemonset.yaml
@@ -64,6 +64,7 @@ spec:
             - --nfs-server-path={{ .Values.config.nfsServerPath }}
             - --provisioner-name={{ .Values.config.provisionerName }}
             - --sync-interval={{ .Values.config.syncInterval }}
+            - --state-dir={{ .Values.state.path }}
             {{- if .Values.config.metricsAddr }}
             - --metrics-addr={{ .Values.config.metricsAddr }}
             {{- end }}
@@ -157,13 +158,11 @@ spec:
               mountPath: /etc/projects
             - name: etc-projid
               mountPath: /etc/projid
+            - name: state
+              mountPath: {{ .Values.state.path }}
             {{- if .Values.audit.enabled }}
             - name: audit-log
               mountPath: /var/log/nfs-quota-agent
-            {{- end }}
-            {{- if .Values.history.enabled }}
-            - name: history-data
-              mountPath: /var/lib/nfs-quota-agent
             {{- end }}
           {{- with .Values.resources }}
           resources:
@@ -186,15 +185,13 @@ spec:
           hostPath:
             path: /etc/projid
             type: FileOrCreate
+        - name: state
+          hostPath:
+            path: {{ .Values.state.hostPath }}
+            type: DirectoryOrCreate
         {{- if .Values.audit.enabled }}
         - name: audit-log
           hostPath:
             path: {{ .Values.audit.hostPath }}
-            type: DirectoryOrCreate
-        {{- end }}
-        {{- if .Values.history.enabled }}
-        - name: history-data
-          hostPath:
-            path: {{ .Values.history.hostPath }}
             type: DirectoryOrCreate
         {{- end }}

--- a/charts/nfs-quota-agent/values.yaml
+++ b/charts/nfs-quota-agent/values.yaml
@@ -50,17 +50,33 @@ cleanup:
   # Dry-run mode: log what would be deleted but don't actually delete
   dryRun: true
 
+# Agent state directory: usage history (when enabled) and the crash-safe
+# backup sidecars the agent keeps for /etc/projects and /etc/projid before
+# rewriting them in place (see internal/quota/project.go RemoveLineFromFile
+# and RecoverProjectFile). Always mounted, independent of history.enabled,
+# because the sidecar mechanism needs it regardless of whether history
+# collection is on. hostPath and path previously lived under `history:` as
+# `history.hostPath`/part of `history.path`; they moved here because a
+# volume gated on history.enabled would leave the sidecar with nowhere
+# durable to land the rest of the time. Do not add a second volume mounting
+# `state.path` — see the mount-collision note this replaced.
+state:
+  # Host path backing the state volume (mounted unconditionally).
+  hostPath: /var/lib/nfs-quota-agent
+  # Path inside the container where the state volume is mounted, and the
+  # value passed to --state-dir. Keep this equal to hostPath's mountPath
+  # unless you know why you're changing it.
+  path: /var/lib/nfs-quota-agent
+
 # Usage history and trend tracking
 history:
   enabled: false
-  # Path to store history data inside container
+  # Path to store history data inside container (under state.path).
   path: /var/lib/nfs-quota-agent/history.json
   # Interval between history snapshots
   interval: 5m
   # How long to keep history data
   retention: 720h  # 30 days
-  # Host path for persistent history (mounted as hostPath volume)
-  hostPath: /var/lib/nfs-quota-agent
 
 # Namespace quota policy
 policy:

--- a/cmd/nfs-quota-agent/main.go
+++ b/cmd/nfs-quota-agent/main.go
@@ -152,6 +152,7 @@ func runAgent(args []string) {
 		uiAddr          string
 		enableAudit     bool
 		auditLogPath    string
+		stateDir        string
 
 		// Auto-cleanup options
 		enableAutoCleanup bool
@@ -182,6 +183,7 @@ func runAgent(args []string) {
 	fs.StringVar(&uiAddr, "ui-addr", ":8080", "Web UI listen address")
 	fs.BoolVar(&enableAudit, "enable-audit", false, "Enable audit logging")
 	fs.StringVar(&auditLogPath, "audit-log-path", "/var/log/nfs-quota-agent/audit.log", "Audit log file path")
+	fs.StringVar(&stateDir, "state-dir", "/var/lib/nfs-quota-agent", "Host-backed directory for crash-recovery backups of /etc/projects and /etc/projid (empty disables the backup)")
 
 	// Auto-cleanup flags
 	fs.BoolVar(&enableAutoCleanup, "enable-auto-cleanup", false, "Enable automatic orphan directory cleanup")
@@ -233,6 +235,7 @@ func runAgent(args []string) {
 	ag := agent.NewQuotaAgent(client, nfsBasePath, nfsServerPath, provisionerName)
 	ag.SetProcessAllNFS(processAllNFS)
 	ag.SetSyncInterval(syncInterval)
+	ag.SetStateDir(stateDir)
 
 	// Configure auto-cleanup
 	ag.SetEnableAutoCleanup(enableAutoCleanup)
@@ -450,6 +453,7 @@ func runCleanup(args []string) {
 		path          string
 		nfsServerPath string
 		kubeconfig    string
+		stateDir      string
 		dryRun        bool
 		force         bool
 	)
@@ -457,6 +461,7 @@ func runCleanup(args []string) {
 	fs.StringVar(&path, "path", "/data", "NFS export path")
 	fs.StringVar(&nfsServerPath, "nfs-server-path", "/data", "NFS server's export path (for path mapping)")
 	fs.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file")
+	fs.StringVar(&stateDir, "state-dir", "/var/lib/nfs-quota-agent", "Host-backed directory for crash-recovery backups of the projects/projid files (empty disables the backup; useful when run standalone on a host without the agent's state directory)")
 	fs.BoolVar(&dryRun, "dry-run", true, "Dry-run mode (no changes)")
 	fs.BoolVar(&force, "force", false, "Force cleanup without confirmation")
 
@@ -478,7 +483,7 @@ func runCleanup(args []string) {
 
 	_ = fs.Parse(args)
 
-	if _, err := cleanup.RunCleanup(path, nfsServerPath, kubeconfig, dryRun, force); err != nil {
+	if _, err := cleanup.RunCleanup(path, nfsServerPath, kubeconfig, stateDir, dryRun, force); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,7 +15,7 @@ This document provides a security threat model and minimum-privilege assessment 
 | `/etc/projects` hostPath mount | [daemonset.yaml](../charts/nfs-quota-agent/templates/daemonset.yaml)<br>[daemonset.yaml](../charts/nfs-quota-agent/templates/daemonset.yaml) | `AddProject`, `RemoveLineFromFile`, and `ReadProjectsFile` in [project.go](../internal/quota/project.go) write/read `projectID:path` entries. | XFS/ext4 project quota mapping fails; host filesystem utilities lose project path metadata. | Required for XFS & ext4. |
 | `/etc/projid` hostPath mount | [daemonset.yaml](../charts/nfs-quota-agent/templates/daemonset.yaml)<br>[daemonset.yaml](../charts/nfs-quota-agent/templates/daemonset.yaml) | `AddProject`, `RemoveLineFromFile`, `ReadProjidFile`, and `loadExistingProjectIDs` in [agent.go](../internal/agent/agent.go) write/read `projectName:projectID` entries. | Project ID generation and collision resolution against existing host IDs fail. | Required for XFS & ext4. |
 | `/var/log/nfs-quota-agent` | [daemonset.yaml](../charts/nfs-quota-agent/templates/daemonset.yaml)<br>[daemonset.yaml](../charts/nfs-quota-agent/templates/daemonset.yaml) | Persists structured JSON audit logs emitted by `audit.Logger` in [logger.go](../internal/audit/logger.go). | Audit logs are lost when the container restarts. | Optional (enabled via `audit.enabled`). |
-| `/var/lib/nfs-quota-agent` | [daemonset.yaml](../charts/nfs-quota-agent/templates/daemonset.yaml)<br>[daemonset.yaml](../charts/nfs-quota-agent/templates/daemonset.yaml) | Persists historical usage snapshots in `history.Store` in [store.go](../internal/history/store.go). | Usage history trend data is lost on container restart. | Optional (enabled via `history.enabled`). |
+| `/var/lib/nfs-quota-agent` (`state.hostPath`) | [daemonset.yaml](../charts/nfs-quota-agent/templates/daemonset.yaml)<br>[daemonset.yaml](../charts/nfs-quota-agent/templates/daemonset.yaml) | Two uses: (1) `RemoveLineFromFile` / `RecoverProjectFile` in [project.go](../internal/quota/project.go) keep a `<name>.bak` crash-recovery sidecar here for `/etc/projects` and `/etc/projid` before rewriting them in place — see `--state-dir` in [main.go](../cmd/nfs-quota-agent/main.go). (2) When enabled, `history.Store` in [store.go](../internal/history/store.go) persists historical usage snapshots here. | Without this mount, a crash mid-rewrite of `/etc/projects`/`/etc/projid` has no backup to recover from (the sidecar would otherwise land in the container's own ephemeral `/etc`, since only the individual files are bind-mounted, and be lost on restart). If `history.enabled`, usage history trend data is also lost on container restart. | **Required**, mounted unconditionally (not gated on `history.enabled`) precisely so the recovery sidecar has somewhere durable to land regardless of whether history collection is on. |
 
 ---
 
@@ -138,7 +138,7 @@ If you maintain a fork that added a consumer for either, re-add the correspondin
 
 ## 5. Pod Security Admission (PSA) Compliance
 
-Because the agent requires `hostPath` volumes (`/data`, `/dev`, `/etc/projects`, `/etc/projid`) and root/capability execution, the deployment **cannot** satisfy Kubernetes `restricted` or `baseline` Pod Security Admission standards.
+Because the agent requires `hostPath` volumes (`/data`, `/dev`, `/etc/projects`, `/etc/projid`, `/var/lib/nfs-quota-agent`) and root/capability execution, the deployment **cannot** satisfy Kubernetes `restricted` or `baseline` Pod Security Admission standards.
 
 It requires the **`privileged`** PSA profile.
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -66,6 +66,12 @@ type QuotaAgent struct {
 	fsType          string
 	projectsFile    string
 	projidFile      string
+	// stateDir is a host-backed directory (distinct from projectsFile's and
+	// projidFile's own directory, which may be nothing but a bind-mounted
+	// individual file inside the container) used to hold the crash-recovery
+	// backup sidecars quota.RemoveLineFromFile/RecoverProjectFile keep. See
+	// their doc comments in internal/quota/project.go.
+	stateDir        string
 	syncInterval    time.Duration
 	mu              sync.Mutex
 	appliedQuotas   map[string]int64
@@ -120,6 +126,7 @@ func NewQuotaAgent(client kubernetes.Interface, nfsBasePath, nfsServerPath, prov
 		quotaPath:         nfsBasePath,
 		projectsFile:      "/etc/projects",
 		projidFile:        "/etc/projid",
+		stateDir:          "/var/lib/nfs-quota-agent",
 		syncInterval:      30 * time.Second,
 		appliedQuotas:     make(map[string]int64),
 		knownProjectIDs:   make(map[uint32]string),
@@ -143,6 +150,12 @@ func (a *QuotaAgent) SetProjectsFile(v string) { a.projectsFile = v }
 
 // SetProjidFile sets the projid file path.
 func (a *QuotaAgent) SetProjidFile(v string) { a.projidFile = v }
+
+// SetStateDir sets the host-backed directory used for crash-recovery backup
+// sidecars of projectsFile/projidFile. An empty value disables the sidecar
+// (see quota.RemoveLineFromFile/RecoverProjectFile), degrading gracefully
+// rather than failing quota operations.
+func (a *QuotaAgent) SetStateDir(v string) { a.stateDir = v }
 
 // SetSyncInterval sets the synchronization interval.
 func (a *QuotaAgent) SetSyncInterval(v time.Duration) { a.syncInterval = v }
@@ -418,6 +431,17 @@ func (a *QuotaAgent) loadProjects() error {
 	if a.fsType == quota.FSTypeBtrfs {
 		return nil
 	}
+
+	// Recover the host's project metadata files from their backup sidecar
+	// before anything reads them, in case an earlier in-place rewrite
+	// crashed and left projects or projid truncated/corrupt.
+	if err := quota.RecoverProjectFile(a.projectsFile, a.stateDir); err != nil {
+		slog.Warn("Failed to recover projects file", "error", err)
+	}
+	if err := quota.RecoverProjectFile(a.projidFile, a.stateDir); err != nil {
+		slog.Warn("Failed to recover projid file", "error", err)
+	}
+
 	projects, err := quota.ReadProjectsFile(a.projectsFile)
 	if err != nil {
 		return err

--- a/internal/agent/helpers_test.go
+++ b/internal/agent/helpers_test.go
@@ -91,6 +91,10 @@ func newTestAgent(t *testing.T, client *fake.Clientset) *QuotaAgent {
 	a := NewQuotaAgent(client, base, "/exports", "example.com/nfs")
 	a.SetProjectsFile(filepath.Join(base, "projects"))
 	a.SetProjidFile(filepath.Join(base, "projid"))
+	// Constructor defaults stateDir to the real host path
+	// /var/lib/nfs-quota-agent; point it at a temp dir instead so tests
+	// never touch that path.
+	a.SetStateDir(t.TempDir())
 	return a
 }
 

--- a/internal/agent/orphan.go
+++ b/internal/agent/orphan.go
@@ -281,10 +281,10 @@ func (a *QuotaAgent) removeQuotaForPath(path string) {
 		}
 	}
 
-	_ = quota.RemoveLineFromFile(a.projectsFile, projectID+":")
+	_ = quota.RemoveLineFromFile(a.projectsFile, projectID+":", a.stateDir)
 
 	if projectName != "" {
-		_ = quota.RemoveLineFromFile(a.projidFile, projectName+":")
+		_ = quota.RemoveLineFromFile(a.projidFile, projectName+":", a.stateDir)
 	}
 }
 

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -168,7 +168,12 @@ func classifyProject(sets *activeSets, basePath, projectPath string) (classifyRe
 // RunCleanup performs the cleanup operation. It returns a Result summarizing
 // what was scanned, found active/orphaned/skipped, and (if not a dry-run)
 // actually removed.
-func RunCleanup(basePath, nfsServerPath, kubeconfig string, dryRun, force bool) (*Result, error) {
+//
+// stateDir is where quota.RemoveLineFromFile keeps its crash-recovery
+// backup sidecar; pass "" to disable it (e.g. when this runs standalone on
+// a host without the agent's state directory) — the rewrite still happens,
+// just without a recoverable backup.
+func RunCleanup(basePath, nfsServerPath, kubeconfig, stateDir string, dryRun, force bool) (*Result, error) {
 	fmt.Printf("NFS Quota Cleanup\n")
 	fmt.Printf("=================\n\n")
 	fmt.Printf("Path: %s\n", basePath)
@@ -374,11 +379,11 @@ func RunCleanup(basePath, nfsServerPath, kubeconfig string, dryRun, force bool) 
 			continue
 		}
 
-		if err := quota.RemoveLineFromFile(projectsFile, projectID+":"); err != nil {
+		if err := quota.RemoveLineFromFile(projectsFile, projectID+":", stateDir); err != nil {
 			fmt.Printf("  [WARN] Failed to update projects file: %v\n", err)
 		}
 
-		if err := quota.RemoveLineFromFile(projidFile, o.ProjectName+":"); err != nil {
+		if err := quota.RemoveLineFromFile(projidFile, o.ProjectName+":", stateDir); err != nil {
 			fmt.Printf("  [WARN] Failed to update projid file: %v\n", err)
 		}
 

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -104,7 +104,7 @@ users:
 }
 
 func TestRunCleanup_InvalidKubeconfig(t *testing.T) {
-	result, err := RunCleanup(t.TempDir(), "/exports", filepath.Join(t.TempDir(), "does-not-exist"), true, false)
+	result, err := RunCleanup(t.TempDir(), "/exports", filepath.Join(t.TempDir(), "does-not-exist"), t.TempDir(), true, false)
 	if err == nil {
 		t.Fatal("expected error for a nonexistent kubeconfig path")
 	}
@@ -121,7 +121,7 @@ func TestRunCleanup_PVListFailure(t *testing.T) {
 	// should fail fast (connection refused) instead of hanging.
 	kubeconfig := writeKubeconfig(t, "https://127.0.0.1:1")
 
-	result, err := RunCleanup(t.TempDir(), "/exports", kubeconfig, true, false)
+	result, err := RunCleanup(t.TempDir(), "/exports", kubeconfig, t.TempDir(), true, false)
 	if err == nil {
 		t.Fatal("expected error when the API server is unreachable")
 	}
@@ -161,7 +161,7 @@ func TestRunCleanup_NoOrphans(t *testing.T) {
 	var result *Result
 	out := captureStdout(t, func() {
 		var err error
-		result, err = RunCleanup(t.TempDir(), "/exports", kubeconfig, true, false)
+		result, err = RunCleanup(t.TempDir(), "/exports", kubeconfig, t.TempDir(), true, false)
 		if err != nil {
 			t.Fatalf("RunCleanup: %v", err)
 		}
@@ -199,7 +199,7 @@ func TestRunCleanup_DryRunReportsOrphan(t *testing.T) {
 	var result *Result
 	out := captureStdout(t, func() {
 		var err error
-		result, err = RunCleanup(base, "/exports", kubeconfig, true, false)
+		result, err = RunCleanup(base, "/exports", kubeconfig, t.TempDir(), true, false)
 		if err != nil {
 			t.Fatalf("RunCleanup: %v", err)
 		}
@@ -295,7 +295,7 @@ func TestRunCleanup_CSIActivePVNotOrphaned(t *testing.T) {
 	var result *Result
 	_ = captureStdout(t, func() {
 		var err error
-		result, err = RunCleanup(base, "/exports", kubeconfig, true, false)
+		result, err = RunCleanup(base, "/exports", kubeconfig, t.TempDir(), true, false)
 		if err != nil {
 			t.Fatalf("RunCleanup: %v", err)
 		}
@@ -328,7 +328,7 @@ func TestRunCleanup_CSIShareOnlyActivePVNotOrphaned(t *testing.T) {
 	var result *Result
 	_ = captureStdout(t, func() {
 		var err error
-		result, err = RunCleanup(base, "/exports", kubeconfig, true, false)
+		result, err = RunCleanup(base, "/exports", kubeconfig, t.TempDir(), true, false)
 		if err != nil {
 			t.Fatalf("RunCleanup: %v", err)
 		}
@@ -358,7 +358,7 @@ func TestRunCleanup_NativeNFSActivePVNotOrphaned(t *testing.T) {
 	var result *Result
 	_ = captureStdout(t, func() {
 		var err error
-		result, err = RunCleanup(base, "/exports", kubeconfig, true, false)
+		result, err = RunCleanup(base, "/exports", kubeconfig, t.TempDir(), true, false)
 		if err != nil {
 			t.Fatalf("RunCleanup: %v", err)
 		}
@@ -396,7 +396,7 @@ func TestRunCleanup_SameBasenameFullPathIdentity(t *testing.T) {
 	var result *Result
 	_ = captureStdout(t, func() {
 		var err error
-		result, err = RunCleanup(base, "/exports", kubeconfig, true, false)
+		result, err = RunCleanup(base, "/exports", kubeconfig, t.TempDir(), true, false)
 		if err != nil {
 			t.Fatalf("RunCleanup: %v", err)
 		}
@@ -426,7 +426,7 @@ func TestRunCleanup_PathOutsideRootSkipped(t *testing.T) {
 	var result *Result
 	out := captureStdout(t, func() {
 		var err error
-		result, err = RunCleanup(base, "/exports", kubeconfig, true, false)
+		result, err = RunCleanup(base, "/exports", kubeconfig, t.TempDir(), true, false)
 		if err != nil {
 			t.Fatalf("RunCleanup: %v", err)
 		}
@@ -478,7 +478,7 @@ func TestRunCleanup_PreDeleteRevalidation_SkipsNewlyActivePath(t *testing.T) {
 	out := captureStdout(t, func() {
 		var err error
 		// force=true so the run doesn't block on the interactive confirmation prompt.
-		result, err = RunCleanup(base, "/exports", kubeconfig, false, true)
+		result, err = RunCleanup(base, "/exports", kubeconfig, t.TempDir(), false, true)
 		if err != nil {
 			t.Fatalf("RunCleanup: %v", err)
 		}

--- a/internal/quota/project.go
+++ b/internal/quota/project.go
@@ -22,12 +22,24 @@ package quota
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
 
-// AddProject adds a project to the projects and projid files
+// AddProject adds a project to the projects and projid files.
+//
+// Order is load-bearing: projid is written first, then projects.
+// loadExistingProjectIDs (internal/agent/agent.go) reads projid to decide
+// which project IDs are already taken. If a crash happens after the projid
+// write but before the projects write, the ID is already reserved and the
+// next sync simply re-runs AddProject: the projid write no-ops (the key
+// already exists) and projects gets written, so the sequence is
+// self-healing. Writing projects first would leave the ID unreserved in
+// projid after a crash, letting a different project claim the same ID and
+// bleed quota across two paths. Do not reorder these two writes.
 func AddProject(path, projectName string, projectID uint32, projectsFile, projidFile string) error {
 	// Add to projid file: projectName:projectID
 	projidEntry := fmt.Sprintf("%s:%d\n", projectName, projectID)
@@ -44,7 +56,10 @@ func AddProject(path, projectName string, projectID uint32, projectsFile, projid
 	return nil
 }
 
-// AppendToFile appends an entry to a file if it doesn't already exist
+// AppendToFile appends an entry to a file if it doesn't already exist. The
+// write is fsynced (file and containing directory) before returning success,
+// so a caller that gets a nil error knows the bytes reached disk rather than
+// just the page cache.
 func AppendToFile(filename, entry, searchKey string) (err error) {
 	// Read existing content
 	data, err := os.ReadFile(filename)
@@ -73,15 +88,53 @@ func AppendToFile(filename, entry, searchKey string) (err error) {
 		}
 	}()
 
-	_, err = f.WriteString(entry)
+	if _, err = f.WriteString(entry); err != nil {
+		return err
+	}
+	if err = f.Sync(); err != nil {
+		return err
+	}
+	err = syncDir(filepath.Dir(filename))
 	return err
 }
 
-// RemoveLineFromFile removes lines starting with prefix from a file
-func RemoveLineFromFile(filename, prefix string) error {
+// RemoveLineFromFile removes lines starting with prefix from a file.
+//
+// The target file (/etc/projects or /etc/projid) is bind-mounted as an
+// individual host file, so it cannot be replaced via the usual
+// temp-file-plus-rename pattern — rename onto a mount point fails with
+// EBUSY, and even a successful rename elsewhere would only replace the
+// mount inside the container, decoupling the agent from the file the quota
+// tools actually read. The rewrite therefore has to happen in place, which
+// opens a real (if small) window where a crash mid-write leaves a truncated
+// or partial file. To make that recoverable rather than eliminating it
+// (which in-place rewriting cannot do), the pre-rewrite contents are first
+// saved to a sidecar under stateDir — see sidecarPath — fsynced before the
+// rewrite starts. RecoverProjectFile restores from it on the next startup
+// if the rewrite didn't finish.
+//
+// stateDir must be a host-backed directory, not a directory that lives
+// inside a bind-mounted individual file's own mount (e.g. the container's
+// /etc when only /etc/projects and /etc/projid are bind-mounted into it) —
+// otherwise the sidecar is written to the container's ephemeral layer and
+// is gone on the next restart, exactly when recovery is needed. Losing the
+// backup must never block the rewrite itself: if stateDir is empty, or the
+// backup can't be created or written, this logs a warning and proceeds
+// with the rewrite anyway.
+func RemoveLineFromFile(filename, prefix, stateDir string) error {
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return err
+	}
+
+	if backupPath := sidecarPath(filename, stateDir); backupPath != "" {
+		if mkErr := os.MkdirAll(stateDir, 0755); mkErr != nil {
+			slog.Warn("Cannot create state directory; proceeding without a recovery backup",
+				"stateDir", stateDir, "error", mkErr)
+		} else if wErr := writeFileSynced(backupPath, data, 0644); wErr != nil {
+			slog.Warn("Failed to write recovery backup; proceeding without one",
+				"backup", backupPath, "error", wErr)
+		}
 	}
 
 	var newLines []string
@@ -91,7 +144,122 @@ func RemoveLineFromFile(filename, prefix string) error {
 		}
 	}
 
-	return os.WriteFile(filename, []byte(strings.Join(newLines, "\n")), 0644)
+	return writeFileSynced(filename, []byte(strings.Join(newLines, "\n")), 0644)
+}
+
+// backupSuffix names the sidecar RemoveLineFromFile keeps next to its
+// target. It is a single fixed name that gets overwritten on every rewrite,
+// so it never accumulates garbage across repeated operations.
+const backupSuffix = ".bak"
+
+// sidecarPath returns the backup sidecar path for filename under stateDir,
+// or "" if stateDir is empty — the signal used throughout this file to mean
+// "no recovery backup available," so the sidecar degrades gracefully
+// instead of failing the caller's real operation.
+func sidecarPath(filename, stateDir string) string {
+	if stateDir == "" {
+		return ""
+	}
+	return filepath.Join(stateDir, filepath.Base(filename)+backupSuffix)
+}
+
+// writeFileSynced truncates (or creates) filename, writes data, and fsyncs
+// both the file and its containing directory before returning, so a nil
+// error means the bytes are durable rather than merely cached.
+func writeFileSynced(filename string, data []byte, perm os.FileMode) (err error) {
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			err = errors.Join(err, cerr)
+		}
+	}()
+
+	if _, err = f.Write(data); err != nil {
+		return err
+	}
+	if err = f.Sync(); err != nil {
+		return err
+	}
+	err = syncDir(filepath.Dir(filename))
+	return err
+}
+
+// syncDir fsyncs a directory so that entries created or replaced within it
+// (a new file, a rewritten file's data) survive a crash rather than only
+// existing in the page cache. Linux-only, which matches this agent's
+// privileged, host-node-only design.
+func syncDir(dir string) (err error) {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := d.Close(); cerr != nil {
+			err = errors.Join(err, cerr)
+		}
+	}()
+
+	err = d.Sync()
+	return err
+}
+
+// isWellFormedProjectFile reports whether every non-blank, non-comment line
+// in data contains a ":" separator, matching the projects/projid line
+// format. A line that fails this is treated as evidence of a corrupt,
+// partially-written file.
+func isWellFormedProjectFile(data []byte) bool {
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if !strings.Contains(line, ":") {
+			return false
+		}
+	}
+	return true
+}
+
+// RecoverProjectFile restores filename from its RemoveLineFromFile backup
+// sidecar under stateDir when filename looks truncated or corrupt from a
+// crash mid-rewrite: zero-length while a non-empty sidecar exists, or
+// containing a line that fails to parse as "key:value". It is a no-op when
+// stateDir is empty, there is no sidecar (nothing to recover from), or the
+// sidecar is itself empty, so a file that is legitimately empty on a fresh
+// install — or a host where the state directory isn't available at all —
+// is never clobbered. Callers should invoke it before anything else reads
+// these files.
+func RecoverProjectFile(filename, stateDir string) error {
+	backupPath := sidecarPath(filename, stateDir)
+	if backupPath == "" {
+		return nil
+	}
+
+	backup, err := os.ReadFile(backupPath)
+	if err != nil || len(backup) == 0 {
+		// No usable sidecar to recover from.
+		return nil
+	}
+
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No target file yet: a fresh install, not corruption.
+			return nil
+		}
+		return err
+	}
+
+	if len(data) != 0 && isWellFormedProjectFile(data) {
+		return nil // target looks fine, nothing to do
+	}
+
+	slog.Error("Detected truncated/corrupt project file, restoring from backup",
+		"file", filename, "backup", backupPath)
+	return writeFileSynced(filename, backup, 0644)
 }
 
 // ReadProjectsFile reads the projects file and returns projectID -> path mapping

--- a/internal/quota/project_test.go
+++ b/internal/quota/project_test.go
@@ -135,7 +135,7 @@ func TestRemoveLineFromFile(t *testing.T) {
 		t.Fatalf("setup failed: %v", err)
 	}
 
-	if err := RemoveLineFromFile(f, "100:"); err != nil {
+	if err := RemoveLineFromFile(f, "100:", t.TempDir()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -153,8 +153,308 @@ func TestRemoveLineFromFile(t *testing.T) {
 
 func TestRemoveLineFromFile_MissingFile(t *testing.T) {
 	dir := t.TempDir()
-	if err := RemoveLineFromFile(filepath.Join(dir, "missing"), "100:"); err == nil {
+	if err := RemoveLineFromFile(filepath.Join(dir, "missing"), "100:", t.TempDir()); err == nil {
 		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestRemoveLineFromFile_LeavesRecoverableBackupInStateDir(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(t.TempDir(), "state") // does not exist yet: MkdirAll must create it
+	f := filepath.Join(dir, "file")
+	original := "100:/data\n200:/other\n"
+	if err := os.WriteFile(f, []byte(original), 0644); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+
+	if err := RemoveLineFromFile(f, "100:", stateDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	backupPath := filepath.Join(stateDir, "file.bak")
+	backup, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("expected backup sidecar to exist under stateDir: %v", err)
+	}
+	if string(backup) != original {
+		t.Errorf("expected backup to hold pre-rewrite contents %q, got %q", original, string(backup))
+	}
+
+	// Confirm it did NOT land next to the target (the bug this replaced:
+	// the target's own directory can be a bind-mounted individual file's
+	// mount, which does not survive a container restart).
+	if _, err := os.Stat(f + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("backup should not be written next to the target file, got err=%v", err)
+	}
+}
+
+func TestRemoveLineFromFile_BackupDoesNotAccumulate(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := t.TempDir()
+	f := filepath.Join(dir, "file")
+	backupPath := filepath.Join(stateDir, "file.bak")
+	if err := os.WriteFile(f, []byte("100:/data\n200:/other\n"), 0644); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+
+	if err := RemoveLineFromFile(f, "100:", stateDir); err != nil {
+		t.Fatalf("unexpected error on first rewrite: %v", err)
+	}
+	firstBackup, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("failed to read backup after first rewrite: %v", err)
+	}
+
+	if err := RemoveLineFromFile(f, "200:", stateDir); err != nil {
+		t.Fatalf("unexpected error on second rewrite: %v", err)
+	}
+	secondBackup, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("failed to read backup after second rewrite: %v", err)
+	}
+
+	if string(secondBackup) == string(firstBackup)+string(firstBackup) {
+		t.Errorf("backup appears to have accumulated content across rewrites: %q", string(secondBackup))
+	}
+	if strings.Count(string(secondBackup), "100:/data") != 0 {
+		t.Errorf("second backup should reflect post-first-rewrite state, got %q", string(secondBackup))
+	}
+	if !strings.Contains(string(secondBackup), "200:/other") {
+		t.Errorf("second backup should hold the pre-second-rewrite contents, got %q", string(secondBackup))
+	}
+}
+
+func TestRemoveLineFromFile_DegradesWhenStateDirUnusable(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "file")
+	if err := os.WriteFile(f, []byte("100:/data\n200:/other\n"), 0644); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+
+	t.Run("empty stateDir disables the sidecar but the rewrite still succeeds", func(t *testing.T) {
+		if err := RemoveLineFromFile(f, "100:", ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fileContains(t, f, "100:") {
+			t.Errorf("expected rewrite to still happen with sidecar disabled")
+		}
+	})
+
+	t.Run("stateDir that cannot be created still lets the rewrite succeed", func(t *testing.T) {
+		f2 := filepath.Join(dir, "file2")
+		if err := os.WriteFile(f2, []byte("300:/data\n400:/other\n"), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		// A regular file in the way of stateDir makes os.MkdirAll fail.
+		blocker := filepath.Join(t.TempDir(), "blocked")
+		if err := os.WriteFile(blocker, []byte("x"), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		unusableStateDir := filepath.Join(blocker, "state") // MkdirAll under a file: fails
+
+		if err := RemoveLineFromFile(f2, "300:", unusableStateDir); err != nil {
+			t.Fatalf("expected RemoveLineFromFile to degrade gracefully, got error: %v", err)
+		}
+		data, err := os.ReadFile(f2)
+		if err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+		if strings.Contains(string(data), "300:") {
+			t.Errorf("expected rewrite to still happen despite unusable state dir, got %q", string(data))
+		}
+	})
+}
+
+func TestRecoverProjectFile(t *testing.T) {
+	t.Run("no sidecar is a no-op", func(t *testing.T) {
+		dir := t.TempDir()
+		f := filepath.Join(dir, "file")
+		if err := os.WriteFile(f, []byte("100:/data\n"), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		if err := RecoverProjectFile(f, t.TempDir()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !fileContains(t, f, "100:/data") {
+			t.Errorf("file should be untouched")
+		}
+	})
+
+	t.Run("empty stateDir is a no-op even for a corrupt target", func(t *testing.T) {
+		dir := t.TempDir()
+		f := filepath.Join(dir, "file")
+		if err := os.WriteFile(f, []byte(""), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		if err := RecoverProjectFile(f, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, err := os.ReadFile(f); err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+	})
+
+	t.Run("missing state directory is a no-op, not an error", func(t *testing.T) {
+		dir := t.TempDir()
+		f := filepath.Join(dir, "file")
+		if err := os.WriteFile(f, []byte("100:/data\n"), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		if err := RecoverProjectFile(f, filepath.Join(dir, "does-not-exist")); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !fileContains(t, f, "100:/data") {
+			t.Errorf("file should be untouched")
+		}
+	})
+
+	t.Run("legitimately empty file on fresh install is not clobbered", func(t *testing.T) {
+		dir := t.TempDir()
+		f := filepath.Join(dir, "file")
+		if err := os.WriteFile(f, []byte(""), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		// No sidecar at all.
+		if err := RecoverProjectFile(f, t.TempDir()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		data, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+		if len(data) != 0 {
+			t.Errorf("expected file to remain empty, got %q", string(data))
+		}
+	})
+
+	t.Run("empty file with empty sidecar is not clobbered", func(t *testing.T) {
+		dir := t.TempDir()
+		stateDir := t.TempDir()
+		f := filepath.Join(dir, "file")
+		if err := os.WriteFile(f, []byte(""), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(stateDir, "file.bak"), []byte(""), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		if err := RecoverProjectFile(f, stateDir); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		data, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+		if len(data) != 0 {
+			t.Errorf("expected file to remain empty, got %q", string(data))
+		}
+	})
+
+	t.Run("truncated target with good sidecar is restored", func(t *testing.T) {
+		dir := t.TempDir()
+		stateDir := t.TempDir()
+		f := filepath.Join(dir, "file")
+		good := "100:/data\n200:/other\n"
+		if err := os.WriteFile(filepath.Join(stateDir, "file.bak"), []byte(good), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		if err := os.WriteFile(f, []byte(""), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+
+		if err := RecoverProjectFile(f, stateDir); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+		if string(data) != good {
+			t.Errorf("expected restored content %q, got %q", good, string(data))
+		}
+	})
+
+	t.Run("malformed line with good sidecar is restored", func(t *testing.T) {
+		dir := t.TempDir()
+		stateDir := t.TempDir()
+		f := filepath.Join(dir, "file")
+		good := "100:/data\n200:/other\n"
+		if err := os.WriteFile(filepath.Join(stateDir, "file.bak"), []byte(good), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		// Simulates a crash mid-write: the second line's "key:" got cut off
+		// before the colon ever landed on disk.
+		if err := os.WriteFile(f, []byte("100:/data\n20"), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+
+		if err := RecoverProjectFile(f, stateDir); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !fileContains(t, f, good) {
+			t.Errorf("expected file to be restored from backup")
+		}
+	})
+
+	t.Run("well-formed target is left alone even with a sidecar present", func(t *testing.T) {
+		dir := t.TempDir()
+		stateDir := t.TempDir()
+		f := filepath.Join(dir, "file")
+		current := "200:/other\n"
+		if err := os.WriteFile(filepath.Join(stateDir, "file.bak"), []byte("100:/data\n"), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		if err := os.WriteFile(f, []byte(current), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+
+		if err := RecoverProjectFile(f, stateDir); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+		if string(data) != current {
+			t.Errorf("expected file to be left as-is, got %q", string(data))
+		}
+	})
+
+	t.Run("missing target with sidecar is not created out of thin air", func(t *testing.T) {
+		dir := t.TempDir()
+		stateDir := t.TempDir()
+		f := filepath.Join(dir, "file")
+		if err := os.WriteFile(filepath.Join(stateDir, "file.bak"), []byte("100:/data\n"), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		if err := RecoverProjectFile(f, stateDir); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, err := os.Stat(f); !os.IsNotExist(err) {
+			t.Errorf("expected target to remain absent, got err=%v", err)
+		}
+	})
+}
+
+func TestAppendToFile_DurableAndIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "file")
+
+	if err := AppendToFile(f, "100:/data\n", "100"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := AppendToFile(f, "100:/data\n", "100"); err != nil {
+		t.Fatalf("unexpected error on repeat call: %v", err)
+	}
+
+	data, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatalf("failed to read: %v", err)
+	}
+	if strings.Count(string(data), "100:/data") != 1 {
+		t.Errorf("expected exactly one entry after repeated append, got %q", string(data))
 	}
 }
 


### PR DESCRIPTION
Addresses #10.

## Nothing was ever fsynced

`grep -rn '\.Sync()'` returned **nothing** across the whole repository. Every write to `/etc/projects` and `/etc/projid` was a page-cache success only, so a node losing power shortly after a "successful" quota apply could come back without the entry. Both write paths now fsync the file **and its containing directory** (the dentry for a newly created file needs the directory fsync too) before reporting success, with `Sync`/`Close` errors joined into the return instead of dropped.

## The rewrite could truncate host state

`RemoveLineFromFile` ended in `os.WriteFile`, which **truncates before writing**. A crash mid-rewrite could leave the host's project mapping truncated or half-written.

**Temp-file + rename — the usual fix — does not work here.** The chart bind-mounts these as *individual files* (`type: FileOrCreate`), and on Linux `rename()` onto a path that is itself a mount point fails; where it appeared to succeed it would swap the mount inside the container while the host file `xfs_quota` actually reads stayed behind. The paths are not configurable to sidestep it.

So the rewrite stays in place and is made **recoverable** instead: the previous contents go to a sidecar first, and startup restores from it when the target comes back zero-length, or with a non-comment line that never got its `:` separator.

## The sidecar has to survive the crash

First attempt put it at `<file>.bak` — i.e. `/etc/projects.bak`. That is wrong, and it is the interesting part of this PR.

The container's mount list is exactly `/export`, `/dev`, `/etc/projects`, `/etc/projid` — **only the two files**, so the container's `/etc` *directory* is the image's own. `/etc/projects.bak` lands in the container's ephemeral writable layer, which does not survive what the sidecar exists for: kubelet builds a fresh container on restart, and the agent binary is the entrypoint, so a process crash *is* a container exit. `RecoverProjectFile` could essentially never find a sidecar in production — protection that reads as real and isn't.

It now goes to a **state directory** the chart mounts from the host unconditionally. The `history-data` volume already mounted host `/var/lib/nfs-quota-agent` at the identical container path, but only when `history.enabled` — it is promoted to an always-on `state` volume serving both, so there is never a second volume claiming that mountPath (verified: 1 with defaults, still 1 with `--set history.enabled=true`).

A `--state-dir` flag lets the standalone CLI point elsewhere or pass empty to disable the backup, and an unusable state directory **degrades to a warning and proceeds** — losing a backup must never block a cleanup run.

## Ordering invariant, now written down

`AddProject` writes **projid before projects**, and that reads as arbitrary while being load-bearing. `loadExistingProjectIDs` consults *projid* to decide which IDs are taken:

- projid first: a crash leaves the ID reserved, the next sync no-ops on the existing key and completes the pair. Self-healing.
- projects first: the ID is unreserved, so a different project can be handed the **same ID** — two paths sharing one project, quota bleeding between them.

Documented on the function so nobody tidies the order later. The order itself is unchanged.

## What is still not safe

An in-place rewrite cannot be made atomic. A crash that truncates **exactly at a line boundary** leaves a well-formed file that recovery cannot distinguish from a correct one. That window is inherent to writing through a bind-mounted file; this change shrinks and makes recoverable the common shapes, it does not eliminate the class.

## Verification

```
gofmt -l .                       (no output)
go build ./... / go vet ./...    OK
go test ./...                    all 12 packages ok
golangci-lint run                0 issues
helm lint --strict               0 failed
mountPath count, default         1
mountPath count, history on      1
```

Beyond the unit tests, the full sequence was driven end to end — populate, remove an entry, confirm the sidecar holds the pre-rewrite contents **in the state dir**, truncate the target to simulate the crash, recover, and check both surviving entries and mode `0644` (these files are read by `xfs_quota` on the host).

Also fixed in passing: `newTestAgent` did not set `stateDir`, so unit tests inherited the real `/var/lib/nfs-quota-agent` default and would have called `os.MkdirAll` against that literal host path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)