### PR TITLE
fix(quota): reject conflicting and malformed project identities

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -442,6 +442,17 @@ func (a *QuotaAgent) loadProjects() error {
 		slog.Warn("Failed to recover projid file", "error", err)
 	}
 
+	// Report (never auto-repair) any project ID present in only one of
+	// projects/projid: rewriting host quota metadata based on a guess is
+	// worse than surfacing the mismatch for an operator to resolve.
+	if mismatches, err := quota.CheckProjectFileConsistency(a.projectsFile, a.projidFile); err != nil {
+		slog.Warn("Failed to check project file consistency", "error", err)
+	} else {
+		for _, mismatch := range mismatches {
+			slog.Error("Inconsistent project identity files detected", "detail", mismatch)
+		}
+	}
+
 	projects, err := quota.ReadProjectsFile(a.projectsFile)
 	if err != nil {
 		return err
@@ -473,6 +484,7 @@ func (a *QuotaAgent) syncAllQuotas(ctx context.Context) error {
 	// Refresh project ID cache once per sync cycle so generateProjectID
 	// doesn't read /etc/projid on every PV.
 	ids := a.loadExistingProjectIDs()
+	a.markOrphanedProjectIDsAsTaken(ids)
 	a.mu.Lock()
 	a.knownProjectIDs = ids
 	a.mu.Unlock()
@@ -582,12 +594,16 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume) e
 	}
 
 	projectName := a.getProjectName(pv)
-	projectID := a.generateProjectID(projectName)
+	projectID, err := a.generateProjectID(projectName)
+	if err != nil {
+		a.updateQuotaStatus(ctx, pv, QuotaStatusFailed)
+		return fmt.Errorf("failed to allocate project ID for PV %s: %w", pv.Name, err)
+	}
 
 	oldQuota := a.appliedQuotas[localPath]
 	isUpdate := oldQuota > 0 && oldQuota != capacityBytes
 
-	err := a.applyQuota(localPath, projectName, projectID, capacityBytes)
+	err = a.applyQuota(localPath, projectName, projectID, capacityBytes)
 
 	var namespace, pvcName string
 	if pv.Spec.ClaimRef != nil {
@@ -651,16 +667,29 @@ func (a *QuotaAgent) getProjectName(pv *v1.PersistentVolume) string {
 	return "pv_" + name
 }
 
+// maxProjectIDProbe bounds how many consecutive IDs generateProjectID will
+// try past the initial hash before giving up. The hash spreads names
+// roughly uniformly across ~2^32 values, so a chain of collisions this long
+// is astronomically unlikely for any realistic PV count; hitting the bound
+// means knownProjectIDs is corrupted or pathological (e.g. duplicate/crafted
+// entries), not that the ID space is genuinely exhausted. Bounding the probe
+// turns that case into a reported error instead of an infinite loop.
+const maxProjectIDProbe = 4096
+
+// errProjectIDExhausted is returned by generateProjectID when no free ID
+// was found within maxProjectIDProbe attempts.
+var errProjectIDExhausted = fmt.Errorf("no available project ID found within %d attempts", maxProjectIDProbe)
+
 // generateProjectID generates a unique numeric project ID from project name.
 // Uses the in-memory knownProjectIDs cache (refreshed once per sync cycle).
 // Must be called with a.mu held.
-func (a *QuotaAgent) generateProjectID(projectName string) uint32 {
+func (a *QuotaAgent) generateProjectID(projectName string) (uint32, error) {
 	id := a.hashProjectName(projectName)
 
-	for {
+	for attempt := 0; attempt < maxProjectIDProbe; attempt++ {
 		if existingName, taken := a.knownProjectIDs[id]; !taken || existingName == projectName {
 			a.knownProjectIDs[id] = projectName // update cache for subsequent calls this cycle
-			return id
+			return id, nil
 		}
 		// Collision: different project already owns this ID, try next
 		slog.Warn("Project ID collision detected, trying next ID",
@@ -673,6 +702,8 @@ func (a *QuotaAgent) generateProjectID(projectName string) uint32 {
 			id = 1 // avoid ID 0
 		}
 	}
+
+	return 0, fmt.Errorf("%w for project %q", errProjectIDExhausted, projectName)
 }
 
 // hashProjectName computes the initial FNV-1 hash for a project name
@@ -705,6 +736,44 @@ func (a *QuotaAgent) loadExistingProjectIDs() map[uint32]string {
 		}
 	}
 	return existing
+}
+
+// orphanedProjectIDSentinel marks a knownProjectIDs entry for an ID that
+// CheckProjectFileConsistency would report: present in the projects file
+// but with no matching name in projid. It contains a control character,
+// which validateQuotaArg rejects from every real project name before it
+// can reach a quota command, so this value can never equal — and can
+// never be handed out as — a legitimate project name.
+const orphanedProjectIDSentinel = "\x00orphaned-project-id"
+
+// markOrphanedProjectIDsAsTaken folds every ID present in the projects file
+// but absent from projid into ids as taken.
+//
+// loadExistingProjectIDs only reads projid, so an orphaned ID (a
+// pre-existing half-applied state — see CheckProjectFileConsistency) looks
+// free to generateProjectID. Hashing a new project onto it would let
+// AddProject's identity validation correctly reject the mismatch every
+// single cycle, but the hash is deterministic, so without this the same
+// project would retry the same doomed ID forever instead of the probe
+// moving on to one that's actually free. Errors reading the projects file
+// are logged and otherwise ignored: it's an availability hardening pass
+// over an already-computed cache, not a correctness requirement for this
+// sync cycle to proceed.
+func (a *QuotaAgent) markOrphanedProjectIDsAsTaken(ids map[uint32]string) {
+	projects, err := quota.ReadProjectsFile(a.projectsFile)
+	if err != nil {
+		slog.Warn("Failed to read projects file while checking for orphaned project IDs", "error", err)
+		return
+	}
+	for idStr := range projects {
+		id, err := strconv.ParseUint(idStr, 10, 32)
+		if err != nil {
+			continue
+		}
+		if _, known := ids[uint32(id)]; !known {
+			ids[uint32(id)] = orphanedProjectIDSentinel
+		}
+	}
 }
 
 // applyQuota applies project quota based on filesystem type

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package agent
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -275,7 +278,10 @@ func TestGenerateProjectIDCollision(t *testing.T) {
 	// Force a collision: id already claimed by a different project name.
 	a.knownProjectIDs[id] = "someone-else"
 
-	got := a.generateProjectID("proj-a")
+	got, err := a.generateProjectID("proj-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if got == id {
 		t.Fatalf("expected generateProjectID to skip the colliding id")
 	}
@@ -284,8 +290,37 @@ func TestGenerateProjectIDCollision(t *testing.T) {
 	}
 
 	// Same name again should now return the same cached id without collision handling.
-	if got2 := a.generateProjectID("proj-a"); got2 != got {
+	got2, err := a.generateProjectID("proj-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got2 != got {
 		t.Fatalf("generateProjectID not stable for same project name: %d vs %d", got2, got)
+	}
+}
+
+func TestGenerateProjectIDExhaustion(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.knownProjectIDs = make(map[uint32]string)
+
+	// Fill every ID generateProjectID would probe (the hash-derived start
+	// plus up to maxProjectIDProbe consecutive IDs) with a different name,
+	// so no free slot exists within the bound. This must return an error
+	// promptly rather than loop forever, which is exactly the regression
+	// this test guards against.
+	id := a.hashProjectName("proj-exhausted")
+	for i := 0; i <= maxProjectIDProbe; i++ {
+		a.knownProjectIDs[id] = fmt.Sprintf("someone-else-%d", i)
+		id++
+		if id == 0 {
+			id = 1
+		}
+	}
+
+	if _, err := a.generateProjectID("proj-exhausted"); err == nil {
+		t.Fatal("expected an error when the probe bound is exhausted")
+	} else if !errors.Is(err, errProjectIDExhausted) {
+		t.Fatalf("expected errProjectIDExhausted, got: %v", err)
 	}
 }
 
@@ -310,6 +345,68 @@ func TestLoadExistingProjectIDs(t *testing.T) {
 	missing.projidFile = filepath.Join(t.TempDir(), "does-not-exist")
 	if ids := missing.loadExistingProjectIDs(); len(ids) != 0 {
 		t.Fatalf("expected empty map for missing file, got %+v", ids)
+	}
+}
+
+// TestMarkOrphanedProjectIDsAsTaken verifies an ID present in projects but
+// absent from projid (the exact half-applied shape CheckProjectFileConsistency
+// reports) gets folded into the knownProjectIDs cache as taken, while an
+// already-known entry is left untouched.
+func TestMarkOrphanedProjectIDsAsTaken(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	content := "10:/export/orphan\n20:/export/known\n"
+	if err := os.WriteFile(a.projectsFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write projects: %v", err)
+	}
+
+	ids := map[uint32]string{20: "pv_known"}
+	a.markOrphanedProjectIDsAsTaken(ids)
+
+	if _, ok := ids[10]; !ok {
+		t.Fatalf("expected orphaned id 10 to be marked as taken, got %+v", ids)
+	}
+	if ids[20] != "pv_known" {
+		t.Fatalf("expected known entry to be left untouched, got %q", ids[20])
+	}
+}
+
+// TestGenerateProjectID_ConvergesPastOrphanedProjectsFileID is the
+// regression test for the allocator/validator disagreement a code review of
+// this change surfaced: without markOrphanedProjectIDsAsTaken folding
+// projects-file orphans into the cache, generateProjectID (which only reads
+// projid) would consider an orphaned ID free, deterministically re-hash the
+// same project onto it every sync cycle, and have AddProject's identity
+// validation reject it every single time — a permanent, self-inflicted
+// failure loop instead of the probe moving on to a genuinely free ID.
+func TestGenerateProjectID_ConvergesPastOrphanedProjectsFileID(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	projectName := "pv_orphan_target"
+	orphanID := a.hashProjectName(projectName)
+
+	if err := os.WriteFile(a.projectsFile,
+		[]byte(fmt.Sprintf("%d:/export/orphan\n", orphanID)), 0644); err != nil {
+		t.Fatalf("write projects: %v", err)
+	}
+	// projidFile intentionally has no entry for orphanID: loadExistingProjectIDs
+	// alone would consider it free.
+
+	ids := a.loadExistingProjectIDs()
+	a.markOrphanedProjectIDsAsTaken(ids)
+	a.knownProjectIDs = ids
+
+	got, err := a.generateProjectID(projectName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == orphanID {
+		t.Fatalf("expected the probe to skip the orphaned id %d, got the same id back", orphanID)
+	}
+
+	// The resulting ID must actually be usable: AddProject must accept it
+	// cleanly against the same files, proving real convergence rather than
+	// landing on a second conflicting ID.
+	if err := quota.AddProject("/export/new", projectName, got, a.projectsFile, a.projidFile); err != nil {
+		t.Fatalf("expected the converged id to be usable, got: %v", err)
 	}
 }
 
@@ -344,6 +441,39 @@ func TestLoadProjects(t *testing.T) {
 	dirAgent.projectsFile = t.TempDir()
 	if err := dirAgent.loadProjects(); err == nil {
 		t.Fatalf("expected error when projectsFile is a directory")
+	}
+}
+
+// TestLoadProjects_ReportsInconsistentFiles verifies loadProjects surfaces
+// (via slog.Error) a half-applied projects/projid pair — the on-disk shape
+// the reported defect could leave behind — without failing the call or
+// attempting to auto-repair it.
+func TestLoadProjects_ReportsInconsistentFiles(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	// id 3 is fully consistent; id 5 has a path in projects but no name in
+	// projid — the exact half-applied shape the reported defect produced.
+	if err := os.WriteFile(a.projectsFile, []byte("3:/export/pvc-a\n5:/export/pvc-a-new\n"), 0644); err != nil {
+		t.Fatalf("write projects: %v", err)
+	}
+	if err := os.WriteFile(a.projidFile, []byte("pvc_a:3\n"), 0644); err != nil {
+		t.Fatalf("write projid: %v", err)
+	}
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	if err := a.loadProjects(); err != nil {
+		t.Fatalf("loadProjects should report, not fail, on inconsistent files: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Inconsistent project identity files detected") {
+		t.Errorf("expected a reported mismatch in the logs, got: %s", out)
+	}
+	if !strings.Contains(out, "level=ERROR") {
+		t.Errorf("expected the mismatch to be logged at Error level, got: %s", out)
 	}
 }
 
@@ -595,6 +725,98 @@ func TestEnsureQuotaCommandFailure(t *testing.T) {
 	}
 	if updated.Annotations[AnnotationQuotaStatus] != QuotaStatusFailed {
 		t.Fatalf("expected quota status failed, got %q", updated.Annotations[AnnotationQuotaStatus])
+	}
+}
+
+// TestEnsureQuota_ProjectIdentityConflictFailsPVWithoutCrashing verifies
+// the AddProject identity-conflict path (project.go's checkProjectIdentityConflict)
+// surfaces through ensureQuota as a plain error — setting the PV to
+// QuotaStatusFailed and leaving the on-disk projid entry untouched — rather
+// than panicking or silently applying a quota under a stale ID.
+func TestEnsureQuota_ProjectIdentityConflictFailsPVWithoutCrashing(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, pv, client := ensureQuotaFixture(t, 1)
+	a.fsType = quota.FSTypeXFS
+
+	projectName := a.getProjectName(pv)
+	conflictingID := a.hashProjectName(projectName) + 1 // deliberately not the ID generateProjectID will compute
+	preexisting := fmt.Sprintf("%s:%d\n", projectName, conflictingID)
+	if err := os.WriteFile(a.projidFile, []byte(preexisting), 0644); err != nil {
+		t.Fatalf("seed projid file: %v", err)
+	}
+
+	ctx := context.Background()
+	err := a.ensureQuota(ctx, pv)
+	if err == nil {
+		t.Fatal("expected an error from a project identity conflict")
+	}
+	if !errors.Is(err, quota.ErrProjectConflict) {
+		t.Fatalf("expected ErrProjectConflict, got: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if _, ok := a.appliedQuotas[localPath]; ok {
+		t.Fatalf("appliedQuotas should not be set when identity validation fails")
+	}
+
+	updated, getErr := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("get pv: %v", getErr)
+	}
+	if updated.Annotations[AnnotationQuotaStatus] != QuotaStatusFailed {
+		t.Fatalf("expected quota status failed, got %q", updated.Annotations[AnnotationQuotaStatus])
+	}
+
+	data, readErr := os.ReadFile(a.projidFile)
+	if readErr != nil {
+		t.Fatalf("read projid file: %v", readErr)
+	}
+	if string(data) != preexisting {
+		t.Fatalf("projid file must be left unmodified on conflict, got %q, want %q", string(data), preexisting)
+	}
+}
+
+// TestEnsureQuota_ProjectNameWithColonFromAnnotationRejected proves the
+// colon rejection is reachable from where the untrusted value actually
+// enters: getProjectName returns the nfs.io/project-name annotation
+// verbatim (unlike the derived-from-PV-name fallback, which only ever
+// contains '-'/'_' and alphanumerics), so anyone who can create or patch a
+// PV controls this string end to end into AddProject.
+func TestEnsureQuota_ProjectNameWithColonFromAnnotationRejected(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, pv, client := ensureQuotaFixture(t, 1)
+	a.fsType = quota.FSTypeXFS
+	if pv.Annotations == nil {
+		pv.Annotations = map[string]string{}
+	}
+	pv.Annotations[AnnotationProjectName] = "evil:999"
+	if _, err := client.CoreV1().PersistentVolumes().Update(context.Background(), pv, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update pv: %v", err)
+	}
+
+	ctx := context.Background()
+	err := a.ensureQuota(ctx, pv)
+	if err == nil {
+		t.Fatal("expected an error for a project name containing ':'")
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if _, ok := a.appliedQuotas[localPath]; ok {
+		t.Fatalf("appliedQuotas should not be set when the name is rejected")
+	}
+
+	updated, getErr := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("get pv: %v", getErr)
+	}
+	if updated.Annotations[AnnotationQuotaStatus] != QuotaStatusFailed {
+		t.Fatalf("expected quota status failed, got %q", updated.Annotations[AnnotationQuotaStatus])
+	}
+
+	if data, readErr := os.ReadFile(a.projidFile); readErr == nil && len(data) != 0 {
+		t.Errorf("projid file must not be written when the name is rejected, got %q", string(data))
+	} else if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatalf("unexpected error reading projid file: %v", readErr)
 	}
 }
 

--- a/internal/quota/project.go
+++ b/internal/quota/project.go
@@ -25,11 +25,29 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 )
 
+// ErrProjectConflict indicates that a requested name/ID/path triple
+// disagrees with what the projects or projid file already records for one
+// of its keys. Callers can match it with errors.Is instead of parsing
+// message strings.
+var ErrProjectConflict = errors.New("project identity conflict")
+
 // AddProject adds a project to the projects and projid files.
+//
+// The full name/ID/path triple is validated against the current file
+// contents before either file is touched: a match on all three is a
+// no-op success (this runs every sync and must stay idempotent), and any
+// disagreement — projectName already owns a different ID, projectID
+// already owns a different name, or projectID already owns a different
+// path — is rejected as a unit via ErrProjectConflict, with neither file
+// written. Without this upfront check, a conflict caught only by the
+// per-file AppendToFile write below could still leave projid written and
+// projects rejected (or vice versa), producing exactly the half-applied
+// state this function exists to prevent.
 //
 // Order is load-bearing: projid is written first, then projects.
 // loadExistingProjectIDs (internal/agent/agent.go) reads projid to decide
@@ -41,6 +59,17 @@ import (
 // projid after a crash, letting a different project claim the same ID and
 // bleed quota across two paths. Do not reorder these two writes.
 func AddProject(path, projectName string, projectID uint32, projectsFile, projidFile string) error {
+	// Validate here rather than at each argv site: this is the only path by
+	// which a name reaches /etc/projid, and a name that breaks that file's
+	// format corrupts identity without ever touching a command line.
+	if err := validateProjectName(projectName); err != nil {
+		return err
+	}
+
+	if err := checkProjectIdentityConflict(path, projectName, projectID, projectsFile, projidFile); err != nil {
+		return err
+	}
+
 	// Add to projid file: projectName:projectID
 	projidEntry := fmt.Sprintf("%s:%d\n", projectName, projectID)
 	if err := AppendToFile(projidFile, projidEntry, projectName); err != nil {
@@ -56,10 +85,55 @@ func AddProject(path, projectName string, projectID uint32, projectsFile, projid
 	return nil
 }
 
+// checkProjectIdentityConflict verifies that (path, projectName, projectID)
+// agrees with whatever projectsFile and projidFile currently record, without
+// writing anything. projidFile and projectsFile are both keyed by project
+// ID (ReadProjidFile/ReadProjectsFile already return id -> value maps), so
+// the ID-keyed checks are a single map lookup; the name -> ID direction
+// requires a scan since projid has no reverse index.
+func checkProjectIdentityConflict(path, projectName string, projectID uint32, projectsFile, projidFile string) error {
+	projidByID, err := ReadProjidFile(projidFile) // id -> name
+	if err != nil {
+		return err
+	}
+	projectsByID, err := ReadProjectsFile(projectsFile) // id -> path
+	if err != nil {
+		return err
+	}
+
+	idStr := strconv.FormatUint(uint64(projectID), 10)
+
+	for id, name := range projidByID {
+		if name == projectName && id != idStr {
+			return fmt.Errorf("%w: project name %q is already mapped to id %s in %s, refusing to also map it to id %d",
+				ErrProjectConflict, projectName, id, projidFile, projectID)
+		}
+	}
+
+	if existingName, ok := projidByID[idStr]; ok && existingName != projectName {
+		return fmt.Errorf("%w: project id %d is already mapped to name %q in %s, refusing to remap it to %q",
+			ErrProjectConflict, projectID, existingName, projidFile, projectName)
+	}
+
+	if existingPath, ok := projectsByID[idStr]; ok && existingPath != path {
+		return fmt.Errorf("%w: project id %d is already mapped to path %q in %s, refusing to remap it to %q",
+			ErrProjectConflict, projectID, existingPath, projectsFile, path)
+	}
+
+	return nil
+}
+
 // AppendToFile appends an entry to a file if it doesn't already exist. The
 // write is fsynced (file and containing directory) before returning success,
 // so a caller that gets a nil error knows the bytes reached disk rather than
 // just the page cache.
+//
+// A line already present for searchKey is only treated as a no-op when it
+// matches entry exactly (an idempotent re-add); a line present for searchKey
+// with a different value — including a bare "searchKey" line with no value
+// at all, the shape a write truncated mid-flush leaves behind — is a
+// conflict and returns an error wrapping ErrProjectConflict instead of
+// silently leaving the stale value in place.
 func AppendToFile(filename, entry, searchKey string) (err error) {
 	// Read existing content
 	data, err := os.ReadFile(filename)
@@ -69,11 +143,23 @@ func AppendToFile(filename, entry, searchKey string) (err error) {
 
 	// Check if entry already exists by looking for searchKey at the start of any line
 	prefix := searchKey + ":"
+	wantLine := strings.TrimRight(entry, "\n")
 	lines := strings.Split(string(data), "\n")
 	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, prefix) || line == searchKey {
-			return nil // Already exists
+		trimmed := strings.TrimSpace(line)
+		// Check the identical-entry case first: entry always carries a
+		// "key:value" shape, so a bare marker line (trimmed == searchKey,
+		// no colon) can never equal wantLine and always falls through to
+		// the conflict below. That matters because a bare marker is what a
+		// write truncated mid-flush looks like (cut off right after the
+		// key, before the ":value"); treating it as "already exists" would
+		// silently accept a corrupt line instead of catching it here.
+		if trimmed == wantLine {
+			return nil // Identical entry already present
+		}
+		if trimmed == searchKey || strings.HasPrefix(trimmed, prefix) {
+			return fmt.Errorf("%w: %s already has an entry %q, refusing to write conflicting entry %q",
+				ErrProjectConflict, filename, trimmed, wantLine)
 		}
 	}
 
@@ -315,6 +401,43 @@ func ReadProjidFile(filename string) (map[string]string, error) {
 	}
 
 	return result, nil
+}
+
+// CheckProjectFileConsistency reports every project ID present in only one
+// of projectsFile/projidFile. AddProject's pre-write validation stops new
+// half-applied entries going forward, but it cannot retroactively fix a
+// mismatch that already exists on disk — from files predating this check,
+// a manual edit, or a rewrite that crashed outside AddProject's own
+// self-healing window. This is read-only: it reports, it does not repair,
+// so callers decide whether surfacing (rather than guessing) is the right
+// response for host quota metadata. The returned messages are sorted for
+// deterministic logging/test output.
+func CheckProjectFileConsistency(projectsFile, projidFile string) ([]string, error) {
+	projectsByID, err := ReadProjectsFile(projectsFile) // id -> path
+	if err != nil {
+		return nil, err
+	}
+	projidByID, err := ReadProjidFile(projidFile) // id -> name
+	if err != nil {
+		return nil, err
+	}
+
+	var mismatches []string
+	for id, path := range projectsByID {
+		if _, ok := projidByID[id]; !ok {
+			mismatches = append(mismatches, fmt.Sprintf(
+				"project id %s has path %q in %s but no matching name in %s", id, path, projectsFile, projidFile))
+		}
+	}
+	for id, name := range projidByID {
+		if _, ok := projectsByID[id]; !ok {
+			mismatches = append(mismatches, fmt.Sprintf(
+				"project id %s has name %q in %s but no matching path in %s", id, name, projidFile, projectsFile))
+		}
+	}
+
+	sort.Strings(mismatches)
+	return mismatches, nil
 }
 
 // RemoveQuotaByID removes quota for a project ID

--- a/internal/quota/project_test.go
+++ b/internal/quota/project_test.go
@@ -53,6 +53,77 @@ func TestAddProject(t *testing.T) {
 	}
 }
 
+// TestAddProject_NameRemappedToDifferentID reproduces the reported defect:
+// projid already maps "pvc_a" -> 3 and projects already maps 3 -> /export/pvc-a.
+// Calling AddProject for the same name with a *different* ID (as happens
+// when generateProjectID hands out the base hash to a second project after
+// the first, bumped one, is removed) must be rejected as a unit, leaving
+// both files exactly as they were — not silently drop the projid write
+// while still writing projects, which is what let two PVs end up sharing
+// project ID 3 with only one of them named in projid.
+func TestAddProject_NameRemappedToDifferentID(t *testing.T) {
+	dir := t.TempDir()
+	projectsFile := filepath.Join(dir, "projects")
+	projidFile := filepath.Join(dir, "projid")
+
+	if err := os.WriteFile(projidFile, []byte("pvc_a:3\n"), 0644); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	if err := os.WriteFile(projectsFile, []byte("3:/export/pvc-a\n"), 0644); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+
+	err := AddProject("/export/pvc-a-new", "pvc_a", 5, projectsFile, projidFile)
+	if err == nil {
+		t.Fatal("expected an error when a name is remapped to a different id")
+	}
+	if !errors.Is(err, ErrProjectConflict) {
+		t.Errorf("expected ErrProjectConflict, got: %v", err)
+	}
+
+	projidData, _ := os.ReadFile(projidFile)
+	if string(projidData) != "pvc_a:3\n" {
+		t.Errorf("projid file must be left unmodified, got %q", string(projidData))
+	}
+	projectsData, _ := os.ReadFile(projectsFile)
+	if string(projectsData) != "3:/export/pvc-a\n" {
+		t.Errorf("projects file must be left unmodified (no orphaned id 5 entry), got %q", string(projectsData))
+	}
+}
+
+// TestAddProject_IDRemappedToDifferentPath covers the third leg of the
+// identity triple: the ID already resolves to a different path than the
+// one requested. This can only be caught by validating against both files
+// before writing (AppendToFile's own per-file check on the projid write
+// alone would not see it, since projid does not carry path information).
+func TestAddProject_IDRemappedToDifferentPath(t *testing.T) {
+	dir := t.TempDir()
+	projectsFile := filepath.Join(dir, "projects")
+	projidFile := filepath.Join(dir, "projid")
+
+	if err := AddProject("/export/pvc-a", "pvc_a", 3, projectsFile, projidFile); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+
+	err := AddProject("/export/pvc-b", "pvc_b", 3, projectsFile, projidFile)
+	if err == nil {
+		t.Fatal("expected an error when an id is remapped to a different path")
+	}
+	if !errors.Is(err, ErrProjectConflict) {
+		t.Errorf("expected ErrProjectConflict, got: %v", err)
+	}
+
+	projidData, _ := os.ReadFile(projidFile)
+	if strings.Contains(string(projidData), "pvc_b") {
+		t.Errorf("projid file must not have been written for the rejected conflict, got %q", string(projidData))
+	}
+}
+
+// Colon/newline-in-name rejection at the AddProject level (neither file
+// touched) is covered by TestAddProjectRejectsDelimiterInName, and the
+// ordinary-name-still-works case by TestAddProjectAcceptsOrdinaryName, both
+// in projectname_test.go.
+
 func TestAddProject_WriteFailure(t *testing.T) {
 	// Using a directory path as the projid "file" forces a write failure.
 	badDir := t.TempDir()
@@ -74,18 +145,45 @@ func TestAppendToFile(t *testing.T) {
 		}
 	})
 
-	t.Run("skips duplicate entries", func(t *testing.T) {
+	t.Run("skips identical duplicate entries", func(t *testing.T) {
 		dir := t.TempDir()
 		f := filepath.Join(dir, "file")
 		if err := os.WriteFile(f, []byte("100:/data\n"), 0644); err != nil {
 			t.Fatalf("setup failed: %v", err)
 		}
-		if err := AppendToFile(f, "100:/other\n", "100"); err != nil {
+		if err := AppendToFile(f, "100:/data\n", "100"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		data, _ := os.ReadFile(f)
+		if strings.Count(string(data), "100:/data") != 1 {
+			t.Errorf("expected exactly one entry, got %q", string(data))
+		}
+	})
+
+	t.Run("rejects a conflicting value for an existing key", func(t *testing.T) {
+		// This is the bug this behavior replaces: silently discarding a
+		// value that disagrees with what's already on disk under the same
+		// key (e.g. the same project ID reassigned to a different path)
+		// used to look like success. It must now be a reported conflict,
+		// and the file must be left untouched.
+		dir := t.TempDir()
+		f := filepath.Join(dir, "file")
+		if err := os.WriteFile(f, []byte("100:/data\n"), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		err := AppendToFile(f, "100:/other\n", "100")
+		if err == nil {
+			t.Fatal("expected an error for a conflicting value")
+		}
+		if !errors.Is(err, ErrProjectConflict) {
+			t.Errorf("expected ErrProjectConflict, got: %v", err)
+		}
+		data, _ := os.ReadFile(f)
 		if strings.Contains(string(data), "/other") {
-			t.Errorf("expected duplicate entry to be skipped, got %q", string(data))
+			t.Errorf("expected file to be left unchanged, got %q", string(data))
+		}
+		if !strings.Contains(string(data), "100:/data") {
+			t.Errorf("expected original entry to remain, got %q", string(data))
 		}
 	})
 
@@ -103,18 +201,27 @@ func TestAppendToFile(t *testing.T) {
 		}
 	})
 
-	t.Run("exact searchKey match without colon also skips", func(t *testing.T) {
+	t.Run("bare searchKey line with no value is a conflict, not a silent skip", func(t *testing.T) {
+		// A bare "marker" line with no ":value" is what a write truncated
+		// mid-flush looks like (cut off right after the key). Treating it
+		// as "already exists" would silently accept corrupt data instead
+		// of surfacing it — the same class of bug this change fixes for
+		// same-key-different-value entries.
 		dir := t.TempDir()
 		f := filepath.Join(dir, "file")
 		if err := os.WriteFile(f, []byte("marker\n"), 0644); err != nil {
 			t.Fatalf("setup failed: %v", err)
 		}
-		if err := AppendToFile(f, "marker:extra\n", "marker"); err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		err := AppendToFile(f, "marker:extra\n", "marker")
+		if err == nil {
+			t.Fatal("expected an error for a bare marker line with no value")
+		}
+		if !errors.Is(err, ErrProjectConflict) {
+			t.Errorf("expected ErrProjectConflict, got: %v", err)
 		}
 		data, _ := os.ReadFile(f)
 		if strings.Contains(string(data), "extra") {
-			t.Errorf("expected append to be skipped due to bare marker match, got %q", string(data))
+			t.Errorf("expected file to be left unchanged, got %q", string(data))
 		}
 	})
 
@@ -520,6 +627,57 @@ func TestReadProjidFile_MissingFile(t *testing.T) {
 	}
 }
 
+func TestCheckProjectFileConsistency(t *testing.T) {
+	t.Run("reports no mismatches for a fully consistent pair", func(t *testing.T) {
+		dir := t.TempDir()
+		projectsFile := filepath.Join(dir, "projects")
+		projidFile := filepath.Join(dir, "projid")
+		if err := os.WriteFile(projectsFile, []byte("3:/export/pvc-a\n"), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		if err := os.WriteFile(projidFile, []byte("pvc_a:3\n"), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+
+		mismatches, err := CheckProjectFileConsistency(projectsFile, projidFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(mismatches) != 0 {
+			t.Errorf("expected no mismatches, got %v", mismatches)
+		}
+	})
+
+	t.Run("reports a half-applied state in both directions", func(t *testing.T) {
+		// id 3 has a path but no name (the reported defect's exact shape);
+		// id 7 has a name but no path (the reverse half-applied case).
+		dir := t.TempDir()
+		projectsFile := filepath.Join(dir, "projects")
+		projidFile := filepath.Join(dir, "projid")
+		if err := os.WriteFile(projectsFile, []byte("3:/export/pvc-a-new\n"), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		if err := os.WriteFile(projidFile, []byte("pvc_g:7\n"), 0644); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+
+		mismatches, err := CheckProjectFileConsistency(projectsFile, projidFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(mismatches) != 2 {
+			t.Fatalf("expected 2 mismatches, got %v", mismatches)
+		}
+		joined := strings.Join(mismatches, " | ")
+		if !strings.Contains(joined, "id 3") || !strings.Contains(joined, "/export/pvc-a-new") {
+			t.Errorf("expected a mismatch describing id 3's orphaned path, got %v", mismatches)
+		}
+		if !strings.Contains(joined, "id 7") || !strings.Contains(joined, "pvc_g") {
+			t.Errorf("expected a mismatch describing id 7's orphaned name, got %v", mismatches)
+		}
+	})
+}
+
 func TestRemoveQuotaByID(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -587,4 +745,62 @@ func TestRemoveQuotaByID(t *testing.T) {
 			t.Errorf("expected zero exec calls, got %d", len(r.calls))
 		}
 	})
+}
+
+// A rejected name must leave pre-existing content alone, not merely avoid
+// creating the files: the reachable case is a bad annotation arriving on a
+// host that already has projects/projid populated.
+func TestAddProject_RejectedNameLeavesExistingFilesIntact(t *testing.T) {
+	dir := t.TempDir()
+	projectsFile := filepath.Join(dir, "projects")
+	projidFile := filepath.Join(dir, "projid")
+
+	const seedProjects = "3:/export/pvc-a\n"
+	const seedProjid = "pvc_a:3\n"
+	if err := os.WriteFile(projectsFile, []byte(seedProjects), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(projidFile, []byte(seedProjid), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AddProject("/export/victim", "evil:999", 7, projectsFile, projidFile); err == nil {
+		t.Fatal("expected an error for a project name containing ':'")
+	}
+
+	gotProjects, err := os.ReadFile(projectsFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotProjid, err := os.ReadFile(projidFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotProjects) != seedProjects {
+		t.Errorf("projects changed: %q", string(gotProjects))
+	}
+	if string(gotProjid) != seedProjid {
+		t.Errorf("projid changed: %q", string(gotProjid))
+	}
+}
+
+// Positive control for the delimiter rejection: an ordinary name still writes
+// through and parses back with its ID intact, which is what makes the ID
+// visible to allocation.
+func TestAddProject_OrdinaryNameStillParsesBack(t *testing.T) {
+	dir := t.TempDir()
+	projectsFile := filepath.Join(dir, "projects")
+	projidFile := filepath.Join(dir, "projid")
+
+	if err := AddProject("/export/pvc-b", "pvc_b", 7, projectsFile, projidFile); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+
+	ids, err := ReadProjidFile(projidFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ids["7"] != "pvc_b" {
+		t.Fatalf("projid parsed back as %v; ID 7 must map to pvc_b or it is invisible to allocation", ids)
+	}
 }

--- a/internal/quota/validate.go
+++ b/internal/quota/validate.go
@@ -42,3 +42,31 @@ func validateQuotaArg(kind, value string) error {
 
 	return nil
 }
+
+// validateProjectName additionally rejects the ':' that separates the fields
+// of an /etc/projid line.
+//
+// Project names come straight from the nfs.io/project-name annotation, so
+// anyone able to create or patch a PV controls this string. A name such as
+// "evil:999" writes the line "evil:999:7", which parses back as the name
+// "evil" under the ID "999:7". That ID fails ParseUint, so the line is skipped
+// when the taken-ID set is built and the real ID 7 reads as free — handing it
+// to a second project and bleeding quota between two unrelated volumes.
+//
+// Names are rejected rather than sanitised: rewriting one silently changes
+// which quota an operator's PV is bound to, whereas a rejection surfaces on
+// the PV as a failed status. Paths are exempt because /etc/projects lines
+// parse as "id:path" with SplitN(line, ":", 2), so a colon inside the path is
+// harmless. Newlines, the other delimiter that would corrupt these files, are
+// already covered by the control-character check above.
+func validateProjectName(projectName string) error {
+	if err := validateQuotaArg("projectName", projectName); err != nil {
+		return err
+	}
+	for _, r := range projectName {
+		if r == ':' {
+			return fmt.Errorf("invalid projectName %q: contains ':', which separates the fields of an /etc/projid entry", projectName)
+		}
+	}
+	return nil
+}

--- a/internal/quota/validate_test.go
+++ b/internal/quota/validate_test.go
@@ -99,3 +99,9 @@ func TestValidateQuotaArg(t *testing.T) {
 		})
 	}
 }
+
+// validateProjectName itself is covered by TestValidateProjectName in
+// projectname_test.go (colon/newline rejection, ordinary names, empty/quote
+// delegation to validateQuotaArg); AddProject-level and ensureQuota-level
+// reachability are covered by TestAddProjectRejectsDelimiterInName and
+// TestEnsureQuota_ProjectNameWithColonFromAnnotationRejected respectively.


### PR DESCRIPTION
Addresses the enforceable core of #15 (acceptance criteria 1, 2, 3 and 5).

## Two ways one project ID ended up on two volumes

### 1. A name silently kept its old ID

`AppendToFile` treated "a line for this key exists" as success **without comparing the value**, and `AddProject` calls it twice — projid keyed by name, projects keyed by ID. So a name already mapped to a different ID was dropped while the projects write went through anyway. Reproduced against the real code:

```go
// projid = "pvc_a:3", projects = "3:/export/pvc-a"
AddProject("/export/pvc-a-new", "pvc_a", 5, projectsFile, projidFile)  // returned nil
```
```
projid  : pvc_a:3                    <- the 5 was dropped
projects: 3:/export/pvc-a
          5:/export/pvc-a-new        <- ID 5 has no name in projid
```

`loadExistingProjectIDs` builds its taken-set from **projid**, so ID 5 reads as free and gets handed to another project — two unrelated volumes on one project ID, quotas bleeding across. `AddProject` reported success the whole way.

**No file corruption is needed to reach this.** When two names hash-collide the second is bumped to `hash+1`. Remove the first and clean it up, and the base ID frees — so the survivor's next allocation returns the *base* hash while projid still records the bump. That is exactly the case above.

`AddProject` now validates the whole **name ↔ ID ↔ path** triple against both files *before* writing either, and rejects as a unit via `ErrProjectConflict`. An exact match on all three stays a silent no-op, since this runs every sync.

### 2. A project name could break the file format

Names reached `/etc/projid` with **no validation at all** — `xfs.go` and `ext4.go` validate before argv, but the file-write path had nothing in front of it. And `getProjectName` returns `pv.Annotations["nfs.io/project-name"]` **verbatim** (only the derived fallback is sanitised), so anyone who can create or patch a PV controls it:

```
name "evil:999"  ->  projid line "evil:999:7"
ReadProjidFile   ->  map["999:7"] = "evil"
```

`ParseUint("999:7")` fails, the line is skipped, and the real ID 7 goes invisible — the same corruption by another route, and `docs/security.md` already lists this annotation as an attacker-controlled input.

Rejected, **not sanitised**: silently rewriting a name changes which quota an operator's PV is bound to, whereas a rejection surfaces on the PV as a failed status. The ban is scoped to names — `/etc/projects` parses as `id:path` with `SplitN(line, ":", 2)`, so a colon inside a *path* is harmless. Newlines were already caught (by the whitespace check, verified rather than assumed).

## Also

- **`generateProjectID` had no exit condition** — `id++` with `if id == 0 { id = 1 }` and nothing bounding the probe. Now bounded, reporting exhaustion instead of spinning.
- **Startup consistency check**: reports entries present in only one of the two files. It **reports and does not repair** — rewriting host quota metadata on a guess is worse than surfacing the drift.
- A conflicting PV lands in the existing failed-status path; `syncAllQuotas` already logs and continues per PV, so one bad identity never blocks the others.

## Verification

```
gofmt -l .                       (no output)
go build ./... / go vet ./...    OK
go test ./...                    all 12 packages ok
golangci-lint run                0 issues
```

Both reproductions above now return an error and leave **both files byte-identical**, asserted against pre-seeded files rather than empty ones. Exhaustion is covered by a bounded test that fails fast instead of hanging CI.

## Deliberately not done (still open on #15)

Quarantine/cooldown for released IDs, PV/PVC-UID-based identity keys, read-back verification of the actual on-filesystem project association, audit events for allocate/release/reuse, and validation of the path→ID leg (a path can still end up under two IDs via an annotation rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)