### PR TITLE
feat(quotapolicy): reconcile QuotaPolicy CRD into filesystem quota enforcement

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Pinning every action to a commit SHA (see the workflows) removes the
+# supply-chain risk of a repointable tag, but it also freezes the actions
+# permanently unless something proposes updates. That is the trade this
+# file exists to close: without it, SHA pinning swaps a compromise risk for
+# a staleness risk that nobody notices for a year.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+
+  # Deliberately NOT enabling the gomod or docker ecosystems here.
+  # CI fails the License Check job whenever THIRD_PARTY_LICENSES.md is
+  # stale relative to go.mod (.github/workflows/ci.yaml), and `make license`
+  # has to be run and committed by hand. A gomod ecosystem would therefore
+  # open dependency PRs that are red on arrival, every week, training
+  # everyone to ignore a gate that exists to catch real license changes.
+  # Enable it only together with automation that regenerates the inventory
+  # in the same PR.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26'
           cache: true
@@ -27,7 +27,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           files: ./coverage.out
           fail_ci_if_error: false
@@ -37,16 +37,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26'
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.12.2
           install-mode: binary
@@ -58,10 +58,10 @@ jobs:
     needs: [test, lint]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26'
           cache: true
@@ -72,7 +72,7 @@ jobs:
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/nfs-quota-agent-linux-arm64 ./cmd/nfs-quota-agent
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: binaries
           path: bin/
@@ -82,10 +82,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26'
           cache: true
@@ -104,10 +104,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26'
           cache: true
@@ -132,10 +132,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: 'latest'
 
@@ -153,10 +153,10 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Run Trivy vulnerability scanner (filesystem)
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -164,13 +164,13 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run govulncheck
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
         with:
           go-version-input: '1.26'
           go-package: './...'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26'
           cache: true
@@ -33,13 +33,13 @@ jobs:
       changelog: ${{ steps.changelog.outputs.content }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Generate changelog
         id: changelog
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: cliff.toml
           args: --latest --strip header
@@ -48,7 +48,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Upload changelog
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: changelog
           path: CHANGELOG.md
@@ -62,16 +62,16 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -90,7 +90,7 @@ jobs:
             type=sha
 
       - name: Build and push multi-arch image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7
@@ -111,14 +111,14 @@ jobs:
       security-events: write
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           format: 'sarif'
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -130,10 +130,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26'
           cache: true
@@ -151,19 +151,19 @@ jobs:
           cd dist && sha256sum * > checksums.txt
 
       - name: Generate SBOM for binaries
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: ./dist
           format: spdx-json
           output-file: dist/sbom.spdx.json
 
       - name: Download changelog
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: changelog
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           body_path: CHANGELOG.md
           files: |
@@ -180,7 +180,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -190,7 +190,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Setup Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: 'latest'
 
@@ -199,7 +199,7 @@ jobs:
           helm package ./charts/nfs-quota-agent -d .helm-releases
 
       - name: Upload Helm chart artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: helm-chart
           path: .helm-releases/*.tgz
@@ -212,13 +212,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           ref: main
 
       - name: Generate full changelog
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: cliff.toml
           args: --verbose

--- a/charts/nfs-quota-agent/crds/quota.nfs.io_quotapolicies.yaml
+++ b/charts/nfs-quota-agent/crds/quota.nfs.io_quotapolicies.yaml
@@ -73,6 +73,9 @@ spec:
                   the nfs.io/default-quota annotation it supersedes.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: defaultQuota must not be negative
+                  rule: quantity(self).compareTo(quantity('0')) >= 0
               enforceMax:
                 default: true
                 description: |-
@@ -92,6 +95,9 @@ spec:
                   the nfs.io/max-quota annotation it supersedes.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: maxQuota must not be negative
+                  rule: quantity(self).compareTo(quantity('0')) >= 0
               minQuota:
                 anyOf:
                 - type: integer
@@ -103,6 +109,9 @@ spec:
                   from a LimitRange's PVC min.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: minQuota must not be negative
+                  rule: quantity(self).compareTo(quantity('0')) >= 0
               priority:
                 default: 100
                 description: |-

--- a/charts/nfs-quota-agent/templates/NOTES.txt
+++ b/charts/nfs-quota-agent/templates/NOTES.txt
@@ -1,4 +1,4 @@
-NFS Quota Agent has been deployed!
+NFS Quota Agent "{{ include "nfs-quota-agent.fullname" . }}" has been deployed to namespace "{{ .Release.Namespace }}"!
 
 {{- if .Release.IsUpgrade }}
 NOTE: nfs-quota-agent now runs as a DaemonSet instead of a Deployment.
@@ -8,16 +8,34 @@ running a pre-DaemonSet release, expect the old pod to be replaced by a
 new one on each labeled NFS server node rather than a rolling update.
 {{- end }}
 
-1. Ensure your NFS server node is labeled:
+*** This agent requires the "privileged" Pod Security Standard. ***
+If you see 0 pods after install, this is the most likely reason: the
+target namespace is enforcing "baseline" or "restricted", which rejects
+this pod's hostPath volumes and privileged securityContext. Fix it with:
+
+   kubectl label namespace {{ .Release.Namespace }} pod-security.kubernetes.io/enforce=privileged
+
+See docs/security.md for why this cannot be tuned away.
+
+1. Ensure at least one node matches the chart's nodeSelector, or no pod
+   will ever be scheduled (a typo here looks identical to "0 pods" above):
    kubectl label node <nfs-server-node> nfs-server=true
 
-2. Verify the agent is running:
+2. Check rollout status:
+   kubectl rollout status daemonset/{{ include "nfs-quota-agent.fullname" . }} -n {{ .Release.Namespace }}
+
+3. Verify the agent is running:
    kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "nfs-quota-agent.name" . }}"
 
-3. Check the agent logs:
+4. If pods don't appear, the real error is on the DaemonSet, not on any
+   pod (there's no pod object yet for admission failures to attach to):
+   kubectl -n {{ .Release.Namespace }} describe daemonset {{ include "nfs-quota-agent.fullname" . }}
+   kubectl -n {{ .Release.Namespace }} get events --field-selector reason=FailedCreate
+
+5. Check the agent logs:
    kubectl logs -n {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "nfs-quota-agent.name" . }}"
 
-4. Verify quota status on PVs:
+6. Verify quota status on PVs:
    kubectl get pv -o jsonpath='{range .items[*]}{.metadata.name}: {.metadata.annotations.nfs\.io/quota-status}{"\n"}{end}'
 
 Configuration:

--- a/charts/nfs-quota-agent/templates/clusterrole.yaml
+++ b/charts/nfs-quota-agent/templates/clusterrole.yaml
@@ -21,14 +21,37 @@ rules:
   - apiGroups: [""]
     resources: ["resourcequotas"]
     verbs: ["get", "list", "watch"]
-  # QuotaPolicy (quota.nfs.io/v1alpha1) read + status write. No consumer yet —
-  # the CRD ships in this chart ahead of the controller that reconciles it
-  # (issue #13, step 1). "delete" is deliberately omitted: nothing writes or
-  # removes QuotaPolicy objects from the agent's side; that authority stays
-  # with whoever manages the CRs, not this ClusterRole.
+  {{- if .Values.quotaPolicy.enabled }}
+  # PersistentVolumeClaim read, needed by the QuotaPolicy controller
+  # (internal/quotapolicy) to fetch PVC labels for
+  # spec.selector.labelSelector matching -- see docs/quotapolicy-design.md
+  # §4. This is a new grant beyond what step 1 (CRD-only) of the QuotaPolicy
+  # work added: reading QuotaPolicy objects alone does not tell the agent
+  # which PVCs a labelSelector matches, only listing PersistentVolumeClaims
+  # does. Read-only, matching the verb set already used for
+  # namespaces/limitranges/resourcequotas above. Gated on
+  # quotaPolicy.enabled: an earlier PR on this branch's history already
+  # removed a cluster-wide PersistentVolumeClaim read rule precisely because
+  # nothing called it -- granting it unconditionally again, to every
+  # existing deployment that has this feature off by default, would repeat
+  # that defect (cluster-wide read on other tenants' PVC names/labels/
+  # annotations for zero capability gained).
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  # QuotaPolicy (quota.nfs.io/v1alpha1) read + status write, consumed by
+  # internal/quotapolicy. "delete" is deliberately omitted: nothing writes
+  # or removes QuotaPolicy objects from the agent's side; that authority
+  # stays with whoever manages the CRs, not this ClusterRole. Gated on
+  # quotaPolicy.enabled for the same least-privilege reason as the
+  # PersistentVolumeClaim rule above -- a deployment with the feature off
+  # has no consumer for either read or status-write access to this CRD.
   - apiGroups: ["quota.nfs.io"]
     resources: ["quotapolicies"]
     verbs: ["get", "list", "watch"]
+  # "patch" is deliberately omitted: quotapolicy.WriteStatus only ever
+  # calls UpdateStatus (re-Get, then a full status replace), never Patch.
   - apiGroups: ["quota.nfs.io"]
     resources: ["quotapolicies/status"]
-    verbs: ["update", "patch"]
+    verbs: ["update"]
+  {{- end }}

--- a/charts/nfs-quota-agent/templates/daemonset.yaml
+++ b/charts/nfs-quota-agent/templates/daemonset.yaml
@@ -102,6 +102,12 @@ spec:
             - --enforce-max-quota
             {{- end }}
             {{- end }}
+            {{- if .Values.quotaPolicy.enabled }}
+            - --enable-quota-policy
+            {{- if .Values.quotaPolicy.singleWriter }}
+            - --quota-policy-single-writer
+            {{- end }}
+            {{- end }}
           ports:
             {{- if .Values.config.metricsAddr }}
             - name: metrics

--- a/charts/nfs-quota-agent/values.yaml
+++ b/charts/nfs-quota-agent/values.yaml
@@ -96,6 +96,31 @@ policy:
   # Enforce maximum quota from namespace annotation
   enforceMaxQuota: false
 
+# QuotaPolicy (quota.nfs.io/v1alpha1) custom resource-based quota
+# enforcement — see docs/quotapolicy-design.md. Distinct from `policy:`
+# above, which is the older LimitRange/Annotation/Global namespace-wide
+# chain; QuotaPolicy sits above that chain and adds per-PVC-name and
+# per-label-selector policies. Off by default for two reasons: it is a new
+# reconcile path added well after this chart's other enforcement
+# mechanisms, so existing deployments must opt in rather than pick up new
+# enforcement behavior on a chart bump; and the chart installs the CRD from
+# crds/ once, but never updates it on `helm upgrade` (see the note at the
+# top of this file) or removes it on `helm uninstall`, so turning this on
+# is a step an operator should take deliberately, not one bundled silently
+# into an unrelated values change.
+quotaPolicy:
+  enabled: false
+  # Gates QuotaPolicy *status* write-back only -- enforcement is unaffected.
+  # This chart is a DaemonSet that explicitly supports several NFS server
+  # nodes at once (see nodeSelector's comment below): every one of them
+  # would otherwise overwrite the same QuotaPolicy's status with its own
+  # partial appliedClaims/failingClaims view every sync cycle, making the
+  # object's status flap rather than converge. Set this to true only when
+  # you have verified exactly one node runs with quotaPolicy.enabled: true
+  # (e.g. a single NFS server node, or a separate release with its own
+  # nodeSelector for the rest). See docs/quotapolicy-design.md §11.
+  singleWriter: false
+
 # Metrics service configuration
 service:
   enabled: true

--- a/cmd/nfs-quota-agent/main.go
+++ b/cmd/nfs-quota-agent/main.go
@@ -30,6 +30,7 @@ import (
 	"syscall"
 	"time"
 
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -170,6 +171,10 @@ func runAgent(args []string) {
 		enablePolicy    bool
 		defaultQuota    string
 		enforceMaxQuota bool
+
+		// QuotaPolicy (quota.nfs.io/v1alpha1) options
+		enableQuotaPolicy       bool
+		quotaPolicySingleWriter bool
 	)
 
 	fs.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (optional, uses in-cluster config if not set)")
@@ -201,6 +206,23 @@ func runAgent(args []string) {
 	fs.BoolVar(&enablePolicy, "enable-policy", false, "Enable namespace quota policy")
 	fs.StringVar(&defaultQuota, "default-quota", "1Gi", "Global default quota for namespaces without annotation")
 	fs.BoolVar(&enforceMaxQuota, "enforce-max-quota", false, "Enforce maximum quota from namespace annotation")
+
+	// QuotaPolicy (quota.nfs.io/v1alpha1) flags. Defaults to false: this is
+	// a new CRD-based enforcement path (docs/quotapolicy-design.md), and a
+	// cluster with quotapolicies objects but no RBAC/CRD applied yet must
+	// not have its agent start resolving a feature it can't reach — see
+	// internal/quotapolicy.List's degrade-to-"no policies" behavior for
+	// what happens if this is turned on before the CRD exists.
+	fs.BoolVar(&enableQuotaPolicy, "enable-quota-policy", false, "Enable QuotaPolicy (quota.nfs.io/v1alpha1) custom resource-based quota enforcement")
+	// quotaPolicySingleWriter gates QuotaPolicy *status* write-back only —
+	// enforcement is unaffected. This chart is a DaemonSet that explicitly
+	// supports several NFS server nodes running at once; every one of them
+	// would otherwise overwrite the same QuotaPolicy's status with its own
+	// partial appliedClaims/failingClaims view every sync cycle. See
+	// docs/quotapolicy-design.md §11 "Multi-writer status" before setting
+	// this to true — do so only when exactly one --enable-quota-policy
+	// agent runs in the cluster.
+	fs.BoolVar(&quotaPolicySingleWriter, "quota-policy-single-writer", false, "Declare this the only QuotaPolicy-enabled agent in the cluster, enabling status write-back (see docs/quotapolicy-design.md)")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: nfs-quota-agent run [flags]")
@@ -265,6 +287,22 @@ func runAgent(args []string) {
 		}
 	}
 	ag.SetEnforceMaxQuota(enforceMaxQuota)
+
+	// Configure QuotaPolicy (quota.nfs.io/v1alpha1). The dynamic client is
+	// only constructed when the feature is enabled — it needs the same
+	// rest.Config already built above, and building it unconditionally
+	// would be one more thing to fail (and log about) for every agent that
+	// never turns this on.
+	ag.SetQuotaPolicyEnabled(enableQuotaPolicy)
+	ag.SetQuotaPolicySingleWriter(quotaPolicySingleWriter)
+	if enableQuotaPolicy {
+		dynamicClient, err := dynamic.NewForConfig(config)
+		if err != nil {
+			slog.Error("Failed to create dynamic Kubernetes client for QuotaPolicy; quota policy enforcement will be skipped", "error", err)
+		} else {
+			ag.SetDynamicClient(dynamicClient)
+		}
+	}
 
 	// Initialize audit logger if enabled
 	if enableAudit {

--- a/docs/quotapolicy-design.md
+++ b/docs/quotapolicy-design.md
@@ -1,14 +1,20 @@
 # QuotaPolicy Custom Resource — Design
 
-Status: types, generated deepcopy, and the generated CRD manifest only
-(issue #13, step 1). No controller, no reconcile/resolution logic, no
-scheme registration. Those land in a follow-up PR once this shape is
-agreed. Types live at
+Status: types, generated deepcopy, the generated CRD manifest, and the
+controller (resolution, effective-quota bounding, status write-back) are
+all implemented, gated behind `--enable-quota-policy` /
+`quotaPolicy.enabled` (default off). Types live at
 [`internal/apis/quota/v1alpha1/types.go`](../internal/apis/quota/v1alpha1/types.go);
 generated output is `zz_generated.deepcopy.go` in the same package and
 [`charts/nfs-quota-agent/crds/`](../charts/nfs-quota-agent/crds/), both
 produced by `make generate` (`go tool controller-gen`) and checked for
-staleness in CI.
+staleness in CI. The controller itself is
+[`internal/quotapolicy`](../internal/quotapolicy) (pure resolution and
+bounding logic, plus dynamic-client listing and status write-back), wired
+into the agent's existing sync cadence from
+[`internal/agent/policy.go`](../internal/agent/policy.go) — no separate
+watch loop or work queue; see §11 below for what that means and what it
+deliberately still doesn't cover (e.g. `Drifted`).
 
 ## 1. Problem
 
@@ -319,3 +325,145 @@ client/lister that would use it, belongs with the controller PR.
   namespace change at once** (e.g. a bulk priority renumbering) is a
   controller-implementation concern, not a types/API concern, and is left
   to the follow-up PR.
+
+## 11. Controller implementation
+
+This section documents the controller PR (`internal/quotapolicy`,
+`internal/agent/policy.go`) — the parts of §4–§6 above that needed a
+concrete choice once actually implemented.
+
+### Effective-quota semantics
+
+`quotapolicy.EffectiveQuota(requested, spec)` computes the size to enforce
+for a claim once `quotapolicy.Resolve` has picked a winning policy, applied
+in this order:
+
+1. Start from `requested` (the PV's own capacity). If `requested <= 0` and
+   `spec.defaultQuota` is set, start from `defaultQuota` instead.
+2. If `spec.minQuota` is set and the value is below it, raise to
+   `minQuota`.
+3. If `spec.maxQuota` is set and `spec.enforceMax` is `true` and the value
+   exceeds it, clamp to `maxQuota`.
+4. If `spec.maxQuota` is set and `spec.enforceMax` is `false` and the value
+   exceeds it, the value is left unchanged — `enforceMax: false` means
+   `maxQuota` is advisory, not a hard cap — but the overage is recorded
+   (`quotapolicy.BoundDecision`) so the caller can log/report it rather than
+   it passing unremarked.
+
+minQuota is applied before maxQuota; since the CRD's `XValidation` rules
+already reject `minQuota > maxQuota`, `defaultQuota < minQuota`, and
+`defaultQuota > maxQuota` at admission time, raising to `minQuota` can never
+itself push a value from a real, admitted `QuotaPolicy` back above
+`maxQuota` — the two outcomes are mutually exclusive in practice for a valid
+object.
+
+### Reconcile cadence, and why the watch path resolves against a cache
+
+`QuotaPolicy` is fully *resolved* only on the agent's existing
+`syncAllQuotas` cadence — there is no second watch loop or work queue for
+that, since `ensureQuota` already serializes every PV through the agent's
+single mutex and there is exactly one agent instance per node. But the
+watch path (`internal/agent/watch.go`) still needs to *use* that
+resolution, not ignore it, for a subtle reason: `ensureQuota` writes the
+`nfs.io/quota-status` annotation onto the PV it just enforced a quota on,
+which generates a `Modified` watch event for that same PV. If the watch
+handler responded to that event with the PV's raw capacity (no policy
+context at all), it would immediately re-apply the unclamped size and undo
+whatever the sync just enforced — the agent fighting itself, oscillating
+between clamped and unclamped every cycle, spending most of the interval
+*unclamped*.
+
+The fix: `beginQuotaPolicyCycle` publishes a `resolvedPolicySnapshot` (the
+namespace→policies map and the PVC labels needed to match them) each sync
+cycle, guarded by `QuotaAgent.mu`. `watch.go`'s Added/Modified handler calls
+`resolveFromSnapshot(pv)`, which runs the same `quotapolicy.Resolve` /
+`EffectiveQuota` the sync path uses, against that cached snapshot, before
+calling `ensureQuota`. This means:
+
+- A watch event between sync cycles resolves policy correctly (lagging the
+  policy set itself by at most one sync interval — acceptable, and honest,
+  since nothing claims tighter freshness).
+- The specific oscillation above cannot happen: the watch handler computes
+  the *same* effective size the last sync did for an unchanged claim, so
+  `ensureQuota`'s cache-hit early return fires and nothing is reapplied.
+- Before the first sync completes (no snapshot published yet), or with the
+  feature off, `resolveFromSnapshot` returns 0 — apply the PV's own
+  capacity, the correct and only sane behavior with nothing resolved yet.
+
+The published snapshot's maps are never mutated after construction, so the
+watch goroutine reading them concurrently with a sync cycle running in the
+main loop is safe without extra locking beyond the pointer swap itself.
+
+### Multi-writer status: this chart's DaemonSet can run on several nodes
+
+`charts/nfs-quota-agent/values.yaml`'s `nodeSelector` comment explicitly
+supports several NFS server nodes ("add each node's label here"), meaning
+several `QuotaAgent` instances can be `--enable-quota-policy` at once. Left
+unaddressed, this breaks `QuotaPolicy` status two ways:
+
+1. **Honesty**: `syncAllQuotas` lists PVs cluster-wide, but a given node
+   only has a local directory for the claims its own export backs. Without
+   filtering, every node would compute the *same* `matchedClaims` (it lists
+   the same policies) but a *different* `appliedClaims` (only the claims it
+   can actually enforce) — and, worse, `ensureQuota` returning `nil` on a
+   missing directory (a deliberate, correct "not mine to enforce" skip, not
+   a failure) would get counted as a successful application if nothing
+   distinguished it, making `Applied=True` a false statement. Fixed with a
+   `hasLocalDir` check in the `syncAllQuotas` loop: a claim without a local
+   directory is (a) excluded entirely from this node's resolution when
+   `quotaPolicySingleWriter` is false — some other node presumably owns it
+   — or (b) resolved and recorded as a real failure
+   (`errLocalDirectoryMissing` → `ReasonFilesystemUnavailable`) when
+   `quotaPolicySingleWriter` is true, since then there *is* no other node to
+   blame it on.
+2. **Convergence**: even with (1)'s honest, per-node counts, N nodes each
+   calling `UpdateStatus` with their own correct-but-partial view would
+   still make the object's status flap between N different snapshots every
+   cycle, never settling — which reads as an intermittent bug, not a
+   deliberate degradation, and is worse than not reporting.
+
+The fix for (2): `finishQuotaPolicyCycle` writes status only when
+`quotaPolicySingleWriter` is `true` (flag: `--quota-policy-single-writer`,
+chart: `quotaPolicy.singleWriter`, both default `false`). Left `false`
+(the default, since the chart's own multi-node support means this can never
+be safely assumed), the agent still enforces quotas exactly as resolved —
+only the `QuotaPolicy` *status* write-back is skipped, logged once, not
+silently. Real leader election (a `coordination.k8s.io` Lease) would let
+this work unattended on multiple nodes without an operator declaration, but
+that needs its own RBAC grant and is a materially larger change than this
+PR; left as a follow-up.
+
+`quotapolicy.WriteStatus` also retries once on `apierrors.IsConflict`
+(re-`Get`, re-apply, re-`UpdateStatus`) — a `Get`-then-`UpdateStatus` can
+still lose a race against whoever manages the CR's spec even with a single
+`QuotaPolicy` writer, and that's a benign, common race that shouldn't fail
+the whole sync cycle.
+
+### What's deliberately not implemented: `Drifted`
+
+The `Drifted` condition is never set by this PR. §5 already requires "if
+you cannot determine it cheaply and honestly, omit the condition entirely
+rather than reporting a check you didn't do" — a real drift check would
+mean reading back the filesystem's actual project quota (`xfs_quota
+report` / `repquota` / btrfs qgroup show) per matched claim and comparing it
+against spec, which this PR does not do. The agent's own
+`appliedQuotas` cache reflects what the agent *thinks* it last applied, not
+an independent read of on-disk state, so it can't honestly back this
+condition either. Left for a follow-up that adds that read-back.
+
+### RBAC: two new grants beyond the CRD-only ClusterRole, both gated on `quotaPolicy.enabled`
+
+Resolving `spec.selector.labelSelector` needs each claim's PVC labels, which
+the agent did not previously read at all. The ClusterRole now also grants
+`get`/`list`/`watch` on core `persistentvolumeclaims`, matching the verb set
+already used for `namespaces`/`limitranges`/`resourcequotas`. The
+`quotapolicies`/`quotapolicies/status` grants were already present from the
+CRD-only PR and didn't need widening. All three QuotaPolicy-related rules
+are wrapped in `{{- if .Values.quotaPolicy.enabled }}` in
+`clusterrole.yaml`: this branch's own history already removed a
+cluster-wide `PersistentVolumeClaim` read rule once because nothing called
+it, and granting cluster-wide read on other tenants' PVC names/labels
+unconditionally — to every existing deployment that has this feature off by
+default — would repeat that defect for zero capability gained. Verified by
+rendering both ways: `quotaPolicy.enabled=false` produces a ClusterRole with
+none of the three rules; `=true` produces all three.

--- a/docs/security.md
+++ b/docs/security.md
@@ -138,12 +138,35 @@ If you maintain a fork that added a consumer for either, re-add the correspondin
 
 ## 5. Pod Security Admission (PSA) Compliance
 
-Because the agent requires `hostPath` volumes (`/data`, `/dev`, `/etc/projects`, `/etc/projid`, `/var/lib/nfs-quota-agent`) and root/capability execution, the deployment **cannot** satisfy Kubernetes `restricted` or `baseline` Pod Security Admission standards.
+Because the agent requires `hostPath` volumes (`/data`, `/dev`, `/etc/projects`, `/etc/projid`, `/var/lib/nfs-quota-agent`) and root/capability execution, the deployment **cannot** satisfy Kubernetes `restricted` or `baseline` Pod Security Standards (PSS).
 
-It requires the **`privileged`** PSA profile.
+It requires the **`privileged`** PSS level:
 
-### Recommended Namespace Security Policy Manifest
-Cluster operators should deploy the agent into a dedicated namespace labeled with `privileged` PSA enforcement:
+```
+kubectl label namespace <namespace> pod-security.kubernetes.io/enforce=privileged
+```
+
+### 5.1 Measured Rejections
+
+Rendering this chart's DaemonSet pod template on a live Kubernetes 1.35 cluster against each PSS enforce level produces:
+
+* **`enforce=restricted`** → rejected, six violations: `privileged` (container must not set `securityContext.privileged=true`); `allowPrivilegeEscalation != false`; unrestricted capabilities (must drop `ALL`); restricted volume types — the `nfs-export`, `dev`, `etc-projects`, `etc-projid`, and `state` volumes all use `hostPath`; `runAsNonRoot != true`; `seccompProfile` unset.
+* **`enforce=baseline`** → rejected: the same five `hostPath` volumes, plus `privileged`.
+* **`enforce=privileged`** → accepted.
+
+The failure mode is easy to miss: `helm install`/`upgrade` still succeeds (the `DaemonSet` object itself is admitted), but admission silently rejects every pod it tries to create, so the symptom is a `DaemonSet` stuck at 0 ready with the actual reason recorded only in its events (see the chart's `NOTES.txt`).
+
+### 5.2 Why These Are Inherent, Not Configurable
+
+Per §1, dropping privileges or moving off the NFS server node means redesigning the quota path, not tightening the manifest — the same holds pod-by-pod:
+
+* **`privileged` / capabilities / `allowPrivilegeEscalation`**: required to issue `quotactl`, XFS ioctls, and Btrfs qgroup ioctls against the host filesystem via `xfs_quota`, `setquota`, `chattr`, and `btrfs`, and to identify backing block devices in `/dev` (§1, §2). There is no capability set that both satisfies `restricted`/`baseline` and lets these binaries operate on host quota state — §2 shows even the narrower `SYS_ADMIN`/`DAC_OVERRIDE`/`FOWNER`/`SYS_RESOURCE` set still requires `privileged: false` to be paired with unverified host mount-namespace access.
+* **`hostPath` volumes**: `nfs-export` is the NFS export itself; `etc-projects`/`etc-projid` are `/etc/projects` and `/etc/projid`, which are host quota metadata by definition (§1); `dev` is the host's block devices. Note that no Go code in this repo opens a path under `/dev`, and no quota call passes a device node — `setquota -P <id> ... <filesystem>` takes the mount path and `findmnt` is only queried for FSTYPE and OPTIONS. The mount is there because `setquota`/`xfs_quota` resolve that mount path to its backing device and operate on it themselves; that indirection has not been verified against a host in this repo's tests, so treat the `dev` mount as required-by-the-tools rather than required-by-the-agent; `state` is the crash-recovery sidecar directory for the two `/etc` files. None of these have a non-`hostPath` equivalent — they *are* host state, not data that could be supplied through a `ConfigMap`, `emptyDir`, or CSI volume.
+* **`runAsNonRoot` / `seccompProfile`**: the quota ioctls and `/etc/projects`/`/etc/projid` writes require UID 0 and the syscalls a default seccomp profile blocks (§2).
+
+### 5.3 Recommended Namespace Security Policy Manifest
+
+Deploy the agent into its **own namespace** carrying the `privileged` label, rather than relaxing an existing shared namespace — this scopes the exemption to this one workload instead of every pod that lands in that namespace:
 
 ```yaml
 apiVersion: v1
@@ -157,10 +180,22 @@ metadata:
     pod-security.kubernetes.io/warn: privileged
 ```
 
-### Risk Isolation for Cluster Operators
-Granting a `privileged` namespace exception exposes only the designated NFS server node to risk, provided `nodeSelector` pinning is configured:
-* The agent is constrained to NFS nodes via `nodeSelector: nfs-server: "true"` ([values.yaml](../charts/nfs-quota-agent/values.yaml)).
-* General application workloads running on worker nodes cannot leverage the agent's privilege context.
+or imperatively against an already-created namespace:
+
+```
+kubectl label namespace nfs-quota-agent pod-security.kubernetes.io/enforce=privileged
+```
+
+### 5.4 Third-Party Policy Engines
+
+The `pod-security.kubernetes.io/enforce` label only satisfies the built-in PSA controller. Kyverno and OPA Gatekeeper (or any other admission policy engine) evaluate their own policy sets independently of PSA and will reject the same pod on the same grounds unless separately configured with an exclusion for this namespace or workload. Confirm whether either is installed in the target cluster, and add the matching exemption there too — the PSS label alone is not sufficient once a policy engine is also enforcing pod security.
+
+### 5.5 Risk Isolation for Cluster Operators
+
+Granting a `privileged` namespace exception bounds *which pods* may run privileged, but not by itself *where* they run. Containment to the intended NFS server node comes from `nodeSelector` pinning, which the chart already requires:
+* The agent is constrained to NFS nodes via `nodeSelector: nfs-server: "true"` ([values.yaml](../charts/nfs-quota-agent/values.yaml)), and the chart refuses to render with an empty `nodeSelector` for this reason.
+* General application workloads running on worker nodes cannot leverage the agent's privilege context, since nothing else is scheduled into that namespace.
+* This does **not** bound what a compromised agent pod itself can reach once running — that blast radius is covered in §3.
 
 ---
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -31,8 +31,10 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
 	"github.com/dasomel/nfs-quota-agent/internal/audit"
 	"github.com/dasomel/nfs-quota-agent/internal/history"
 	"github.com/dasomel/nfs-quota-agent/internal/pvpath"
@@ -78,6 +80,18 @@ type QuotaAgent struct {
 	knownProjectIDs map[uint32]string // cache of projid file; refreshed once per sync cycle
 	auditLogger     *audit.Logger
 
+	// policySnapshot is the QuotaPolicy set (and the PVC labels needed to
+	// match it) as of the most recent syncAllQuotas cycle, published by
+	// beginQuotaPolicyCycle and read by the watch path (watch.go via
+	// resolveFromSnapshot) so an Added/Modified event can resolve policy
+	// for itself instead of ignoring it. Guarded by mu; the maps inside a
+	// given snapshot are never mutated after publish, so reading them after
+	// releasing mu is safe — see beginQuotaPolicyCycle's doc comment in
+	// policy.go for why this exists (ensureQuota's own status-annotation
+	// write generates a Modified event for the very PV it just enforced a
+	// quota on).
+	policySnapshot *resolvedPolicySnapshot
+
 	// Auto-cleanup configuration
 	enableAutoCleanup bool
 	cleanupInterval   time.Duration
@@ -93,6 +107,32 @@ type QuotaAgent struct {
 	enablePolicy    bool
 	defaultQuota    int64
 	enforceMaxQuota bool
+
+	// QuotaPolicy (quota.nfs.io/v1alpha1) configuration. Distinct from the
+	// enablePolicy/defaultQuota/enforceMaxQuota block above, which backs the
+	// older LimitRange/Annotation/Global namespace-policy chain in
+	// internal/policy — this is the CRD-based, per-claim policy added by
+	// docs/quotapolicy-design.md, reconciled from internal/quotapolicy.
+	// dynamicClient is nil unless the caller supplies one via
+	// SetDynamicClient; quotaPolicyEnabled with a nil dynamicClient degrades
+	// to "no policies" (logged once) rather than panicking, matching how a
+	// missing CRD degrades in quotapolicy.List.
+	quotaPolicyEnabled bool
+	dynamicClient      dynamic.Interface
+
+	// quotaPolicySingleWriter opts this agent into writing QuotaPolicy
+	// status. Default false, independent of quotaPolicyEnabled: this chart
+	// is a DaemonSet that explicitly supports several NFS server nodes at
+	// once (see values.yaml's nodeSelector comment), and every one of them
+	// resolving the same policy and calling UpdateStatus with its own
+	// partial appliedClaims/failingClaims view would flap that status every
+	// cycle rather than converge — see docs/quotapolicy-design.md §11
+	// "Multi-writer status". Quota *enforcement* is unaffected by this
+	// flag; it only gates finishQuotaPolicyCycle's status write-back.
+	quotaPolicySingleWriter bool
+	// quotaPolicyStatusSkipLogOnce fires the "status write-back disabled"
+	// warning exactly once per process instead of once per sync cycle.
+	quotaPolicyStatusSkipLogOnce sync.Once
 
 	// Health/readiness state, read by the metrics server's /health and
 	// /ready handlers. Kept on a dedicated mutex, separate from mu, so
@@ -186,6 +226,30 @@ func (a *QuotaAgent) SetDefaultQuota(v int64) { a.defaultQuota = v }
 
 // SetEnforceMaxQuota sets whether the maximum namespace quota should be enforced.
 func (a *QuotaAgent) SetEnforceMaxQuota(v bool) { a.enforceMaxQuota = v }
+
+// SetQuotaPolicyEnabled enables or disables QuotaPolicy (quota.nfs.io/v1alpha1)
+// resolution and enforcement. Defaults to false: see
+// docs/quotapolicy-design.md and cmd/nfs-quota-agent/main.go's
+// --enable-quota-policy flag for why this stays opt-in.
+func (a *QuotaAgent) SetQuotaPolicyEnabled(v bool) { a.quotaPolicyEnabled = v }
+
+// SetDynamicClient sets the dynamic client used to list and update the
+// status of QuotaPolicy objects (internal/quotapolicy). Kept as a setter
+// rather than a NewQuotaAgent parameter, matching every other optional
+// dependency on this type, and letting tests wire a
+// k8s.io/client-go/dynamic/fake client without touching the constructor.
+func (a *QuotaAgent) SetDynamicClient(v dynamic.Interface) { a.dynamicClient = v }
+
+// SetQuotaPolicySingleWriter declares that this is the only agent instance
+// that will ever resolve QuotaPolicy for the cluster (a single NFS server
+// node, or a deployment that has verified out-of-band that only one node
+// runs with --enable-quota-policy). Set it to true only when that's
+// actually true: see quotaPolicySingleWriter's doc comment for why a
+// multi-node deployment must leave this false.
+func (a *QuotaAgent) SetQuotaPolicySingleWriter(v bool) { a.quotaPolicySingleWriter = v }
+
+// QuotaPolicyEnabled returns whether QuotaPolicy resolution is enabled.
+func (a *QuotaAgent) QuotaPolicyEnabled() bool { return a.quotaPolicyEnabled }
 
 // Getters for UI/metrics interface
 
@@ -489,16 +553,79 @@ func (a *QuotaAgent) syncAllQuotas(ctx context.Context) error {
 	a.knownProjectIDs = ids
 	a.mu.Unlock()
 
+	// Resolve QuotaPolicy objects once per cycle (nil when the feature is
+	// disabled, no dynamic client is configured, or no policies exist) —
+	// see policy.go. This is the only place QuotaPolicy is reconciled: no
+	// second watch loop or work queue, per docs/quotapolicy-design.md and
+	// CLAUDE.md — ensureQuota already serializes every PV through a.mu, so
+	// there is no concurrency for a queue to protect.
+	cycle := a.beginQuotaPolicyCycle(ctx)
+
 	syncedCount := 0
 	live := make(map[string]struct{}, len(pvList.Items))
 	for _, pv := range pvList.Items {
 		if !a.shouldProcessPV(&pv) {
 			continue
 		}
+		var localPath string
+		var hasLocalDir bool
 		if nfsPath := a.getNFSPath(&pv); nfsPath != "" {
-			live[a.nfsPathToLocal(nfsPath)] = struct{}{}
+			localPath = a.nfsPathToLocal(nfsPath)
+			live[localPath] = struct{}{}
+			if _, statErr := os.Stat(localPath); statErr == nil {
+				hasLocalDir = true
+			}
 		}
-		if err := a.ensureQuota(ctx, &pv); err != nil {
+
+		// Whether to resolve/record a QuotaPolicy outcome for this claim at
+		// all depends on hasLocalDir and quotaPolicySingleWriter together —
+		// see the two cases below. This chart runs as a DaemonSet across
+		// possibly several NFS server nodes (values.yaml's nodeSelector
+		// comment), each with its own disjoint slice of PV directories, and
+		// syncAllQuotas lists PVs cluster-wide regardless of which node's
+		// export backs them.
+		var effectiveBytes int64
+		var winner *v1alpha1.QuotaPolicy
+		switch {
+		case hasLocalDir:
+			// The normal case: this node backs the claim, resolve and
+			// record its real outcome below once ensureQuota runs.
+			effectiveBytes, winner = cycle.resolve(&pv)
+		case a.quotaPolicySingleWriter:
+			// No local directory, but this agent has declared itself the
+			// only writer — so there is no "some other node owns this
+			// claim" explanation available, and staying silent about it
+			// would repeat the exact bug docs/quotapolicy-design.md §11 and
+			// the regression test guarding this describe: a claim a policy
+			// matches but never actually enforces must not be silently
+			// excluded from status, or Applied can read True (or, worse,
+			// vacuously True from zero recorded claims) while nothing was
+			// enforced. Resolve to find out if a policy would have won,
+			// so it can be recorded as a real failure below rather than
+			// dropped.
+			effectiveBytes, winner = cycle.resolve(&pv)
+		default:
+			// Multi-writer default: a claim with no local directory here
+			// most likely belongs to a different NFS server node's export.
+			// Excluding it entirely (not even counting it as matched) is
+			// what makes each node's status view honest about only what it
+			// can see — see finishQuotaPolicyCycle's doc comment for why
+			// that alone still isn't sufficient to write status safely,
+			// which is exactly why status write-back stays gated off here.
+		}
+
+		err := a.ensureQuota(ctx, &pv, effectiveBytes)
+		switch {
+		case hasLocalDir:
+			cycle.recordEnforcement(winner, &pv, err)
+		case a.quotaPolicySingleWriter:
+			// ensureQuota returned nil here too (it skips silently on a
+			// missing directory), so without substituting a real error the
+			// claim would still look like a clean success. Record the
+			// actual, honest outcome: matched, but not enforced.
+			cycle.recordEnforcement(winner, &pv, errLocalDirectoryMissing)
+		}
+		if err != nil {
 			slog.Error("Failed to ensure quota for PV", "pv", pv.Name, "error", err)
 		} else {
 			syncedCount++
@@ -506,6 +633,7 @@ func (a *QuotaAgent) syncAllQuotas(ctx context.Context) error {
 	}
 
 	a.pruneAppliedQuotas(live)
+	a.finishQuotaPolicyCycle(ctx, cycle)
 
 	slog.Debug("Quota sync completed", "synced", syncedCount, "total", len(pvList.Items))
 	return nil
@@ -567,8 +695,20 @@ func (a *QuotaAgent) getNFSPath(pv *v1.PersistentVolume) string {
 	return pvpath.NFSPath(pv)
 }
 
-// ensureQuota ensures the quota is applied for a PV
-func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume) error {
+// ensureQuota ensures the quota is applied for a PV.
+//
+// effectiveBytes, when positive, overrides the PV's own capacity — this is
+// the QuotaPolicy-resolved bound the caller computed via
+// quotapolicy.Resolve/EffectiveQuota. Pass 0 (or a negative value) to apply
+// the PV's capacity unchanged. syncAllQuotas passes 0 whenever the feature
+// is disabled or no policy matches a claim, so the applied value is exactly
+// capacityBytes, unchanged from before QuotaPolicy existed. watch.go does
+// NOT hardcode 0: see resolveFromSnapshot in policy.go, which resolves
+// against the most recent sync cycle's cached policy set so an
+// Added/Modified event doesn't ignore QuotaPolicy (or, worse, undo a clamp
+// the last sync just applied — see beginQuotaPolicyCycle's doc comment for
+// why that would otherwise oscillate forever).
+func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, effectiveBytes int64) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -584,12 +724,17 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume) e
 	}
 	localPath := a.nfsPathToLocal(nfsPath)
 
+	sizeBytes := capacityBytes
+	if effectiveBytes > 0 {
+		sizeBytes = effectiveBytes
+	}
+
 	if _, err := os.Stat(localPath); os.IsNotExist(err) {
 		slog.Warn("Directory does not exist, skipping quota", "path", localPath, "pv", pv.Name)
 		return nil
 	}
 
-	if existingQuota, exists := a.appliedQuotas[localPath]; exists && existingQuota == capacityBytes {
+	if existingQuota, exists := a.appliedQuotas[localPath]; exists && existingQuota == sizeBytes {
 		return nil
 	}
 
@@ -601,9 +746,9 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume) e
 	}
 
 	oldQuota := a.appliedQuotas[localPath]
-	isUpdate := oldQuota > 0 && oldQuota != capacityBytes
+	isUpdate := oldQuota > 0 && oldQuota != sizeBytes
 
-	err = a.applyQuota(localPath, projectName, projectID, capacityBytes)
+	err = a.applyQuota(localPath, projectName, projectID, sizeBytes)
 
 	var namespace, pvcName string
 	if pv.Spec.ClaimRef != nil {
@@ -613,9 +758,9 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume) e
 
 	if a.auditLogger != nil {
 		if isUpdate {
-			a.auditLogger.LogQuotaUpdate(pv.Name, localPath, projectName, projectID, oldQuota, capacityBytes, a.fsType, err)
+			a.auditLogger.LogQuotaUpdate(pv.Name, localPath, projectName, projectID, oldQuota, sizeBytes, a.fsType, err)
 		} else {
-			a.auditLogger.LogQuotaCreate(pv.Name, namespace, pvcName, localPath, projectName, projectID, capacityBytes, a.fsType, err)
+			a.auditLogger.LogQuotaCreate(pv.Name, namespace, pvcName, localPath, projectName, projectID, sizeBytes, a.fsType, err)
 		}
 	}
 
@@ -624,13 +769,13 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume) e
 		return err
 	}
 
-	a.appliedQuotas[localPath] = capacityBytes
+	a.appliedQuotas[localPath] = sizeBytes
 	a.updateQuotaStatus(ctx, pv, QuotaStatusApplied)
 
 	slog.Info("Quota applied successfully",
 		"pv", pv.Name,
 		"path", localPath,
-		"capacity", util.FormatBytes(capacityBytes),
+		"capacity", util.FormatBytes(sizeBytes),
 	)
 
 	return nil

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -585,7 +585,7 @@ func TestEnsureQuotaSuccess(t *testing.T) {
 	a.fsType = quota.FSTypeXFS
 
 	ctx := context.Background()
-	if err := a.ensureQuota(ctx, pv); err != nil {
+	if err := a.ensureQuota(ctx, pv, 0); err != nil {
 		t.Fatalf("ensureQuota: %v", err)
 	}
 
@@ -605,7 +605,7 @@ func TestEnsureQuotaSuccess(t *testing.T) {
 	// Re-running with the same capacity should be a no-op (skip branch).
 	callsBefore := 0
 	// nothing else to assert directly on calls without exposing the runner; verifying idempotence via error/state is enough.
-	if err := a.ensureQuota(ctx, pv); err != nil {
+	if err := a.ensureQuota(ctx, pv, 0); err != nil {
 		t.Fatalf("second ensureQuota: %v", err)
 	}
 	_ = callsBefore
@@ -625,7 +625,7 @@ func TestEnsureQuotaBtrfsSuccess(t *testing.T) {
 	a.fsType = quota.FSTypeBtrfs
 
 	ctx := context.Background()
-	if err := a.ensureQuota(ctx, pv); err != nil {
+	if err := a.ensureQuota(ctx, pv, 0); err != nil {
 		t.Fatalf("ensureQuota: %v", err)
 	}
 
@@ -649,7 +649,7 @@ func TestEnsureQuotaNoCapacity(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "pv-nocap"},
 		Spec:       v1.PersistentVolumeSpec{PersistentVolumeSource: v1.PersistentVolumeSource{NFS: &v1.NFSVolumeSource{Path: "/exports/x"}}},
 	}
-	if err := a.ensureQuota(context.Background(), pv); err == nil || !strings.Contains(err.Error(), "no storage capacity") {
+	if err := a.ensureQuota(context.Background(), pv, 0); err == nil || !strings.Contains(err.Error(), "no storage capacity") {
 		t.Fatalf("expected no-capacity error, got %v", err)
 	}
 }
@@ -658,7 +658,7 @@ func TestEnsureQuotaNoNFSPath(t *testing.T) {
 	a := newTestAgent(t, fake.NewSimpleClientset())
 	pv := newBoundPV("pv-nopath", "", 1)
 	pv.Spec.NFS = nil // remove NFS source, leaving no way to compute a path
-	if err := a.ensureQuota(context.Background(), pv); err == nil || !strings.Contains(err.Error(), "no NFS path") {
+	if err := a.ensureQuota(context.Background(), pv, 0); err == nil || !strings.Contains(err.Error(), "no NFS path") {
 		t.Fatalf("expected no-NFS-path error, got %v", err)
 	}
 }
@@ -670,7 +670,7 @@ func TestEnsureQuotaDirectoryMissing(t *testing.T) {
 	a.nfsServerPath = "/exports"
 	// Note: local directory intentionally not created.
 
-	if err := a.ensureQuota(context.Background(), pv); err != nil {
+	if err := a.ensureQuota(context.Background(), pv, 0); err != nil {
 		t.Fatalf("expected nil error (skip) when directory missing, got %v", err)
 	}
 	localPath := a.nfsPathToLocal("/exports/pvc-missing")
@@ -684,7 +684,7 @@ func TestEnsureQuotaUnsupportedFilesystem(t *testing.T) {
 	// a.fsType left at zero value ("") -> applyQuota hits the default/unsupported branch.
 
 	ctx := context.Background()
-	if err := a.ensureQuota(ctx, pv); err == nil || !strings.Contains(err.Error(), "unsupported filesystem type") {
+	if err := a.ensureQuota(ctx, pv, 0); err == nil || !strings.Contains(err.Error(), "unsupported filesystem type") {
 		t.Fatalf("expected unsupported filesystem error, got %v", err)
 	}
 
@@ -710,7 +710,7 @@ func TestEnsureQuotaCommandFailure(t *testing.T) {
 	a.fsType = quota.FSTypeXFS
 
 	ctx := context.Background()
-	if err := a.ensureQuota(ctx, pv); err == nil {
+	if err := a.ensureQuota(ctx, pv, 0); err == nil {
 		t.Fatalf("expected command failure error")
 	}
 
@@ -746,7 +746,7 @@ func TestEnsureQuota_ProjectIdentityConflictFailsPVWithoutCrashing(t *testing.T)
 	}
 
 	ctx := context.Background()
-	err := a.ensureQuota(ctx, pv)
+	err := a.ensureQuota(ctx, pv, 0)
 	if err == nil {
 		t.Fatal("expected an error from a project identity conflict")
 	}
@@ -795,7 +795,7 @@ func TestEnsureQuota_ProjectNameWithColonFromAnnotationRejected(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	err := a.ensureQuota(ctx, pv)
+	err := a.ensureQuota(ctx, pv, 0)
 	if err == nil {
 		t.Fatal("expected an error for a project name containing ':'")
 	}
@@ -833,7 +833,7 @@ func TestEnsureQuotaUpdateFlowWithAuditLogger(t *testing.T) {
 	a.SetAuditLogger(logger)
 
 	ctx := context.Background()
-	if err := a.ensureQuota(ctx, pv); err != nil {
+	if err := a.ensureQuota(ctx, pv, 0); err != nil {
 		t.Fatalf("initial ensureQuota: %v", err)
 	}
 
@@ -842,7 +842,7 @@ func TestEnsureQuotaUpdateFlowWithAuditLogger(t *testing.T) {
 		v1.ResourceStorage: *resource.NewQuantity(2*1024*1024*1024, resource.BinarySI),
 	}
 
-	if err := a.ensureQuota(ctx, pv); err != nil {
+	if err := a.ensureQuota(ctx, pv, 0); err != nil {
 		t.Fatalf("update ensureQuota: %v", err)
 	}
 

--- a/internal/agent/policy.go
+++ b/internal/agent/policy.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+// policy.go wires internal/quotapolicy (QuotaPolicy resolution, effective-
+// quota bounding, and status write-back) into the agent's existing
+// syncAllQuotas cadence. There is deliberately no second watch loop or work
+// queue here — see docs/quotapolicy-design.md and CLAUDE.md: ensureQuota
+// already serializes every PV through a.mu, and there is exactly one agent
+// instance per node, so there is no concurrency for a queue to protect.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+	"github.com/dasomel/nfs-quota-agent/internal/policy"
+	"github.com/dasomel/nfs-quota-agent/internal/quotapolicy"
+)
+
+// quotaPolicyCycle carries everything one syncAllQuotas pass needs to
+// resolve QuotaPolicy objects and, at the end of the pass, write their
+// status back. A nil *quotaPolicyCycle — returned by beginQuotaPolicyCycle
+// whenever the feature is disabled, unconfigured, or there are simply no
+// QuotaPolicy objects to resolve — makes every method below a documented
+// no-op, so agent.go's call sites don't need a separate "is this enabled"
+// branch.
+type quotaPolicyCycle struct {
+	client kubernetes.Interface
+
+	byNamespace map[string][]v1alpha1.QuotaPolicy
+	// pvcLabels is keyed by "namespace/name" -> the PVC's labels, needed for
+	// labelSelector matching. Populated with one List per namespace that has
+	// at least one QuotaPolicy, per docs/quotapolicy-design.md's "not one
+	// Get per PV" instruction.
+	pvcLabels map[string]map[string]string
+
+	// outcomes is keyed by "namespace/policyName" -> every ClaimOutcome
+	// recorded against that policy this cycle (as winner or shadowed
+	// loser), the input to quotapolicy.BuildStatus.
+	outcomes map[string][]quotapolicy.ClaimOutcome
+
+	// matchKindFor is keyed by "namespace/pvcName" -> the MatchKind the
+	// current winner earned, set by resolve and consumed by
+	// recordEnforcement once the enforcement result (ensureQuota's error,
+	// if any) is known. resolve and recordEnforcement are always called as
+	// a pair for the same PV within one syncAllQuotas loop iteration, so
+	// this simple map is enough — no risk of one PV's entry being read
+	// before it's written or clobbered by another.
+	matchKindFor map[string]v1alpha1.MatchKind
+
+	// limitRange caches internal/policy.GetNamespacePolicy's LimitRange
+	// info per namespace, computed lazily in finishQuotaPolicyCycle (not
+	// every namespace-with-a-policy needs it: only ones where the winning
+	// policy sets maxQuota end up asking).
+	limitRange map[string]quotapolicy.LimitRangeInfo
+}
+
+// resolvedPolicySnapshot is the read-only subset of one syncAllQuotas
+// cycle's QuotaPolicy resolution inputs that the watch path (watch.go, via
+// resolveFromSnapshot) needs between sync cycles. It intentionally carries
+// only byNamespace/pvcLabels — never quotaPolicyCycle's outcomes/
+// matchKindFor/limitRange maps, which accumulate mutations over the cycle
+// and are only ever touched by the syncAllQuotas goroutine. A given
+// snapshot's maps are built once in beginQuotaPolicyCycle and never mutated
+// afterward, so publishing the pointer under QuotaAgent.mu and letting
+// watchPVs' goroutine read the maps lock-free after that is safe: there is
+// no writer left to race with.
+type resolvedPolicySnapshot struct {
+	byNamespace map[string][]v1alpha1.QuotaPolicy
+	pvcLabels   map[string]map[string]string
+}
+
+// setPolicySnapshot publishes s as the snapshot resolveFromSnapshot reads.
+func (a *QuotaAgent) setPolicySnapshot(s *resolvedPolicySnapshot) {
+	a.mu.Lock()
+	a.policySnapshot = s
+	a.mu.Unlock()
+}
+
+// resolveFromSnapshot resolves QuotaPolicy for pv against the most recent
+// syncAllQuotas cycle's published snapshot, for callers with no cycle of
+// their own — specifically watch.go's Added/Modified handler. It returns 0
+// ("apply the PV's own capacity") whenever there's nothing to resolve:
+// the feature disabled, no snapshot published yet (no sync has completed
+// since startup, or since the feature was turned on — raw capacity is the
+// correct thing to apply until the first sync has a chance to resolve
+// policy), the claim's namespace has no policies, or none of them match.
+// It never mutates agent or cycle state and takes no action beyond
+// computing a number, so it's safe to call from the watch goroutine
+// concurrently with a syncAllQuotas cycle running in the main loop.
+func (a *QuotaAgent) resolveFromSnapshot(pv *v1.PersistentVolume) int64 {
+	if !a.quotaPolicyEnabled || pv.Spec.ClaimRef == nil {
+		return 0
+	}
+	a.mu.Lock()
+	snap := a.policySnapshot
+	a.mu.Unlock()
+	if snap == nil {
+		return 0
+	}
+
+	ns, name := pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name
+	policies, ok := snap.byNamespace[ns]
+	if !ok {
+		return 0
+	}
+
+	claim := quotapolicy.Claim{Namespace: ns, Name: name, Labels: snap.pvcLabels[ns+"/"+name]}
+	res := quotapolicy.Resolve(claim, policies)
+	if res.Winner == nil {
+		return 0
+	}
+
+	requested := int64(0)
+	if capacity, ok := pv.Spec.Capacity[v1.ResourceStorage]; ok {
+		requested = capacity.Value()
+	}
+	effective, _ := quotapolicy.EffectiveQuota(requested, res.Winner.Spec)
+	return effective
+}
+
+// beginQuotaPolicyCycle lists QuotaPolicy objects and the PVCs needed to
+// match them, once per syncAllQuotas call, and publishes a
+// resolvedPolicySnapshot from that same listing for the watch path (see
+// resolveFromSnapshot) — including when there are zero policies, so the
+// watch path can tell "policies were listed this cycle; there simply
+// aren't any" apart from "no sync has completed yet" (nil snapshot).
+//
+// It returns nil — meaning "act as if QuotaPolicy doesn't exist" for the
+// rest of *this* cycle's sync-path bookkeeping — whenever the feature
+// isn't usable right now: disabled, no dynamic client configured, a list
+// error, or simply no policies found. None of those are treated as a sync
+// failure: a namespace quota policy problem must never block the base
+// quota-enforcement loop that predates this feature.
+func (a *QuotaAgent) beginQuotaPolicyCycle(ctx context.Context) *quotaPolicyCycle {
+	if !a.quotaPolicyEnabled {
+		return nil
+	}
+	if a.dynamicClient == nil {
+		slog.Warn("QuotaPolicy enabled but no dynamic client configured (SetDynamicClient); skipping policy resolution this cycle")
+		return nil
+	}
+
+	policies, err := quotapolicy.List(ctx, a.dynamicClient)
+	if err != nil {
+		slog.Error("Failed to list QuotaPolicy objects; skipping policy resolution this cycle", "error", err)
+		return nil
+	}
+
+	byNamespace := make(map[string][]v1alpha1.QuotaPolicy)
+	for _, p := range policies {
+		byNamespace[p.Namespace] = append(byNamespace[p.Namespace], p)
+	}
+
+	pvcLabels := make(map[string]map[string]string)
+	for ns := range byNamespace {
+		list, err := a.client.CoreV1().PersistentVolumeClaims(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			slog.Warn("Failed to list PersistentVolumeClaims for QuotaPolicy label matching", "namespace", ns, "error", err)
+			continue
+		}
+		for _, pvc := range list.Items {
+			pvcLabels[ns+"/"+pvc.Name] = pvc.Labels
+		}
+	}
+
+	a.setPolicySnapshot(&resolvedPolicySnapshot{byNamespace: byNamespace, pvcLabels: pvcLabels})
+
+	if len(policies) == 0 {
+		return nil
+	}
+
+	return &quotaPolicyCycle{
+		client:       a.client,
+		byNamespace:  byNamespace,
+		pvcLabels:    pvcLabels,
+		outcomes:     make(map[string][]quotapolicy.ClaimOutcome),
+		matchKindFor: make(map[string]v1alpha1.MatchKind),
+		limitRange:   make(map[string]quotapolicy.LimitRangeInfo),
+	}
+}
+
+// resolve determines the QuotaPolicy-effective quota size to enforce for
+// pv, and records every policy this claim matched (as winner or shadowed
+// loser) for the eventual status write-back. It returns (0, nil) whenever
+// there is nothing to resolve — a nil cycle, a PV with no ClaimRef, a
+// namespace with no QuotaPolicy objects, or a namespace with policies none
+// of which match this claim — and 0 is exactly the sentinel ensureQuota
+// treats as "use the PV's own capacity", so every one of those cases
+// reproduces pre-QuotaPolicy behavior automatically.
+func (c *quotaPolicyCycle) resolve(pv *v1.PersistentVolume) (effectiveBytes int64, winner *v1alpha1.QuotaPolicy) {
+	if c == nil || pv.Spec.ClaimRef == nil {
+		return 0, nil
+	}
+	ns, name := pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name
+	candidates, ok := c.byNamespace[ns]
+	if !ok {
+		return 0, nil
+	}
+
+	claimKey := ns + "/" + name
+	claim := quotapolicy.Claim{Namespace: ns, Name: name, Labels: c.pvcLabels[claimKey]}
+	res := quotapolicy.Resolve(claim, candidates)
+
+	for _, inv := range res.Invalid {
+		slog.Warn("QuotaPolicy has an invalid selector; it is excluded from matching until fixed",
+			"namespace", inv.Policy.Namespace, "name", inv.Policy.Name, "error", inv.Err)
+	}
+
+	for _, l := range res.Losers {
+		c.record(l.Policy.Namespace, l.Policy.Name, quotapolicy.ClaimOutcome{
+			Claim:      claim,
+			MatchKind:  l.MatchKind,
+			Won:        false,
+			ResolvedBy: res.Winner.Name,
+		})
+	}
+
+	if res.Winner == nil {
+		return 0, nil
+	}
+
+	requested := int64(0)
+	if capacity, ok := pv.Spec.Capacity[v1.ResourceStorage]; ok {
+		requested = capacity.Value()
+	}
+	effective, decision := quotapolicy.EffectiveQuota(requested, res.Winner.Spec)
+	if decision.Outcome == quotapolicy.BoundAdvisoryOverage {
+		slog.Warn("Claim exceeds QuotaPolicy maxQuota but enforceMax is false; applying the requested capacity unchanged",
+			"namespace", ns, "pvcName", name, "policy", res.Winner.Name, "detail", decision.Detail)
+	}
+
+	c.matchKindFor[claimKey] = res.MatchKind
+	return effective, res.Winner
+}
+
+// recordEnforcement records the enforcement outcome (ensureQuota's error,
+// if any) for pv's winning QuotaPolicy, once it's known. winner is exactly
+// what resolve returned for this same pv earlier in the same loop
+// iteration; nil means resolve found no matching policy, in which case
+// there is nothing to record and this is a no-op, same as a nil cycle.
+func (c *quotaPolicyCycle) recordEnforcement(winner *v1alpha1.QuotaPolicy, pv *v1.PersistentVolume, err error) {
+	if c == nil || winner == nil || pv.Spec.ClaimRef == nil {
+		return
+	}
+	ns, name := pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name
+	claimKey := ns + "/" + name
+
+	outcome := quotapolicy.ClaimOutcome{
+		Claim:     quotapolicy.Claim{Namespace: ns, Name: name, Labels: c.pvcLabels[claimKey]},
+		MatchKind: c.matchKindFor[claimKey],
+		Won:       true,
+	}
+	if err != nil {
+		outcome.EnforcementErr = err
+		outcome.EnforcementReason = classifyEnforcementError(err)
+	}
+	c.record(winner.Namespace, winner.Name, outcome)
+}
+
+// record appends outcome to the running list for the policy identified by
+// namespace/policyName.
+func (c *quotaPolicyCycle) record(namespace, policyName string, outcome quotapolicy.ClaimOutcome) {
+	key := namespace + "/" + policyName
+	c.outcomes[key] = append(c.outcomes[key], outcome)
+}
+
+// errLocalDirectoryMissing is the synthetic error substituted for a claim
+// this node resolved a winning policy for, but whose backing directory does
+// not exist locally, when quotaPolicySingleWriter is true. ensureQuota
+// itself returns nil (not an error) for that case — see its "Directory
+// does not exist, skipping quota" log line — which is the right contract
+// for enforcement (a missing directory isn't a retryable failure) but would
+// otherwise make recordEnforcement treat "silently skipped" the same as
+// "successfully applied". See the syncAllQuotas loop in agent.go for where
+// this is substituted, and docs/quotapolicy-design.md §11.
+var errLocalDirectoryMissing = errors.New("PV local directory does not exist on this node")
+
+// classifyEnforcementError maps an ensureQuota error to one of the fixed
+// Reason* constants for FailingClaim/Degraded reporting, falling back to
+// the generic ReasonEnforcementFailed for anything not specifically
+// recognized. errProjectIDExhausted and errLocalDirectoryMissing are the
+// only cases distinguished today; docs/quotapolicy-design.md §5 already
+// anticipates ReasonProjectIDExhausted may turn out to be unreachable in
+// practice given the existing collision-fallback in generateProjectID — the
+// same "included for the vocabulary, may never fire" reasoning could apply
+// to either.
+func classifyEnforcementError(err error) string {
+	switch {
+	case errors.Is(err, errProjectIDExhausted):
+		return v1alpha1.ReasonProjectIDExhausted
+	case errors.Is(err, errLocalDirectoryMissing):
+		return v1alpha1.ReasonFilesystemUnavailable
+	default:
+		return v1alpha1.ReasonEnforcementFailed
+	}
+}
+
+// finishQuotaPolicyCycle writes a fresh status to every QuotaPolicy object
+// this cycle observed, whether or not it won any claims — a policy that
+// currently matches nothing still needs its Ready condition reported (see
+// quotapolicy.BuildStatus). No-op on a nil cycle.
+//
+// It is also a no-op — logged once, not once per cycle — unless
+// quotaPolicySingleWriter is true. This chart is a DaemonSet that
+// explicitly supports several NFS server nodes running at once (see
+// values.yaml's nodeSelector comment): every one of them lists the exact
+// same cluster-wide QuotaPolicy objects, but each only ever enforces (and,
+// since syncAllQuotas now applies the has-local-directory predicate before
+// recording an outcome, only ever *counts*) the claims whose backing
+// directory lives on its own node. If every node still called
+// WriteStatus, N agents would each overwrite the same policy's status with
+// their own honest-but-partial appliedClaims/failingClaims/conditions every
+// sync cycle, and the object would appear to flap between N different
+// partial views rather than settle — worse than not reporting, because it
+// reads as an intermittent bug rather than an unsupported topology. Rather
+// than publish a number that might be one node's partial view, this skips
+// the write and leaves status exactly as it was (stale, but honestly so —
+// `status.observedGeneration` will fall behind `metadata.generation`,
+// itself a signal something isn't reconciling). An operator who has
+// verified they run exactly one --enable-quota-policy agent opts in via
+// SetQuotaPolicySingleWriter / --quota-policy-single-writer /
+// quotaPolicy.singleWriter. Real leader election (a coordination.k8s.io
+// Lease) would let this work unattended on multiple nodes, but that needs
+// its own RBAC grant and is a materially larger change than this PR; see
+// docs/quotapolicy-design.md §11.
+func (a *QuotaAgent) finishQuotaPolicyCycle(ctx context.Context, cycle *quotaPolicyCycle) {
+	if cycle == nil {
+		return
+	}
+	if !a.quotaPolicySingleWriter {
+		a.quotaPolicyStatusSkipLogOnce.Do(func() {
+			slog.Warn("QuotaPolicy status write-back is disabled: quotaPolicySingleWriter is not set. " +
+				"This DaemonSet may run on several NFS server nodes; each would otherwise overwrite the same " +
+				"QuotaPolicy's status with its own partial view. Set --quota-policy-single-writer (or " +
+				"quotaPolicy.singleWriter in the chart) only if exactly one agent has --enable-quota-policy set. " +
+				"Quota enforcement itself is unaffected.")
+		})
+		return
+	}
+
+	now := metav1.Now()
+	for ns, policies := range cycle.byNamespace {
+		lr := cycle.limitRangeInfo(ctx, ns)
+		for i := range policies {
+			p := &policies[i]
+			outcomes := cycle.outcomes[ns+"/"+p.Name]
+			status := quotapolicy.BuildStatus(p, outcomes, lr, p.Status.Conditions, now)
+			if err := quotapolicy.WriteStatus(ctx, a.dynamicClient, p, status); err != nil {
+				slog.Error("Failed to write QuotaPolicy status", "namespace", ns, "name", p.Name, "error", err)
+			}
+		}
+	}
+}
+
+// limitRangeInfo returns (and caches) the LimitRangeInfo for ns, used to
+// evaluate the LimitRangeConflict condition. Reuses
+// internal/policy.GetNamespacePolicy — the same LimitRange lookup the
+// older LimitRange/Annotation/Global chain already performs — rather than
+// re-reading LimitRange objects directly.
+func (c *quotaPolicyCycle) limitRangeInfo(ctx context.Context, ns string) quotapolicy.LimitRangeInfo {
+	if lr, ok := c.limitRange[ns]; ok {
+		return lr
+	}
+
+	var lr quotapolicy.LimitRangeInfo
+	if c.client != nil {
+		pol, err := policy.GetNamespacePolicy(ctx, c.client, ns)
+		if err != nil {
+			slog.Warn("Failed to get namespace policy for LimitRangeConflict check", "namespace", ns, "error", err)
+		} else if pol.LimitRangeMax > 0 {
+			lr = quotapolicy.LimitRangeInfo{Present: true, MaxBytes: pol.LimitRangeMax}
+		}
+	}
+	c.limitRange[ns] = lr
+	return lr
+}

--- a/internal/agent/policy_test.go
+++ b/internal/agent/policy_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+	"github.com/dasomel/nfs-quota-agent/internal/quota"
+	"github.com/dasomel/nfs-quota-agent/internal/quotapolicy"
+)
+
+// newFakeQuotaPolicyClient builds a dynamic fake client pre-loaded with
+// policies, usable as the agent's dynamicClient. QuotaPolicy has no
+// registered runtime.Scheme yet (see internal/apis/quota/v1alpha1's package
+// doc comment), so — same as internal/quotapolicy's own list_test.go — the
+// test builds one locally.
+func newFakeQuotaPolicyClient(t *testing.T, policies ...*v1alpha1.QuotaPolicy) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(quotapolicy.GroupVersionResource.GroupVersion().WithKind("QuotaPolicy"), &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(quotapolicy.GroupVersionResource.GroupVersion().WithKind("QuotaPolicyList"), &unstructured.UnstructuredList{})
+	gvrToListKind := map[schema.GroupVersionResource]string{quotapolicy.GroupVersionResource: "QuotaPolicyList"}
+
+	var objs []runtime.Object
+	for _, p := range policies {
+		m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(p)
+		if err != nil {
+			t.Fatalf("ToUnstructured: %v", err)
+		}
+		u := &unstructured.Unstructured{Object: m}
+		u.SetAPIVersion(v1alpha1.GroupName + "/" + v1alpha1.GroupVersion)
+		u.SetKind(v1alpha1.QuotaPolicyKind)
+		objs = append(objs, u)
+	}
+
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objs...)
+}
+
+// gi1MaxPolicy returns a namespace-wide policy in "default" (matching
+// newBoundPV's ClaimRef.Namespace) enforcing a hard 1Gi maximum.
+func gi1MaxPolicy(namespace, name string) *v1alpha1.QuotaPolicy {
+	return &v1alpha1.QuotaPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: v1alpha1.QuotaPolicySpec{
+			MaxQuota:   resource.NewQuantity(1*1024*1024*1024, resource.BinarySI),
+			EnforceMax: true,
+		},
+	}
+}
+
+// quotaPolicyTestFixture wires an agent, a 10Gi bound PV (with its
+// namespace/name-matching PVC, needed for QuotaPolicy label matching), and
+// the local directory ensureQuota expects to already exist.
+func quotaPolicyTestFixture(t *testing.T) (*QuotaAgent, *v1.PersistentVolume) {
+	t.Helper()
+	pv := newBoundPV("pv-1", "/exports/pvc-1", 10) // 10Gi requested
+	pv.Annotations = map[string]string{"pv.kubernetes.io/provisioned-by": "example.com/nfs"}
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pv.Spec.ClaimRef.Namespace,
+			Name:      pv.Spec.ClaimRef.Name,
+		},
+	}
+	client := fake.NewSimpleClientset(pv, pvc)
+
+	a := newTestAgent(t, client)
+	a.nfsServerPath = "/exports"
+	a.fsType = quota.FSTypeXFS
+	a.provisionerName = "example.com/nfs"
+
+	if err := os.MkdirAll(filepath.Join(a.nfsBasePath, "pvc-1"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return a, pv
+}
+
+const tenGiBytes = 10 * 1024 * 1024 * 1024
+const oneGiBytes = 1 * 1024 * 1024 * 1024
+
+// TestSyncAllQuotas_QuotaPolicyDisabled_AppliesCapacityUnchanged is the
+// regression test that matters most for this feature: with
+// quotaPolicyEnabled left at its default (false), a claim that would be
+// clamped hard by a QuotaPolicy object sitting right there in the fake
+// dynamic client must still get exactly its own PV capacity applied — the
+// same behavior as every version of this agent before QuotaPolicy existed.
+// If this ever starts failing, QuotaPolicy has leaked into the enforcement
+// path for users who never opted in.
+func TestSyncAllQuotas_QuotaPolicyDisabled_AppliesCapacityUnchanged(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, _ := quotaPolicyTestFixture(t)
+
+	// Deliberately NOT calling a.SetQuotaPolicyEnabled(true), even though a
+	// policy that would clamp this claim to 1Gi is right there.
+	a.SetDynamicClient(newFakeQuotaPolicyClient(t, gi1MaxPolicy("default", "cap-at-1gi")))
+
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if got := a.appliedQuotas[localPath]; got != tenGiBytes {
+		t.Fatalf("applied quota = %d, want %d (raw PV capacity, unaffected by the disabled feature)", got, tenGiBytes)
+	}
+}
+
+// TestSyncAllQuotas_QuotaPolicyEnabledNoPolicies_AppliesCapacityUnchanged
+// covers the other half of the same regression: the feature flag is ON but
+// no QuotaPolicy object exists (empty dynamic client). This must behave
+// identically to the flag being off — enabling the feature with nothing yet
+// applied must never itself change enforcement.
+func TestSyncAllQuotas_QuotaPolicyEnabledNoPolicies_AppliesCapacityUnchanged(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, _ := quotaPolicyTestFixture(t)
+
+	a.SetQuotaPolicyEnabled(true)
+	a.SetDynamicClient(newFakeQuotaPolicyClient(t)) // no policies at all
+
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if got := a.appliedQuotas[localPath]; got != tenGiBytes {
+		t.Fatalf("applied quota = %d, want %d (raw PV capacity, no policies to apply)", got, tenGiBytes)
+	}
+}
+
+// TestSyncAllQuotas_QuotaPolicyEnabledNilDynamicClient_AppliesCapacityUnchanged
+// covers enabling the flag without ever wiring a dynamic client (an
+// operator error, or a deployment that hasn't been given RBAC yet) — this
+// must degrade the same way, not panic or fail the sync.
+func TestSyncAllQuotas_QuotaPolicyEnabledNilDynamicClient_AppliesCapacityUnchanged(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, _ := quotaPolicyTestFixture(t)
+
+	a.SetQuotaPolicyEnabled(true) // dynamicClient left nil
+
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if got := a.appliedQuotas[localPath]; got != tenGiBytes {
+		t.Fatalf("applied quota = %d, want %d", got, tenGiBytes)
+	}
+}
+
+// TestSyncAllQuotas_QuotaPolicyResolves_ClampsToMax proves the positive
+// path: with the feature enabled and a matching, enforceMax=true policy
+// present, the size actually handed to the filesystem is the
+// QuotaPolicy-resolved bound, not the PV's raw capacity.
+func TestSyncAllQuotas_QuotaPolicyResolves_ClampsToMax(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, _ := quotaPolicyTestFixture(t)
+
+	a.SetQuotaPolicyEnabled(true)
+	a.SetDynamicClient(newFakeQuotaPolicyClient(t, gi1MaxPolicy("default", "cap-at-1gi")))
+
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if got := a.appliedQuotas[localPath]; got != oneGiBytes {
+		t.Fatalf("applied quota = %d, want %d (clamped to the policy's maxQuota)", got, oneGiBytes)
+	}
+}
+
+// TestFinishQuotaPolicyCycle_WritesStatusWhenSingleWriter verifies the
+// status write-back path: with quotaPolicySingleWriter explicitly opted
+// into, after a sync cycle with a matching, successfully-enforced policy,
+// the QuotaPolicy object's status in the dynamic client reflects the match.
+func TestFinishQuotaPolicyCycle_WritesStatusWhenSingleWriter(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, _ := quotaPolicyTestFixture(t)
+
+	a.SetQuotaPolicyEnabled(true)
+	a.SetQuotaPolicySingleWriter(true)
+	p := gi1MaxPolicy("default", "cap-at-1gi")
+	dyn := newFakeQuotaPolicyClient(t, p)
+	a.SetDynamicClient(dyn)
+
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas: %v", err)
+	}
+
+	got, err := dyn.Resource(quotapolicy.GroupVersionResource).Namespace(p.Namespace).Get(context.Background(), p.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get policy after sync: %v", err)
+	}
+	matched, found, err := unstructured.NestedInt64(got.Object, "status", "matchedClaims")
+	if err != nil || !found || matched != 1 {
+		t.Fatalf("matchedClaims: found=%v err=%v value=%d, want 1", found, err, matched)
+	}
+	applied, found, err := unstructured.NestedInt64(got.Object, "status", "appliedClaims")
+	if err != nil || !found || applied != 1 {
+		t.Fatalf("appliedClaims: found=%v err=%v value=%d, want 1", found, err, applied)
+	}
+	conditions, found, err := unstructured.NestedSlice(got.Object, "status", "conditions")
+	if err != nil || !found || len(conditions) == 0 {
+		t.Fatalf("expected non-empty conditions: found=%v err=%v", found, err)
+	}
+}
+
+// TestFinishQuotaPolicyCycle_SkipsStatusByDefault guards the multi-writer
+// fix: with QuotaPolicy enabled but quotaPolicySingleWriter left at its
+// default (false) — the topology this DaemonSet supports out of the box,
+// per values.yaml's nodeSelector comment allowing several NFS server nodes
+// — a sync cycle must enforce the quota (that's unaffected) but must NOT
+// write QuotaPolicy status at all. Publishing a partial per-node view from
+// every replica would flap the object's status every cycle; see
+// finishQuotaPolicyCycle's doc comment and docs/quotapolicy-design.md §11.
+func TestFinishQuotaPolicyCycle_SkipsStatusByDefault(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, _ := quotaPolicyTestFixture(t)
+
+	a.SetQuotaPolicyEnabled(true) // quotaPolicySingleWriter left false (default)
+	p := gi1MaxPolicy("default", "cap-at-1gi")
+	dyn := newFakeQuotaPolicyClient(t, p)
+	a.SetDynamicClient(dyn)
+
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas: %v", err)
+	}
+
+	// Enforcement itself must still have happened (clamped to 1Gi).
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if got := a.appliedQuotas[localPath]; got != oneGiBytes {
+		t.Fatalf("applied quota = %d, want %d — status-write gating must not affect enforcement", got, oneGiBytes)
+	}
+
+	got, err := dyn.Resource(quotapolicy.GroupVersionResource).Namespace(p.Namespace).Get(context.Background(), p.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get policy after sync: %v", err)
+	}
+	// The QuotaPolicy's Status field always round-trips as `status: {}`
+	// (non-pointer structs aren't omitted by encoding/json's omitempty),
+	// so asserting the whole "status" key is absent would be wrong — the
+	// int32/slice fields *inside* it are what actually get omitted when
+	// unset, so their absence is what proves WriteStatus never ran.
+	if _, found, _ := unstructured.NestedInt64(got.Object, "status", "matchedClaims"); found {
+		t.Fatalf("expected status.matchedClaims to be unset without quotaPolicySingleWriter, got %+v", got.Object["status"])
+	}
+	if _, found, _ := unstructured.NestedSlice(got.Object, "status", "conditions"); found {
+		t.Fatalf("expected status.conditions to be unset without quotaPolicySingleWriter, got %+v", got.Object["status"])
+	}
+}

--- a/internal/agent/watch.go
+++ b/internal/agent/watch.go
@@ -26,13 +26,52 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
+const (
+	defaultMinBackoff = 1 * time.Second
+	defaultMaxBackoff = 60 * time.Second
+	// defaultMinHealthyDuration is how long a watch must stay up before a
+	// disconnect is treated as "was working" rather than "never really
+	// connected". See the comment in watchPVsWithBackoff for why this,
+	// rather than "received at least one event", is the reset signal.
+	defaultMinHealthyDuration = 30 * time.Second
+)
+
+// watchBackoffConfig holds the reconnect-backoff timings for watchPVs. Zero
+// fields default to the package constants above (see withDefaults) — this
+// gives production callers a zero-value config while letting tests inject
+// short timings. It is a parameter rather than fields on QuotaAgent because
+// QuotaAgent (agent.go) is off limits for this change; a defaulted-zero
+// config parameter gets the same test seam without touching that struct.
+type watchBackoffConfig struct {
+	minBackoff         time.Duration
+	maxBackoff         time.Duration
+	minHealthyDuration time.Duration
+}
+
+func (c watchBackoffConfig) withDefaults() watchBackoffConfig {
+	if c.minBackoff <= 0 {
+		c.minBackoff = defaultMinBackoff
+	}
+	if c.maxBackoff <= 0 {
+		c.maxBackoff = defaultMaxBackoff
+	}
+	if c.minHealthyDuration <= 0 {
+		c.minHealthyDuration = defaultMinHealthyDuration
+	}
+	return c
+}
+
 // watchPVs watches for PV changes with exponential backoff on reconnect.
 func (a *QuotaAgent) watchPVs(ctx context.Context) {
-	const (
-		minBackoff = 1 * time.Second
-		maxBackoff = 60 * time.Second
-	)
-	backoff := minBackoff
+	a.watchPVsWithBackoff(ctx, watchBackoffConfig{})
+}
+
+// watchPVsWithBackoff is watchPVs with injectable backoff timings, so tests
+// can exercise backoff growth and reset without waiting out real,
+// minute-scale delays.
+func (a *QuotaAgent) watchPVsWithBackoff(ctx context.Context, cfg watchBackoffConfig) {
+	cfg = cfg.withDefaults()
+	backoff := cfg.minBackoff
 
 	for {
 		select {
@@ -49,43 +88,99 @@ func (a *QuotaAgent) watchPVs(ctx context.Context) {
 				return
 			case <-time.After(backoff):
 			}
-			backoff = min(backoff*2, maxBackoff)
+			backoff = min(backoff*2, cfg.maxBackoff)
 			continue
 		}
 
-		// Successful connection — reset backoff
-		backoff = minBackoff
+		// Only trust a connection, and reset the backoff, once it has stayed
+		// up for minHealthyDuration. The old behavior reset on Watch()
+		// merely returning without error, which treats "connects, then dies
+		// instantly" as success — turning a persistent mid-stream failure
+		// (auth revoked, an API server that keeps rejecting the stream) into
+		// an unthrottled reconnect once per minBackoff, forever.
+		//
+		// "Reset after at least one event" was considered and rejected: a
+		// healthy watch against a quiescent cluster (no PV churn) can
+		// legitimately see zero events for a long time, and that watch is
+		// still healthy — it must not be penalized with growing backoff for
+		// having nothing to report.
+		connectedAt := time.Now()
+		healthy := false
+		healthyTimer := time.NewTimer(cfg.minHealthyDuration)
 
-		for event := range watcher.ResultChan() {
-			pv, ok := event.Object.(*v1.PersistentVolume)
-			if !ok {
-				continue
-			}
+	eventLoop:
+		for {
+			select {
+			case <-ctx.Done():
+				healthyTimer.Stop()
+				watcher.Stop()
+				return
+			case <-healthyTimer.C:
+				healthy = true
+				backoff = cfg.minBackoff
+			case event, ok := <-watcher.ResultChan():
+				if !ok {
+					break eventLoop
+				}
 
-			switch event.Type {
-			case watch.Added, watch.Modified:
-				if a.shouldProcessPV(pv) {
-					if err := a.ensureQuota(ctx, pv); err != nil {
-						slog.Error("Failed to ensure quota", "pv", pv.Name, "error", err)
+				if event.Type == watch.Error {
+					// watch.Error events carry a *metav1.Status describing
+					// why the stream is ending, not a PV — the type
+					// assertion below would just drop it silently. Log it
+					// so a persistently rejected stream is diagnosable
+					// instead of showing up only as a 1/s "restarting" log.
+					if status, ok := event.Object.(*metav1.Status); ok {
+						slog.Error("PV watch received error event", "message", status.Message, "reason", status.Reason)
+					} else {
+						slog.Error("PV watch received error event", "object", event.Object)
 					}
+					continue
 				}
-			case watch.Deleted:
-				a.mu.Lock()
-				nfsPath := a.getNFSPath(pv)
-				if nfsPath != "" {
-					localPath := a.nfsPathToLocal(nfsPath)
-					delete(a.appliedQuotas, localPath)
+
+				pv, ok := event.Object.(*v1.PersistentVolume)
+				if !ok {
+					continue
 				}
-				a.mu.Unlock()
-				slog.Debug("PV deleted, quota tracking removed", "pv", pv.Name)
+
+				switch event.Type {
+				case watch.Added, watch.Modified:
+					if a.shouldProcessPV(pv) {
+						// Resolve QuotaPolicy against the last sync cycle's
+						// cached policy set (see resolveFromSnapshot in
+						// policy.go) rather than passing 0 unconditionally:
+						// ensureQuota's own quota-status annotation write
+						// generates a Modified event for the very PV it just
+						// enforced a quota on, and blindly reapplying raw
+						// capacity here would immediately undo a QuotaPolicy
+						// clamp the last sync applied.
+						effectiveBytes := a.resolveFromSnapshot(pv)
+						if err := a.ensureQuota(ctx, pv, effectiveBytes); err != nil {
+							slog.Error("Failed to ensure quota", "pv", pv.Name, "error", err)
+						}
+					}
+				case watch.Deleted:
+					a.mu.Lock()
+					nfsPath := a.getNFSPath(pv)
+					if nfsPath != "" {
+						localPath := a.nfsPathToLocal(nfsPath)
+						delete(a.appliedQuotas, localPath)
+					}
+					a.mu.Unlock()
+					slog.Debug("PV deleted, quota tracking removed", "pv", pv.Name)
+				}
 			}
 		}
+		healthyTimer.Stop()
 
-		slog.Warn("PV watch ended, restarting...", "retryIn", minBackoff)
+		if !healthy {
+			backoff = min(backoff*2, cfg.maxBackoff)
+		}
+
+		slog.Warn("PV watch ended, restarting...", "retryIn", backoff, "connectedFor", time.Since(connectedAt))
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(minBackoff):
+		case <-time.After(backoff):
 		}
 	}
 }

--- a/internal/agent/watch_backoff_test.go
+++ b/internal/agent/watch_backoff_test.go
@@ -1,0 +1,318 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/dasomel/nfs-quota-agent/internal/quota"
+)
+
+// TestWatchPVsBackoffGrowsWhenWatchDiesImmediately proves the fix for the
+// hot-loop defect: a watch that establishes and then ends at once (the
+// mid-stream-failure shape — authorization revoked, an API server
+// persistently rejecting the stream) must not reset to minBackoff on every
+// reconnect. Timings are injected via watchPVsWithBackoff so this asserts on
+// the actual gap between Watch() calls, not just a call count, and finishes
+// in well under a second.
+func TestWatchPVsBackoffGrowsWhenWatchDiesImmediately(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	var mu sync.Mutex
+	var callTimes []time.Time
+	client.PrependWatchReactor("persistentvolumes", func(action ktesting.Action) (bool, watch.Interface, error) {
+		mu.Lock()
+		callTimes = append(callTimes, time.Now())
+		mu.Unlock()
+		w := watch.NewFake()
+		go w.Stop() // establishes fine, then ends immediately
+		return true, w, nil
+	})
+
+	a := newTestAgent(t, client)
+	cfg := watchBackoffConfig{
+		minBackoff:         15 * time.Millisecond,
+		maxBackoff:         200 * time.Millisecond,
+		minHealthyDuration: time.Hour, // never reached: every connection dies instantly
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() { a.watchPVsWithBackoff(ctx, cfg); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("watchPVsWithBackoff did not stop after context deadline")
+	}
+
+	mu.Lock()
+	times := append([]time.Time(nil), callTimes...)
+	mu.Unlock()
+
+	if len(times) < 3 {
+		t.Fatalf("expected at least 3 reconnect attempts to observe growth, got %d", len(times))
+	}
+	// A hot loop reconnecting every minBackoff (15ms) would produce ~30
+	// calls in 500ms. A backing-off loop (15, 30, 60, 120, 200, 200...)
+	// produces far fewer.
+	if len(times) > 12 {
+		t.Errorf("reconnect did not back off: %d Watch() calls in 500ms of continuous immediate failure", len(times))
+	}
+
+	firstGap := times[1].Sub(times[0])
+	lastGap := times[len(times)-1].Sub(times[len(times)-2])
+	if lastGap < firstGap {
+		t.Errorf("expected reconnect delay to grow, first gap=%s last gap=%s", firstGap, lastGap)
+	}
+}
+
+// TestWatchPVsBackoffResetsAfterHealthyConnection proves the other half of
+// the fix: a connection that stays up past minHealthyDuration is treated as
+// healthy, so the *next* reconnect (after it eventually drops) uses
+// minBackoff again rather than continuing to escalate.
+func TestWatchPVsBackoffResetsAfterHealthyConnection(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	var attempt int
+	var mu sync.Mutex
+	var callTimes []time.Time
+	client.PrependWatchReactor("persistentvolumes", func(action ktesting.Action) (bool, watch.Interface, error) {
+		mu.Lock()
+		attempt++
+		n := attempt
+		callTimes = append(callTimes, time.Now())
+		mu.Unlock()
+
+		w := watch.NewFake()
+		if n == 1 {
+			// First connection dies immediately, forcing backoff to grow.
+			go w.Stop()
+		} else {
+			// Second connection stays up past minHealthyDuration, then ends.
+			go func() {
+				time.Sleep(60 * time.Millisecond)
+				w.Stop()
+			}()
+		}
+		return true, w, nil
+	})
+
+	a := newTestAgent(t, client)
+	cfg := watchBackoffConfig{
+		minBackoff:         10 * time.Millisecond,
+		maxBackoff:         500 * time.Millisecond,
+		minHealthyDuration: 30 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() { a.watchPVsWithBackoff(ctx, cfg); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("watchPVsWithBackoff did not stop after context deadline")
+	}
+
+	mu.Lock()
+	times := append([]time.Time(nil), callTimes...)
+	mu.Unlock()
+
+	if len(times) < 3 {
+		t.Fatalf("expected at least 3 connection attempts, got %d", len(times))
+	}
+	// Gap 1->2: after the immediate-death connection, backoff doubled to 20ms.
+	gapAfterFailure := times[1].Sub(times[0])
+	// Gap 2->3: connection 2 stayed healthy for 30ms+ before dropping, so
+	// backoff should have been reset to minBackoff (10ms) rather than
+	// continuing to double toward maxBackoff.
+	gapAfterHealthy := times[2].Sub(times[1])
+
+	// gapAfterHealthy includes the ~30ms the connection stayed up plus the
+	// reset 10ms sleep; gapAfterFailure is just the ~20ms backoff sleep with
+	// no connected time. Compare against the reconnect sleep only by
+	// checking gapAfterHealthy is not escalating past what a reset implies:
+	// it should be well under what continued doubling (40ms+ sleep on top
+	// of the same connected time) would produce.
+	if gapAfterHealthy > gapAfterFailure+cfg.minHealthyDuration+50*time.Millisecond {
+		t.Errorf("backoff did not appear to reset after a healthy connection: gapAfterFailure=%s gapAfterHealthy=%s", gapAfterFailure, gapAfterHealthy)
+	}
+}
+
+// TestWatchPVsLogsWatchErrorEvent proves watch.Error events are surfaced via
+// slog instead of being silently dropped by the *v1.PersistentVolume type
+// assertion (the second defect in the report).
+func TestWatchPVsLogsWatchErrorEvent(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	fw := watch.NewFake()
+	client.PrependWatchReactor("persistentvolumes", func(action ktesting.Action) (bool, watch.Interface, error) {
+		return true, fw, nil
+	})
+
+	a := newTestAgent(t, client)
+	cfg := watchBackoffConfig{
+		minBackoff:         10 * time.Millisecond,
+		maxBackoff:         50 * time.Millisecond,
+		minHealthyDuration: time.Hour,
+	}
+
+	var buf syncBuffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { a.watchPVsWithBackoff(ctx, cfg); close(done) }()
+
+	fw.Error(&metav1.Status{Message: "watch closed by API server", Reason: metav1.StatusReasonExpired})
+
+	waitFor(t, 2*time.Second, func() bool {
+		return strings.Contains(buf.String(), "PV watch received error event")
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, "watch closed by API server") {
+		t.Errorf("expected the Status message in the log, got: %s", out)
+	}
+	if !strings.Contains(out, "level=ERROR") {
+		t.Errorf("expected the error event to be logged at Error level, got: %s", out)
+	}
+
+	cancel()
+	fw.Stop()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("watchPVsWithBackoff did not stop after context cancellation")
+	}
+}
+
+// TestWatchPVsAppliesQuotaOnAddedEventAfterRefactor guards against the
+// backoff/error-handling refactor breaking the happy path: a normal Added
+// event must still reach ensureQuota and get tracked.
+func TestWatchPVsAppliesQuotaOnAddedEventAfterRefactor(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+
+	client := fake.NewSimpleClientset()
+	fw := watch.NewFake()
+	client.PrependWatchReactor("persistentvolumes", func(action ktesting.Action) (bool, watch.Interface, error) {
+		return true, fw, nil
+	})
+
+	a := newTestAgent(t, client)
+	a.nfsServerPath = "/exports"
+	a.fsType = quota.FSTypeXFS
+	a.processAllNFS = true
+
+	localPath := a.nfsPathToLocal("/exports/pvc-refactor")
+	if err := os.MkdirAll(localPath, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	cfg := watchBackoffConfig{minBackoff: 10 * time.Millisecond, maxBackoff: 50 * time.Millisecond, minHealthyDuration: time.Hour}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { a.watchPVsWithBackoff(ctx, cfg); close(done) }()
+
+	fw.Add(newBoundPV("pv-refactor", "/exports/pvc-refactor", 1))
+
+	waitFor(t, 2*time.Second, func() bool {
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		_, ok := a.appliedQuotas[localPath]
+		return ok
+	})
+
+	cancel()
+	fw.Stop()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("watchPVsWithBackoff did not stop after context cancellation")
+	}
+}
+
+// TestWatchPVsReconnectBackoffSleepRespectsContextCancellation proves ctx
+// cancellation short-circuits the post-disconnect backoff sleep (as
+// opposed to the connect-failure backoff sleep, already covered by
+// TestWatchPVsRetriesOnWatchStartError in watch_test.go). minBackoff is set
+// far longer than the test timeout, so a promptly-returning test proves the
+// sleep was interrupted rather than waited out.
+func TestWatchPVsReconnectBackoffSleepRespectsContextCancellation(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependWatchReactor("persistentvolumes", func(action ktesting.Action) (bool, watch.Interface, error) {
+		w := watch.NewFake()
+		go w.Stop() // dies immediately, forcing the post-disconnect backoff sleep
+		return true, w, nil
+	})
+
+	a := newTestAgent(t, client)
+	cfg := watchBackoffConfig{
+		minBackoff:         5 * time.Second, // much longer than the ctx timeout below
+		maxBackoff:         10 * time.Second,
+		minHealthyDuration: time.Hour,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() { a.watchPVsWithBackoff(ctx, cfg); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("watchPVsWithBackoff did not return promptly on context cancellation during the reconnect backoff sleep")
+	}
+}
+
+// syncBuffer is a mutex-guarded bytes.Buffer. slog writes from the watch
+// goroutine and String() reads from the test goroutine race on a bare
+// bytes.Buffer under `go test -race` even though the actual log content is
+// never wrong -- this just makes both sides use the same lock.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}

--- a/internal/agent/zz_f4_watch_regression_test.go
+++ b/internal/agent/zz_f4_watch_regression_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+	"github.com/dasomel/nfs-quota-agent/internal/quotapolicy"
+)
+
+const gib = int64(1024 * 1024 * 1024)
+
+// Guards the interaction between the sync path and the watch path.
+//
+// ensureQuota writes an nfs.io/quota-status annotation onto the PV, which
+// generates a Modified watch event for that same PV. If the watch path
+// applies the PV's raw capacity instead of the QuotaPolicy-resolved bound,
+// the agent overwrites its own clamp moments after making it -- and then
+// the next sync clamps again, so the enforced quota oscillates forever and
+// spends most of each interval UNCLAMPED. That is invisible to any test
+// that exercises syncAllQuotas and the watch loop separately, which is why
+// this one drives them in sequence.
+//
+// This drives the event through the real watchPVsWithBackoff loop (via a
+// watch.FakeWatcher), not by calling resolveFromSnapshot/ensureQuota
+// directly in the test body: an earlier version of this test called those
+// two functions itself to mimic what watch.go's handler does, which meant
+// it kept passing even when watch.go's actual call site was mutated back
+// to the pre-fix hardcoded-0 call -- it was verifying its own inlined copy
+// of the logic, not watch.go. Firing a Modified event at the fake watcher
+// and reading the result back through a.appliedQuotas exercises the real
+// code path.
+func TestWatchEventMustNotUndoTheQuotaPolicyClamp(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+
+	pv := newBoundPV("pv-clamped", "/exports/pvc-clamped", 100) // requests 100Gi
+	client := fake.NewSimpleClientset(pv)
+	a := newTestAgent(t, client)
+
+	localPath := filepath.Join(a.nfsBasePath, "pvc-clamped")
+	if err := os.MkdirAll(localPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A namespace-wide policy clamping every claim in "default" to 5Gi.
+	max := *resourceQuantity(5 * gib)
+	policy := &v1alpha1.QuotaPolicy{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "quota.nfs.io/v1alpha1", Kind: "QuotaPolicy"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "clamp-all", Generation: 1},
+		Spec: v1alpha1.QuotaPolicySpec{
+			Selector:   v1alpha1.QuotaPolicySelector{},
+			Priority:   100,
+			MaxQuota:   &max,
+			EnforceMax: true, // explicit: the Go zero value is false (advisory)
+		},
+	}
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheme := runtime.NewScheme()
+	dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schemaGVR]string{quotapolicy.GroupVersionResource: "QuotaPolicyList"},
+		&unstructured.Unstructured{Object: u})
+
+	a.SetDynamicClient(dc)
+	a.SetQuotaPolicyEnabled(true)
+	a.SetProcessAllNFS(true) // native-NFS PV with no provisioned-by annotation
+	a.fsType = "xfs"
+
+	ctx := context.Background()
+	if err := a.syncAllQuotas(ctx); err != nil {
+		t.Fatalf("syncAllQuotas: %v", err)
+	}
+
+	a.mu.Lock()
+	afterSync := a.appliedQuotas[localPath]
+	a.mu.Unlock()
+	if afterSync != 5*gib {
+		t.Fatalf("after sync, applied = %d, want %d (5Gi clamp); the policy was not applied at all",
+			afterSync, 5*gib)
+	}
+
+	// Drive the watch path for real: a fake watcher wired to the same
+	// client watchPVsWithBackoff calls Watch() on, so the Modified event
+	// below goes through watch.go's actual Added/Modified case, including
+	// its resolveFromSnapshot call -- exactly what ensureQuota's own
+	// annotation write triggers in production.
+	var reconnects int32
+	fw := watch.NewFake()
+	client.PrependWatchReactor("persistentvolumes", func(action ktesting.Action) (bool, watch.Interface, error) {
+		atomic.AddInt32(&reconnects, 1)
+		return true, fw, nil
+	})
+
+	watchCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := watchBackoffConfig{
+		minBackoff:         5 * time.Millisecond,
+		maxBackoff:         20 * time.Millisecond,
+		minHealthyDuration: time.Hour, // irrelevant here; never reconnects on its own
+	}
+	done := make(chan struct{})
+	go func() { a.watchPVsWithBackoff(watchCtx, cfg); close(done) }()
+
+	waitFor(t, time.Second, func() bool { return atomic.LoadInt32(&reconnects) == 1 })
+
+	livePV, err := client.CoreV1().PersistentVolumes().Get(ctx, "pv-clamped", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fw.Modify(livePV)
+	// Stopping the watcher right after Modify closes its ResultChan, which
+	// only unblocks watchPVsWithBackoff's select once it has returned to
+	// the top of the loop -- i.e. once the Modified case above (resolve +
+	// ensureQuota) has fully run. Waiting for the resulting reconnect is
+	// therefore proof the event was completely processed, not a guess at
+	// how long that takes.
+	fw.Stop()
+	waitFor(t, time.Second, func() bool { return atomic.LoadInt32(&reconnects) == 2 })
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("watchPVsWithBackoff did not stop after context cancellation")
+	}
+
+	a.mu.Lock()
+	afterWatch := a.appliedQuotas[localPath]
+	a.mu.Unlock()
+
+	if afterWatch != 5*gib {
+		t.Errorf("after a watch event the applied quota is %d, want %d (5Gi).\n"+
+			"The watch path re-applied the PV's raw capacity and overwrote the "+
+			"QuotaPolicy clamp. Every annotation write triggers this, so the "+
+			"enforced quota oscillates and the policy is effectively unenforced.",
+			afterWatch, 5*gib)
+	}
+}
+
+type schemaGVR = schema.GroupVersionResource
+
+func resourceQuantity(b int64) *resource.Quantity { return resource.NewQuantity(b, resource.BinarySI) }

--- a/internal/agent/zz_f7_applied_lie_test.go
+++ b/internal/agent/zz_f7_applied_lie_test.go
@@ -75,7 +75,7 @@ func TestAppliedMustNotCountClaimsWhoseDirectoryIsMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 	status, _ := got.Object["status"].(map[string]interface{})
-	applied, _ := status["appliedClaims"]
+	applied := status["appliedClaims"]
 	var appliedCond string
 	if conds, ok := status["conditions"].([]interface{}); ok {
 		for _, c := range conds {

--- a/internal/agent/zz_f7_applied_lie_test.go
+++ b/internal/agent/zz_f7_applied_lie_test.go
@@ -1,0 +1,118 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+	"github.com/dasomel/nfs-quota-agent/internal/quotapolicy"
+)
+
+// ensureQuota returns nil (not an error) when the PV's local directory does
+// not exist -- it logs "Directory does not exist, skipping quota" and gives
+// up. recordEnforcement treats a nil error as success, so the claim lands in
+// appliedClaims and Applied reports True.
+//
+// That makes Applied a false statement: its documented meaning is "every
+// claim this policy currently wins for has the quota enforced", and nothing
+// was enforced. This is not only a multi-node concern -- on a single node it
+// fires for any PV whose directory is absent, including every PV backed by a
+// different NFS server's export, which syncAllQuotas still lists because it
+// lists PVs cluster-wide.
+//
+// NOTE: deliberately no directory is created for this PV.
+func TestAppliedMustNotCountClaimsWhoseDirectoryIsMissing(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+
+	pv := newBoundPV("pv-elsewhere", "/exports/pvc-elsewhere", 10)
+	client := fake.NewSimpleClientset(pv)
+	a := newTestAgent(t, client)
+	// No os.MkdirAll here: this PV belongs to another node's export.
+
+	max := *resourceQuantity(5 * gib)
+	policy := &v1alpha1.QuotaPolicy{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "quota.nfs.io/v1alpha1", Kind: "QuotaPolicy"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "p", Generation: 1},
+		Spec: v1alpha1.QuotaPolicySpec{
+			Selector: v1alpha1.QuotaPolicySelector{}, Priority: 100,
+			MaxQuota: &max, EnforceMax: true,
+		},
+	}
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schemaGVR]string{quotapolicy.GroupVersionResource: "QuotaPolicyList"},
+		&unstructured.Unstructured{Object: u})
+
+	a.SetDynamicClient(dc)
+	a.SetQuotaPolicyEnabled(true)
+	a.SetProcessAllNFS(true)
+	// Without this, finishQuotaPolicyCycle no-ops (see its doc comment) and
+	// WriteStatus never runs, so the assertions below would pass vacuously
+	// on the zero-value status this test never wrote -- not because the
+	// fix works. This test is the single-writer node reporting a claim it
+	// resolved a winner for but could not enforce, which is exactly the
+	// case errLocalDirectoryMissing exists to cover.
+	a.SetQuotaPolicySingleWriter(true)
+	a.fsType = "xfs"
+
+	ctx := context.Background()
+	if err := a.syncAllQuotas(ctx); err != nil {
+		t.Fatalf("syncAllQuotas: %v", err)
+	}
+
+	got, err := dc.Resource(quotapolicy.GroupVersionResource).Namespace("default").
+		Get(ctx, "p", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, _ := got.Object["status"].(map[string]interface{})
+	applied, _ := status["appliedClaims"]
+	var appliedCond string
+	if conds, ok := status["conditions"].([]interface{}); ok {
+		for _, c := range conds {
+			m := c.(map[string]interface{})
+			if m["type"] == "Applied" {
+				appliedCond = m["status"].(string)
+			}
+		}
+	}
+
+	a.mu.Lock()
+	_, everApplied := a.appliedQuotas[a.nfsPathToLocal("/exports/pvc-elsewhere")]
+	a.mu.Unlock()
+
+	t.Logf("quota actually applied to the filesystem: %v", everApplied)
+	t.Logf("status.appliedClaims=%v  Applied=%s", applied, appliedCond)
+
+	if everApplied {
+		t.Fatal("test setup wrong: the quota was applied, so there is nothing to catch")
+	}
+	if fmtInt(applied) != 0 {
+		t.Errorf("appliedClaims=%v but no quota was applied to any filesystem; "+
+			"ensureQuota skipped this PV because its directory is absent and returned nil, "+
+			"which recordEnforcement counted as success", applied)
+	}
+	if appliedCond == "True" {
+		t.Errorf("Applied=True while nothing was enforced -- the condition's documented " +
+			"meaning is that every won claim has the quota enforced")
+	}
+}
+
+func fmtInt(v interface{}) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case float64:
+		return int64(n)
+	}
+	return 0
+}

--- a/internal/apis/quota/v1alpha1/types.go
+++ b/internal/apis/quota/v1alpha1/types.go
@@ -207,12 +207,14 @@ type QuotaPolicySpec struct {
 	// Mirrors internal/policy.NamespacePolicy.DefaultQuota /
 	// the nfs.io/default-quota annotation it supersedes.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="quantity(self).compareTo(quantity('0')) >= 0",message="defaultQuota must not be negative"
 	DefaultQuota *resource.Quantity `json:"defaultQuota,omitempty"`
 
 	// maxQuota is the largest filesystem project quota this policy permits
 	// for a matched PVC. Mirrors internal/policy.NamespacePolicy.MaxQuota /
 	// the nfs.io/max-quota annotation it supersedes.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="quantity(self).compareTo(quantity('0')) >= 0",message="maxQuota must not be negative"
 	MaxQuota *resource.Quantity `json:"maxQuota,omitempty"`
 
 	// minQuota is the smallest filesystem project quota this policy permits
@@ -220,6 +222,7 @@ type QuotaPolicySpec struct {
 	// internal/policy.NamespacePolicy.MinQuota is currently populated only
 	// from a LimitRange's PVC min.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="quantity(self).compareTo(quantity('0')) >= 0",message="minQuota must not be negative"
 	MinQuota *resource.Quantity `json:"minQuota,omitempty"`
 
 	// enforceMax controls whether maxQuota is a hard limit (PVCs requesting

--- a/internal/quotapolicy/bound.go
+++ b/internal/quotapolicy/bound.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quotapolicy
+
+import (
+	"fmt"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+)
+
+// BoundOutcome enumerates what EffectiveQuota did to reach its result.
+type BoundOutcome string
+
+const (
+	// BoundUnchanged: the starting value (requested, or defaultQuota when
+	// requested was substituted for it) already satisfied minQuota and
+	// maxQuota, so the returned value equals the starting value.
+	BoundUnchanged BoundOutcome = "Unchanged"
+	// BoundUsedDefault: requested was <= 0, so defaultQuota was used as the
+	// starting point instead of the PV's own capacity.
+	BoundUsedDefault BoundOutcome = "UsedDefault"
+	// BoundRaisedToMin: the starting value was below minQuota and was
+	// raised to meet it.
+	BoundRaisedToMin BoundOutcome = "RaisedToMin"
+	// BoundClampedToMax: enforceMax is true and the value exceeded
+	// maxQuota, so it was clamped down to maxQuota.
+	BoundClampedToMax BoundOutcome = "ClampedToMax"
+	// BoundAdvisoryOverage: enforceMax is false and the value exceeds
+	// maxQuota. The value is left unchanged — maxQuota is advisory only in
+	// this mode — but the overage is recorded here so the caller can
+	// surface it (log line / status), rather than the excess passing
+	// unremarked.
+	BoundAdvisoryOverage BoundOutcome = "AdvisoryOverage"
+)
+
+// BoundDecision explains what EffectiveQuota did and why, for the caller to
+// use in conditions and log messages.
+type BoundDecision struct {
+	Outcome BoundOutcome
+	Detail  string
+}
+
+// EffectiveQuota returns the filesystem quota size (bytes) to enforce for a
+// claim whose winning policy is spec, given the PV's requested capacity in
+// bytes. Semantics, applied in exactly this order:
+//
+//  1. Start from requested. If requested <= 0 and spec.DefaultQuota is set,
+//     start from spec.DefaultQuota instead. (A bound PV should always carry
+//     a positive capacity in practice; this only matters for a
+//     hand-constructed or degenerate claim.)
+//  2. If spec.MinQuota is set and the value is below it, raise to
+//     MinQuota.
+//  3. If spec.MaxQuota is set and spec.EnforceMax is true and the value
+//     exceeds it, clamp to MaxQuota.
+//  4. If spec.MaxQuota is set and spec.EnforceMax is false and the value
+//     exceeds it, leave the value unchanged and report the overage as
+//     advisory via BoundDecision, rather than the caller silently allowing
+//     it unremarked.
+//
+// minQuota is applied before maxQuota so an (admission-time-impossible, but
+// defense-in-depth) minQuota > maxQuota spec still produces a deterministic
+// result (clamped down to maxQuota) instead of depending on evaluation
+// order. In practice the CRD's XValidation rules already reject
+// minQuota > maxQuota, defaultQuota < minQuota, and defaultQuota > maxQuota
+// at admission time, so raising to minQuota can never itself push the value
+// back above maxQuota for a real, admitted QuotaPolicy — the two outcomes
+// (RaisedToMin and ClampedToMax/AdvisoryOverage) are mutually exclusive in
+// practice, and this function reports only the last one it applied.
+func EffectiveQuota(requested int64, spec v1alpha1.QuotaPolicySpec) (int64, BoundDecision) {
+	value := requested
+	decision := BoundDecision{Outcome: BoundUnchanged, Detail: "requested capacity used as-is"}
+
+	if value <= 0 && spec.DefaultQuota != nil {
+		value = spec.DefaultQuota.Value()
+		decision = BoundDecision{
+			Outcome: BoundUsedDefault,
+			Detail:  fmt.Sprintf("requested capacity was %d; used defaultQuota %s", requested, spec.DefaultQuota.String()),
+		}
+	}
+
+	if spec.MinQuota != nil {
+		if min := spec.MinQuota.Value(); value < min {
+			value = min
+			decision = BoundDecision{
+				Outcome: BoundRaisedToMin,
+				Detail:  fmt.Sprintf("raised to minQuota %s", spec.MinQuota.String()),
+			}
+		}
+	}
+
+	if spec.MaxQuota != nil {
+		if max := spec.MaxQuota.Value(); value > max {
+			if spec.EnforceMax {
+				value = max
+				decision = BoundDecision{
+					Outcome: BoundClampedToMax,
+					Detail:  fmt.Sprintf("clamped to maxQuota %s (enforceMax=true)", spec.MaxQuota.String()),
+				}
+			} else {
+				decision = BoundDecision{
+					Outcome: BoundAdvisoryOverage,
+					Detail:  fmt.Sprintf("exceeds maxQuota %s but enforceMax=false; left unchanged (advisory only)", spec.MaxQuota.String()),
+				}
+			}
+		}
+	}
+
+	return value, decision
+}

--- a/internal/quotapolicy/bound_test.go
+++ b/internal/quotapolicy/bound_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quotapolicy
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+)
+
+func gi(n int64) *resource.Quantity {
+	q := resource.NewQuantity(n*1024*1024*1024, resource.BinarySI)
+	return q
+}
+
+// TestEffectiveQuota: every case that sets MaxQuota also sets EnforceMax
+// explicitly (true or false), never relying on the struct literal's Go zero
+// value. This matters because the CRD's +kubebuilder:default=true for
+// enforceMax is an API-server admission-time default (confirmed live: a
+// QuotaPolicy applied with enforceMax omitted comes back as
+// "enforceMax":true) -- a bare Go struct literal that "omits" EnforceMax
+// actually gets false (advisory), the shape the API server never returns
+// for an object that really omitted it. A case meant to exercise clamping
+// that forgot EnforceMax: true would silently test the advisory branch
+// instead while still passing, so every case states its intent explicitly.
+func TestEffectiveQuota(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested int64
+		spec      v1alpha1.QuotaPolicySpec
+		want      int64
+		wantOut   BoundOutcome
+	}{
+		{
+			name:      "unchanged when within bounds",
+			requested: 5 * 1024 * 1024 * 1024,
+			spec:      v1alpha1.QuotaPolicySpec{MinQuota: gi(1), MaxQuota: gi(10), EnforceMax: true},
+			want:      5 * 1024 * 1024 * 1024,
+			wantOut:   BoundUnchanged,
+		},
+		{
+			name:      "no bounds set at all is unchanged",
+			requested: 5 * 1024 * 1024 * 1024,
+			spec:      v1alpha1.QuotaPolicySpec{},
+			want:      5 * 1024 * 1024 * 1024,
+			wantOut:   BoundUnchanged,
+		},
+		{
+			name:      "non-positive requested falls back to defaultQuota",
+			requested: 0,
+			spec:      v1alpha1.QuotaPolicySpec{DefaultQuota: gi(2)},
+			want:      2 * 1024 * 1024 * 1024,
+			wantOut:   BoundUsedDefault,
+		},
+		{
+			name:      "negative requested also falls back to defaultQuota",
+			requested: -1,
+			spec:      v1alpha1.QuotaPolicySpec{DefaultQuota: gi(3)},
+			want:      3 * 1024 * 1024 * 1024,
+			wantOut:   BoundUsedDefault,
+		},
+		{
+			name:      "non-positive requested with no defaultQuota stays as-is",
+			requested: 0,
+			spec:      v1alpha1.QuotaPolicySpec{},
+			want:      0,
+			wantOut:   BoundUnchanged,
+		},
+		{
+			name:      "below minQuota is raised",
+			requested: 1 * 1024 * 1024 * 1024,
+			spec:      v1alpha1.QuotaPolicySpec{MinQuota: gi(5)},
+			want:      5 * 1024 * 1024 * 1024,
+			wantOut:   BoundRaisedToMin,
+		},
+		{
+			name:      "above maxQuota with enforceMax=true is clamped",
+			requested: 20 * 1024 * 1024 * 1024,
+			spec:      v1alpha1.QuotaPolicySpec{MaxQuota: gi(10), EnforceMax: true},
+			want:      10 * 1024 * 1024 * 1024,
+			wantOut:   BoundClampedToMax,
+		},
+		{
+			name:      "above maxQuota with enforceMax=false is left alone but reported",
+			requested: 20 * 1024 * 1024 * 1024,
+			spec:      v1alpha1.QuotaPolicySpec{MaxQuota: gi(10), EnforceMax: false},
+			want:      20 * 1024 * 1024 * 1024,
+			wantOut:   BoundAdvisoryOverage,
+		},
+		{
+			name:      "default then raised to min",
+			requested: 0,
+			spec:      v1alpha1.QuotaPolicySpec{DefaultQuota: gi(1), MinQuota: gi(4)},
+			want:      4 * 1024 * 1024 * 1024,
+			wantOut:   BoundRaisedToMin,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, decision := EffectiveQuota(tt.requested, tt.spec)
+			if got != tt.want {
+				t.Fatalf("EffectiveQuota() = %d, want %d", got, tt.want)
+			}
+			if decision.Outcome != tt.wantOut {
+				t.Fatalf("Outcome = %s, want %s (detail: %s)", decision.Outcome, tt.wantOut, decision.Detail)
+			}
+			if decision.Detail == "" {
+				t.Fatalf("expected a non-empty Detail message")
+			}
+		})
+	}
+}

--- a/internal/quotapolicy/list.go
+++ b/internal/quotapolicy/list.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quotapolicy
+
+// list.go lists and writes back QuotaPolicy objects via the dynamic client,
+// converting to/from the typed v1alpha1.QuotaPolicy with
+// runtime.DefaultUnstructuredConverter. This repo deliberately uses raw
+// client-go with no informers and no generated clientset for this type (see
+// CLAUDE.md and docs/quotapolicy-design.md) — no controller-runtime, no
+// kubebuilder scaffolding.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+)
+
+// GroupVersionResource identifies the QuotaPolicy CRD for the dynamic
+// client. QuotaPolicy is namespace-scoped (docs/quotapolicy-design.md §2),
+// so every call below goes through Namespace(ns) rather than the
+// cluster-scoped resource interface.
+var GroupVersionResource = schema.GroupVersionResource{
+	Group:    v1alpha1.GroupName,
+	Version:  v1alpha1.GroupVersion,
+	Resource: "quotapolicies",
+}
+
+// crdMissingLogOnce makes the "CRD not installed" notice fire once per
+// process rather than once per sync cycle — see List's doc comment.
+var crdMissingLogOnce sync.Once
+
+// List returns every QuotaPolicy across all namespaces.
+//
+// If the CRD is not installed in the cluster, List degrades to "no
+// policies" instead of returning an error: apierrors.IsNotFound and
+// meta.IsNoMatchError both mean the API server has no route for this
+// GroupVersionResource, which is the expected steady state for anyone
+// running with quotaPolicy.enabled=true before (or without ever) applying
+// the CRD. That is logged at Info once per process — not once per sync
+// cycle, which would spam a long-running agent's logs forever — and the
+// caller proceeds exactly as if the list came back empty, never failing
+// the sync cycle over it.
+func List(ctx context.Context, client dynamic.Interface) ([]v1alpha1.QuotaPolicy, error) {
+	list, err := client.Resource(GroupVersionResource).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			crdMissingLogOnce.Do(func() {
+				slog.Info("QuotaPolicy CRD not installed; quota policy enforcement behaves as if no policies exist", "error", err)
+			})
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to list QuotaPolicy objects: %w", err)
+	}
+
+	policies := make([]v1alpha1.QuotaPolicy, 0, len(list.Items))
+	for i := range list.Items {
+		var p v1alpha1.QuotaPolicy
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(list.Items[i].Object, &p); err != nil {
+			slog.Error("Failed to convert QuotaPolicy from unstructured, skipping it this cycle",
+				"namespace", list.Items[i].GetNamespace(), "name", list.Items[i].GetName(), "error", err)
+			continue
+		}
+		policies = append(policies, p)
+	}
+	return policies, nil
+}
+
+// writeStatusMaxAttempts bounds WriteStatus's Get-then-UpdateStatus retry on
+// a resourceVersion conflict. One retry (two attempts total) is enough to
+// win against a single concurrent writer — the CR's own manager patching
+// spec, or (if the caller has confirmed a single-writer topology; see
+// docs/quotapolicy-design.md §11) nothing else, since only one agent
+// writes status at all. It is not a substitute for actual single-writer
+// enforcement: a genuine multi-writer race would just keep colliding, which
+// is exactly why the agent gates WriteStatus behind
+// quotaPolicySingleWriter rather than relying on retries to paper over it.
+const writeStatusMaxAttempts = 2
+
+// WriteStatus writes status back to the cluster for the QuotaPolicy named
+// policy.Namespace/policy.Name, via the status subresource (UpdateStatus).
+// It re-Gets the object immediately before writing so it carries a current
+// resourceVersion — the value on policy may be from an earlier List() this
+// same cycle — and only ever touches the status field, so it can't stomp a
+// concurrent spec edit by whoever manages the CR. On an
+// apierrors.IsConflict (the object changed between the Get and the
+// UpdateStatus — e.g. its owner edited spec, or metadata.generation ticked
+// up mid-write), it re-Gets once and retries rather than failing the whole
+// sync cycle over a benign, common race.
+func WriteStatus(ctx context.Context, client dynamic.Interface, policy *v1alpha1.QuotaPolicy, status v1alpha1.QuotaPolicyStatus) error {
+	res := client.Resource(GroupVersionResource).Namespace(policy.Namespace)
+
+	statusMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&status)
+	if err != nil {
+		return fmt.Errorf("failed to convert QuotaPolicyStatus to unstructured: %w", err)
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < writeStatusMaxAttempts; attempt++ {
+		current, err := res.Get(ctx, policy.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get QuotaPolicy %s/%s for status update: %w", policy.Namespace, policy.Name, err)
+		}
+
+		if err := unstructured.SetNestedMap(current.Object, statusMap, "status"); err != nil {
+			return fmt.Errorf("failed to set status field on QuotaPolicy %s/%s: %w", policy.Namespace, policy.Name, err)
+		}
+
+		_, err = res.UpdateStatus(ctx, current, metav1.UpdateOptions{})
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
+			return fmt.Errorf("failed to update status for QuotaPolicy %s/%s: %w", policy.Namespace, policy.Name, err)
+		}
+		lastErr = err
+	}
+	return fmt.Errorf("failed to update status for QuotaPolicy %s/%s after %d attempts (resourceVersion conflict): %w",
+		policy.Namespace, policy.Name, writeStatusMaxAttempts, lastErr)
+}

--- a/internal/quotapolicy/list_test.go
+++ b/internal/quotapolicy/list_test.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quotapolicy
+
+import (
+	"context"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+)
+
+// newFakeDynamicClient builds a dynamic fake client that knows how to list
+// QuotaPolicy/QuotaPolicyList, pre-loaded with objects. QuotaPolicy does not
+// register a runtime.Scheme of its own yet (see the package doc comment in
+// internal/apis/quota/v1alpha1/types.go), so tests build one locally, same
+// as any other dynamic-client consumer of an unregistered CRD type.
+func newFakeDynamicClient(t *testing.T, objects ...*v1alpha1.QuotaPolicy) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(GroupVersionResource.GroupVersion().WithKind("QuotaPolicy"), &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(GroupVersionResource.GroupVersion().WithKind("QuotaPolicyList"), &unstructured.UnstructuredList{})
+
+	gvrToListKind := map[schema.GroupVersionResource]string{GroupVersionResource: "QuotaPolicyList"}
+
+	var runtimeObjs []runtime.Object
+	for _, o := range objects {
+		runtimeObjs = append(runtimeObjs, toUnstructured(t, o))
+	}
+
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, runtimeObjs...)
+}
+
+func toUnstructured(t *testing.T, p *v1alpha1.QuotaPolicy) *unstructured.Unstructured {
+	t.Helper()
+	m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(p)
+	if err != nil {
+		t.Fatalf("ToUnstructured: %v", err)
+	}
+	u := &unstructured.Unstructured{Object: m}
+	u.SetAPIVersion(v1alpha1.GroupName + "/" + v1alpha1.GroupVersion)
+	u.SetKind(v1alpha1.QuotaPolicyKind)
+	return u
+}
+
+func TestList_ReturnsConvertedPolicies(t *testing.T) {
+	p1 := namedPolicy("ns-a", "one", 100, v1alpha1.QuotaPolicySelector{})
+	p2 := namedPolicy("ns-b", "two", 50, pvcNameSelector("some-pvc"))
+	client := newFakeDynamicClient(t, &p1, &p2)
+
+	policies, err := List(context.Background(), client)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(policies) != 2 {
+		t.Fatalf("expected 2 policies, got %d: %+v", len(policies), policies)
+	}
+
+	byName := map[string]v1alpha1.QuotaPolicy{}
+	for _, p := range policies {
+		byName[p.Name] = p
+	}
+	if byName["one"].Namespace != "ns-a" || byName["one"].Spec.Priority != 100 {
+		t.Fatalf("policy 'one' round-tripped incorrectly: %+v", byName["one"])
+	}
+	if byName["two"].Namespace != "ns-b" || byName["two"].Spec.Selector.PVCName == nil || *byName["two"].Spec.Selector.PVCName != "some-pvc" {
+		t.Fatalf("policy 'two' round-tripped incorrectly: %+v", byName["two"])
+	}
+}
+
+// TestList_QuantityRoundTrip proves resource.Quantity values survive the
+// path this package actually uses in production: Go struct -> unstructured
+// (ToUnstructured, done by newFakeDynamicClient the same way the real
+// dynamic client's List response would arrive) -> back to a typed
+// v1alpha1.QuotaPolicy via List's FromUnstructured. A test built only from
+// typed structs never exercises this conversion at all and would not catch
+// a regression here — e.g. a naive implementation that round-tripped
+// Quantity through its int64 millivalue would silently lose the original
+// suffix/precision even when .Value() still compared equal.
+func TestList_QuantityRoundTrip(t *testing.T) {
+	// Same set verified directly against a live Kubernetes 1.35 cluster:
+	// .Value() and .String() are both preserved for each of these.
+	quantities := []string{"1Gi", "10Gi", "9Gi", "1000Mi", "500M", "1536Mi", "0"}
+
+	for _, qs := range quantities {
+		t.Run(qs, func(t *testing.T) {
+			q := resource.MustParse(qs)
+			p := namedPolicy("ns-a", "p", 100, v1alpha1.QuotaPolicySelector{})
+			p.Spec.MaxQuota = &q
+
+			client := newFakeDynamicClient(t, &p)
+			policies, err := List(context.Background(), client)
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if len(policies) != 1 || policies[0].Spec.MaxQuota == nil {
+				t.Fatalf("expected exactly one policy with MaxQuota set, got %+v", policies)
+			}
+
+			got := policies[0].Spec.MaxQuota
+			if got.Value() != q.Value() {
+				t.Fatalf("Value() = %d, want %d", got.Value(), q.Value())
+			}
+			if got.String() != q.String() {
+				t.Fatalf("String() = %q, want %q", got.String(), q.String())
+			}
+		})
+	}
+}
+
+func TestList_EmptyWhenNoPolicies(t *testing.T) {
+	client := newFakeDynamicClient(t)
+	policies, err := List(context.Background(), client)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(policies) != 0 {
+		t.Fatalf("expected no policies, got %+v", policies)
+	}
+}
+
+// TestList_CRDNotInstalled_NotFound covers the degrade path: the API server
+// has no route for quotapolicies (CRD never applied), which client-go
+// surfaces as a NotFound error on the list call. List must return an empty
+// slice and no error -- never fail the sync cycle over a missing CRD.
+func TestList_CRDNotInstalled_NotFound(t *testing.T) {
+	client := newFakeDynamicClient(t)
+	client.PrependReactor("list", "quotapolicies", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{Group: v1alpha1.GroupName, Resource: "quotapolicies"}, "")
+	})
+
+	policies, err := List(context.Background(), client)
+	if err != nil {
+		t.Fatalf("expected no error for a missing CRD, got %v", err)
+	}
+	if policies != nil {
+		t.Fatalf("expected nil policies for a missing CRD, got %+v", policies)
+	}
+}
+
+// TestList_CRDNotInstalled_NoMatch covers the other shape a missing CRD can
+// take: the RESTMapper has no route at all (meta.IsNoMatchError), which
+// must degrade identically to the NotFound case.
+func TestList_CRDNotInstalled_NoMatch(t *testing.T) {
+	client := newFakeDynamicClient(t)
+	client.PrependReactor("list", "quotapolicies", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, &meta.NoResourceMatchError{PartialResource: GroupVersionResource}
+	})
+
+	policies, err := List(context.Background(), client)
+	if err != nil {
+		t.Fatalf("expected no error for a NoMatch error, got %v", err)
+	}
+	if policies != nil {
+		t.Fatalf("expected nil policies, got %+v", policies)
+	}
+}
+
+func TestList_OtherErrorPropagates(t *testing.T) {
+	client := newFakeDynamicClient(t)
+	client.PrependReactor("list", "quotapolicies", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errString("boom"))
+	})
+
+	_, err := List(context.Background(), client)
+	if err == nil {
+		t.Fatalf("expected a non-nil error to propagate")
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+func TestWriteStatus_RoundTrips(t *testing.T) {
+	p := namedPolicy("ns-a", "one", 100, v1alpha1.QuotaPolicySelector{})
+	p.Generation = 3
+	client := newFakeDynamicClient(t, &p)
+
+	status := v1alpha1.QuotaPolicyStatus{
+		ObservedGeneration: 3,
+		MatchedClaims:      2,
+		AppliedClaims:      1,
+		ShadowedClaims:     1,
+		Conditions: []metav1.Condition{
+			{Type: v1alpha1.ConditionReady, Status: metav1.ConditionTrue, Reason: v1alpha1.ReasonSelectorValid, Message: "ok", LastTransitionTime: metav1.Now()},
+		},
+	}
+
+	if err := WriteStatus(context.Background(), client, &p, status); err != nil {
+		t.Fatalf("WriteStatus: %v", err)
+	}
+
+	got, err := client.Resource(GroupVersionResource).Namespace("ns-a").Get(context.Background(), "one", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get after WriteStatus: %v", err)
+	}
+	matched, found, err := unstructured.NestedInt64(got.Object, "status", "matchedClaims")
+	if err != nil || !found {
+		t.Fatalf("matchedClaims not found in written status: found=%v err=%v obj=%+v", found, err, got.Object)
+	}
+	if matched != 2 {
+		t.Fatalf("matchedClaims = %d, want 2", matched)
+	}
+}
+
+// TestWriteStatus_RetriesOnConflict proves WriteStatus survives a single
+// resourceVersion conflict (e.g. the CR's owner edited spec between our Get
+// and UpdateStatus) by re-Getting and retrying once, rather than failing
+// the whole sync cycle over a benign, common race.
+func TestWriteStatus_RetriesOnConflict(t *testing.T) {
+	p := namedPolicy("ns-a", "one", 100, v1alpha1.QuotaPolicySelector{})
+	client := newFakeDynamicClient(t, &p)
+
+	var updateStatusCalls int
+	client.PrependReactor("update", "quotapolicies", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "status" {
+			return false, nil, nil // not our concern; let the default reactor handle it
+		}
+		updateStatusCalls++
+		if updateStatusCalls == 1 {
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Group: v1alpha1.GroupName, Resource: "quotapolicies"}, "one", errString("simulated conflicting write"))
+		}
+		return false, nil, nil // second attempt: let the default reactor actually apply it
+	})
+
+	status := v1alpha1.QuotaPolicyStatus{MatchedClaims: 5}
+	if err := WriteStatus(context.Background(), client, &p, status); err != nil {
+		t.Fatalf("WriteStatus: %v", err)
+	}
+	if updateStatusCalls != 2 {
+		t.Fatalf("expected exactly 2 UpdateStatus attempts (1 conflict + 1 retry), got %d", updateStatusCalls)
+	}
+
+	got, err := client.Resource(GroupVersionResource).Namespace("ns-a").Get(context.Background(), "one", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get after WriteStatus: %v", err)
+	}
+	matched, found, err := unstructured.NestedInt64(got.Object, "status", "matchedClaims")
+	if err != nil || !found || matched != 5 {
+		t.Fatalf("matchedClaims after retry: found=%v err=%v value=%d, want 5", found, err, matched)
+	}
+}
+
+// TestWriteStatus_ConflictExhaustsRetriesReturnsError proves a persistent
+// conflict (every attempt collides) surfaces as an error rather than
+// silently dropping the status update.
+func TestWriteStatus_ConflictExhaustsRetriesReturnsError(t *testing.T) {
+	p := namedPolicy("ns-a", "one", 100, v1alpha1.QuotaPolicySelector{})
+	client := newFakeDynamicClient(t, &p)
+
+	client.PrependReactor("update", "quotapolicies", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "status" {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewConflict(
+			schema.GroupResource{Group: v1alpha1.GroupName, Resource: "quotapolicies"}, "one", errString("simulated conflicting write"))
+	})
+
+	err := WriteStatus(context.Background(), client, &p, v1alpha1.QuotaPolicyStatus{MatchedClaims: 5})
+	if err == nil {
+		t.Fatalf("expected an error when every UpdateStatus attempt conflicts")
+	}
+}

--- a/internal/quotapolicy/resolve.go
+++ b/internal/quotapolicy/resolve.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package quotapolicy resolves which QuotaPolicy object, if any, governs a
+// given PersistentVolumeClaim, and computes the filesystem quota bound to
+// enforce for it. resolve.go and bound.go are pure — no I/O, no Kubernetes
+// client — so the precedence and bounding rules are testable with plain
+// structs; list.go and status.go are the only files in this package that
+// talk to the cluster. See docs/quotapolicy-design.md for the full design.
+package quotapolicy
+
+import (
+	"fmt"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+)
+
+// Claim is the minimal shape of a PersistentVolumeClaim needed to resolve
+// policy — decoupled from corev1.PersistentVolumeClaim so this package
+// never needs a Kubernetes client type to be tested.
+type Claim struct {
+	Namespace string
+	Name      string
+	Labels    map[string]string
+}
+
+// Shadowed records a QuotaPolicy that matched a claim but lost precedence
+// to the Resolution's Winner.
+type Shadowed struct {
+	Policy    *v1alpha1.QuotaPolicy
+	MatchKind v1alpha1.MatchKind
+	// Reason is a human-readable note on which rule decided this policy
+	// lost: specificity, priority, or name (see docs/quotapolicy-design.md
+	// §4). It is prose for logs/status messages, not one of the fixed
+	// Reason* condition constants.
+	Reason string
+}
+
+// InvalidSelector records a candidate QuotaPolicy (from the namespace being
+// resolved) whose labelSelector could not be converted to a usable
+// selector. An invalid selector never matches any claim — it is excluded
+// from both Winner and Losers entirely, not merely deprioritized — but the
+// caller still needs to know it was skipped so it can set that policy's own
+// Ready=False/SelectorInvalid condition rather than silently treating it as
+// "matches nothing".
+type InvalidSelector struct {
+	Policy *v1alpha1.QuotaPolicy
+	Err    error
+}
+
+// Resolution is the outcome of resolving one claim against a set of
+// QuotaPolicy objects.
+type Resolution struct {
+	// Winner is the QuotaPolicy this claim resolves to, or nil when none of
+	// the supplied policies match.
+	Winner *v1alpha1.QuotaPolicy
+	// MatchKind is meaningful only when Winner != nil.
+	MatchKind v1alpha1.MatchKind
+	// Losers is every other matching policy, ordered most-specific-first,
+	// with why each one lost to Winner.
+	Losers []Shadowed
+	// Invalid lists every policy considered (i.e. in claim.Namespace)
+	// whose selector failed to evaluate. Populated the same way regardless
+	// of claim, since selector validity is a property of the policy, not
+	// of the claim being resolved against it — see ValidateSelector for
+	// the standalone, claim-independent check the status writer uses to
+	// build a policy's Ready condition even when it matches zero claims.
+	Invalid []InvalidSelector
+}
+
+// candidate pairs a matching policy with the MatchKind it earned against
+// the claim being resolved, used internally to sort by precedence.
+type candidate struct {
+	policy    *v1alpha1.QuotaPolicy
+	matchKind v1alpha1.MatchKind
+}
+
+// Resolve determines which of policies (if any) governs claim, applying the
+// precedence rules from docs/quotapolicy-design.md §4 in order:
+//
+//  1. Specificity: PVCName > LabelSelector > NamespaceWide.
+//  2. Tie -> lowest spec.priority wins. 0 is the strongest priority. This
+//     compares Priority exactly as it is on the struct — the CRD's
+//     +kubebuilder:default=100 is an API-server admission-time default, not
+//     a Go zero-value default, so a QuotaPolicy built as a bare struct
+//     literal (as every test here does) legitimately carries Priority == 0.
+//     That value is not re-defaulted to 100 here: 0 already sorts as the
+//     strongest priority, and re-applying the CRD default in Go would
+//     silently disagree with an admitted object that explicitly set
+//     priority: 0.
+//  3. Still tied -> lexicographically smallest metadata.name wins.
+//
+// Only policies whose Namespace equals claim.Namespace are eligible, since
+// QuotaPolicy is namespace-scoped (docs/quotapolicy-design.md §2). Resolve
+// never calls the Kubernetes API; policies must already be fetched (see
+// List in list.go).
+func Resolve(claim Claim, policies []v1alpha1.QuotaPolicy) Resolution {
+	var res Resolution
+	var candidates []candidate
+
+	for i := range policies {
+		p := &policies[i]
+		if p.Namespace != claim.Namespace {
+			continue
+		}
+
+		kind, matches, err := matchSelector(p.Spec.Selector, claim)
+		if err != nil {
+			res.Invalid = append(res.Invalid, InvalidSelector{Policy: p, Err: err})
+			continue
+		}
+		if !matches {
+			continue
+		}
+		candidates = append(candidates, candidate{policy: p, matchKind: kind})
+	}
+
+	if len(candidates) == 0 {
+		return res
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return wins(candidates[i], candidates[j])
+	})
+
+	res.Winner = candidates[0].policy
+	res.MatchKind = candidates[0].matchKind
+
+	for _, c := range candidates[1:] {
+		res.Losers = append(res.Losers, Shadowed{
+			Policy:    c.policy,
+			MatchKind: c.matchKind,
+			Reason:    reasonLostTo(candidates[0], c),
+		})
+	}
+
+	return res
+}
+
+// specificityRank orders MatchKind from most (0) to least (2) specific.
+func specificityRank(k v1alpha1.MatchKind) int {
+	switch k {
+	case v1alpha1.MatchKindPVCName:
+		return 0
+	case v1alpha1.MatchKindLabelSelector:
+		return 1
+	default: // v1alpha1.MatchKindNamespaceWide
+		return 2
+	}
+}
+
+// wins reports whether a outranks (beats) b under the three-step tie-break.
+func wins(a, b candidate) bool {
+	if ra, rb := specificityRank(a.matchKind), specificityRank(b.matchKind); ra != rb {
+		return ra < rb
+	}
+	if a.policy.Spec.Priority != b.policy.Spec.Priority {
+		return a.policy.Spec.Priority < b.policy.Spec.Priority // lower wins
+	}
+	return a.policy.Name < b.policy.Name
+}
+
+// reasonLostTo names, for Shadowed.Reason, which rule decided winner beat
+// loser.
+func reasonLostTo(winner, loser candidate) string {
+	if specificityRank(winner.matchKind) != specificityRank(loser.matchKind) {
+		return fmt.Sprintf("specificity: %s outranks %s", winner.matchKind, loser.matchKind)
+	}
+	if winner.policy.Spec.Priority != loser.policy.Spec.Priority {
+		return fmt.Sprintf("priority: %d beats %d (lower wins)", winner.policy.Spec.Priority, loser.policy.Spec.Priority)
+	}
+	return fmt.Sprintf("name: %q sorts before %q", winner.policy.Name, loser.policy.Name)
+}
+
+// ValidateSelector checks a QuotaPolicySelector's shape independent of any
+// specific claim, so the status writer can set a policy's Ready condition
+// even when it currently matches zero claims (Resolve is never invoked for
+// a namespace with no bound PVs). Today the only failure mode is a
+// LabelSelector that doesn't convert to a usable label selector; PVCName
+// has no comparable failure (length is already bounded by the CRD's
+// MinLength/MaxLength), and PVCName/LabelSelector mutual exclusivity is
+// enforced by the CRD's own XValidation rule, so it isn't re-checked here.
+func ValidateSelector(sel v1alpha1.QuotaPolicySelector) error {
+	if sel.LabelSelector == nil {
+		return nil
+	}
+	if _, err := metav1.LabelSelectorAsSelector(sel.LabelSelector); err != nil {
+		return fmt.Errorf("invalid labelSelector: %w", err)
+	}
+	return nil
+}
+
+// matchSelector reports whether sel matches claim, and which MatchKind it
+// earned. An error means the selector could not be evaluated at all —
+// callers must treat that as "does not match" and separately report it
+// (see InvalidSelector), not silently drop the policy as a non-match.
+func matchSelector(sel v1alpha1.QuotaPolicySelector, claim Claim) (v1alpha1.MatchKind, bool, error) {
+	if sel.PVCName != nil {
+		if *sel.PVCName == claim.Name {
+			return v1alpha1.MatchKindPVCName, true, nil
+		}
+		return "", false, nil
+	}
+	if sel.LabelSelector != nil {
+		selector, err := metav1.LabelSelectorAsSelector(sel.LabelSelector)
+		if err != nil {
+			return "", false, fmt.Errorf("invalid labelSelector: %w", err)
+		}
+		if selector.Matches(labels.Set(claim.Labels)) {
+			return v1alpha1.MatchKindLabelSelector, true, nil
+		}
+		return "", false, nil
+	}
+	// Namespace-wide: both unset, matches every claim in the namespace —
+	// the caller already filtered by namespace above.
+	return v1alpha1.MatchKindNamespaceWide, true, nil
+}

--- a/internal/quotapolicy/resolve_test.go
+++ b/internal/quotapolicy/resolve_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quotapolicy
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+)
+
+// namedPolicy requires priority as an explicit positional argument rather
+// than leaving it to a QuotaPolicySpec struct literal's default, on
+// purpose: the CRD's +kubebuilder:default=100 is an API-server admission
+// time default (confirmed live: `kubectl apply` with priority omitted comes
+// back as priority: 100), not a Go zero-value default -- a bare Go struct
+// literal that "omits" Priority actually gets 0, the *strongest* priority,
+// which is a shape the API server never returns for an object that really
+// omitted it. Forcing every call site to pass a real number here makes that
+// distinction impossible to get wrong by accident: a test that means
+// "matches the CRD default" must write 100, not leave the field unset.
+func namedPolicy(ns, name string, priority int32, sel v1alpha1.QuotaPolicySelector) v1alpha1.QuotaPolicy {
+	return v1alpha1.QuotaPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec: v1alpha1.QuotaPolicySpec{
+			Selector: sel,
+			Priority: priority,
+		},
+	}
+}
+
+func pvcNameSelector(name string) v1alpha1.QuotaPolicySelector {
+	return v1alpha1.QuotaPolicySelector{PVCName: &name}
+}
+
+func labelSelector(labels map[string]string) v1alpha1.QuotaPolicySelector {
+	return v1alpha1.QuotaPolicySelector{LabelSelector: &metav1.LabelSelector{MatchLabels: labels}}
+}
+
+func TestResolve_NoPolicies(t *testing.T) {
+	res := Resolve(Claim{Namespace: "ns", Name: "pvc"}, nil)
+	if res.Winner != nil {
+		t.Fatalf("expected no winner, got %+v", res.Winner)
+	}
+	if len(res.Losers) != 0 || len(res.Invalid) != 0 {
+		t.Fatalf("expected empty losers/invalid, got %+v", res)
+	}
+}
+
+func TestResolve_SpecificityRanking(t *testing.T) {
+	claim := Claim{Namespace: "ns", Name: "my-pvc", Labels: map[string]string{"tier": "gold"}}
+
+	tests := []struct {
+		name       string
+		policies   []v1alpha1.QuotaPolicy
+		wantWinner string
+		wantKind   v1alpha1.MatchKind
+	}{
+		{
+			name: "pvcName beats labelSelector and namespace-wide",
+			policies: []v1alpha1.QuotaPolicy{
+				namedPolicy("ns", "nswide", 100, v1alpha1.QuotaPolicySelector{}),
+				namedPolicy("ns", "bylabel", 100, labelSelector(map[string]string{"tier": "gold"})),
+				namedPolicy("ns", "byname", 100, pvcNameSelector("my-pvc")),
+			},
+			wantWinner: "byname",
+			wantKind:   v1alpha1.MatchKindPVCName,
+		},
+		{
+			name: "labelSelector beats namespace-wide when pvcName absent",
+			policies: []v1alpha1.QuotaPolicy{
+				namedPolicy("ns", "nswide", 100, v1alpha1.QuotaPolicySelector{}),
+				namedPolicy("ns", "bylabel", 100, labelSelector(map[string]string{"tier": "gold"})),
+			},
+			wantWinner: "bylabel",
+			wantKind:   v1alpha1.MatchKindLabelSelector,
+		},
+		{
+			name: "namespace-wide wins when it's the only match",
+			policies: []v1alpha1.QuotaPolicy{
+				namedPolicy("ns", "nswide", 100, v1alpha1.QuotaPolicySelector{}),
+			},
+			wantWinner: "nswide",
+			wantKind:   v1alpha1.MatchKindNamespaceWide,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := Resolve(claim, tt.policies)
+			if res.Winner == nil {
+				t.Fatalf("expected a winner, got none")
+			}
+			if res.Winner.Name != tt.wantWinner {
+				t.Fatalf("winner = %q, want %q", res.Winner.Name, tt.wantWinner)
+			}
+			if res.MatchKind != tt.wantKind {
+				t.Fatalf("matchKind = %s, want %s", res.MatchKind, tt.wantKind)
+			}
+			if len(res.Losers) != len(tt.policies)-1 {
+				t.Fatalf("losers = %d, want %d", len(res.Losers), len(tt.policies)-1)
+			}
+		})
+	}
+}
+
+// TestResolve_PriorityTieBreak_LowerWins is the case that would pass if the
+// priority comparison were backwards: two policies tie on specificity
+// (both namespace-wide), and the one with the numerically lower priority
+// must win, per docs/quotapolicy-design.md §4 ("0 is the strongest
+// priority, not higher-number-wins").
+func TestResolve_PriorityTieBreak_LowerWins(t *testing.T) {
+	claim := Claim{Namespace: "ns", Name: "pvc"}
+	policies := []v1alpha1.QuotaPolicy{
+		namedPolicy("ns", "weak", 200, v1alpha1.QuotaPolicySelector{}),
+		namedPolicy("ns", "strong", 10, v1alpha1.QuotaPolicySelector{}),
+	}
+
+	res := Resolve(claim, policies)
+	if res.Winner == nil || res.Winner.Name != "strong" {
+		t.Fatalf("expected 'strong' (priority 10) to win over 'weak' (priority 200), got %+v", res.Winner)
+	}
+	if len(res.Losers) != 1 || res.Losers[0].Policy.Name != "weak" {
+		t.Fatalf("expected 'weak' to be the sole loser, got %+v", res.Losers)
+	}
+}
+
+func TestResolve_NameTieBreak(t *testing.T) {
+	claim := Claim{Namespace: "ns", Name: "pvc"}
+	policies := []v1alpha1.QuotaPolicy{
+		namedPolicy("ns", "zzz", 100, v1alpha1.QuotaPolicySelector{}),
+		namedPolicy("ns", "aaa", 100, v1alpha1.QuotaPolicySelector{}),
+		namedPolicy("ns", "mmm", 100, v1alpha1.QuotaPolicySelector{}),
+	}
+
+	res := Resolve(claim, policies)
+	if res.Winner == nil || res.Winner.Name != "aaa" {
+		t.Fatalf("expected lexicographically smallest name 'aaa' to win, got %+v", res.Winner)
+	}
+}
+
+func TestResolve_InvalidLabelSelector(t *testing.T) {
+	claim := Claim{Namespace: "ns", Name: "pvc", Labels: map[string]string{"tier": "gold"}}
+	bad := namedPolicy("ns", "bad", 100, v1alpha1.QuotaPolicySelector{
+		LabelSelector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "tier", Operator: "NotARealOperator", Values: []string{"gold"}},
+			},
+		},
+	})
+	good := namedPolicy("ns", "good", 100, v1alpha1.QuotaPolicySelector{})
+
+	res := Resolve(claim, []v1alpha1.QuotaPolicy{bad, good})
+
+	if res.Winner == nil || res.Winner.Name != "good" {
+		t.Fatalf("expected the valid namespace-wide policy to win despite the invalid one, got %+v", res.Winner)
+	}
+	if len(res.Invalid) != 1 || res.Invalid[0].Policy.Name != "bad" {
+		t.Fatalf("expected 'bad' reported as invalid, got %+v", res.Invalid)
+	}
+	if res.Invalid[0].Err == nil {
+		t.Fatalf("expected a non-nil error explaining the invalid selector")
+	}
+	for _, l := range res.Losers {
+		if l.Policy.Name == "bad" {
+			t.Fatalf("invalid-selector policy must not appear as a loser (it never matched at all): %+v", res.Losers)
+		}
+	}
+}
+
+func TestResolve_OtherNamespaceNotMatched(t *testing.T) {
+	claim := Claim{Namespace: "ns-a", Name: "pvc"}
+	policies := []v1alpha1.QuotaPolicy{
+		namedPolicy("ns-b", "other-ns", 0, v1alpha1.QuotaPolicySelector{}),
+	}
+
+	res := Resolve(claim, policies)
+	if res.Winner != nil {
+		t.Fatalf("expected no winner across namespaces, got %+v", res.Winner)
+	}
+	if len(res.Invalid) != 0 {
+		t.Fatalf("policy from another namespace should not even be selector-checked, got %+v", res.Invalid)
+	}
+}
+
+func TestValidateSelector(t *testing.T) {
+	if err := ValidateSelector(v1alpha1.QuotaPolicySelector{}); err != nil {
+		t.Fatalf("namespace-wide selector should be valid: %v", err)
+	}
+	name := "pvc"
+	if err := ValidateSelector(v1alpha1.QuotaPolicySelector{PVCName: &name}); err != nil {
+		t.Fatalf("pvcName selector should be valid: %v", err)
+	}
+	if err := ValidateSelector(labelSelector(map[string]string{"tier": "gold"})); err != nil {
+		t.Fatalf("well-formed labelSelector should be valid: %v", err)
+	}
+
+	bad := v1alpha1.QuotaPolicySelector{
+		LabelSelector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "tier", Operator: "NotARealOperator"},
+			},
+		},
+	}
+	if err := ValidateSelector(bad); err == nil {
+		t.Fatalf("expected an error for a malformed labelSelector")
+	}
+}

--- a/internal/quotapolicy/status.go
+++ b/internal/quotapolicy/status.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quotapolicy
+
+// status.go builds a fresh QuotaPolicyStatus from one sync cycle's
+// resolution/enforcement results. BuildStatus itself is pure — no I/O — so
+// it's testable without a fake dynamic client; WriteStatus in list.go is
+// what actually persists the result.
+
+import (
+	"sort"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+)
+
+// maxStatusSampleEntries bounds FailingClaims and MatchedClaimSample to
+// match the CRD's own +kubebuilder:validation:MaxItems=20
+// (charts/nfs-quota-agent/crds/quota.nfs.io_quotapolicies.yaml) — exceeding
+// it makes the status subresource update fail server-side, so the cap is
+// enforced here too rather than relying on the API server to reject an
+// oversized write after Go has already built it.
+const maxStatusSampleEntries = 20
+
+// ClaimOutcome is one claim's resolution (and, if it won, enforcement)
+// result — the unit BuildStatus aggregates into counts and bounded samples
+// for one policy. The caller (internal/agent) builds one of these per claim
+// per policy it participated in (as winner or as a shadowed loser).
+type ClaimOutcome struct {
+	Claim      Claim
+	MatchKind  v1alpha1.MatchKind
+	Won        bool
+	ResolvedBy string // name of the policy that won instead, when !Won
+
+	// EnforcementErr, when non-nil, means Won was true but applying the
+	// quota to the filesystem failed. Ignored when !Won.
+	EnforcementErr error
+	// EnforcementReason is a Reason* constant describing EnforcementErr
+	// (e.g. ReasonEnforcementFailed, ReasonFilesystemUnavailable,
+	// ReasonProjectIDExhausted). Ignored when EnforcementErr is nil.
+	EnforcementReason string
+}
+
+// LimitRangeInfo carries just what BuildStatus needs from
+// internal/policy.GetNamespacePolicy to evaluate the LimitRangeConflict
+// condition, so this package doesn't need to import internal/policy's full
+// NamespacePolicy type for one field.
+type LimitRangeInfo struct {
+	// Present is true only when the namespace has a LimitRange PVC-max
+	// entry to compare against. A LimitRange that sets only Min/Default
+	// (no Max), or no LimitRange at all, both count as "not present" here
+	// — there is nothing to conflict with either way, so both report
+	// ReasonNoLimitRange.
+	Present  bool
+	MaxBytes int64
+}
+
+// BuildStatus computes a fresh QuotaPolicyStatus for policy from this
+// cycle's outcomes and the namespace's LimitRange info. previous is the
+// policy's current Status.Conditions (before this cycle), used only so
+// meta.SetStatusCondition can preserve LastTransitionTime for conditions
+// whose status hasn't changed — never read for its counts or samples,
+// which are always recomputed fresh every cycle.
+func BuildStatus(policy *v1alpha1.QuotaPolicy, outcomes []ClaimOutcome, lr LimitRangeInfo, previous []metav1.Condition, now metav1.Time) v1alpha1.QuotaPolicyStatus {
+	status := v1alpha1.QuotaPolicyStatus{
+		ObservedGeneration: policy.Generation,
+	}
+
+	conditions := append([]metav1.Condition(nil), previous...)
+
+	setReady(&conditions, policy, now)
+	appliedCount, wonCount, failing := setAppliedAndDegraded(&conditions, policy, outcomes, now)
+	setLimitRangeConflict(&conditions, policy, lr, now)
+
+	status.Conditions = conditions
+	status.MatchedClaims = int32(len(outcomes))
+	status.AppliedClaims = int32(appliedCount)
+	status.ShadowedClaims = int32(len(outcomes) - wonCount)
+	status.FailingClaims = capFailingClaims(failing)
+	status.MatchedClaimSample = capMatchedClaims(outcomes)
+
+	return status
+}
+
+// setReady evaluates the Ready condition, independent of any claim
+// resolution — see ValidateSelector's doc comment for why this must not be
+// derived from Resolve's per-claim Invalid list alone (a policy matching
+// zero claims is never passed to Resolve at all).
+func setReady(conditions *[]metav1.Condition, policy *v1alpha1.QuotaPolicy, now metav1.Time) {
+	cond := metav1.Condition{
+		Type:               v1alpha1.ConditionReady,
+		ObservedGeneration: policy.Generation,
+		LastTransitionTime: now,
+	}
+	if err := ValidateSelector(policy.Spec.Selector); err != nil {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = v1alpha1.ReasonSelectorInvalid
+		cond.Message = err.Error()
+	} else {
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = v1alpha1.ReasonSelectorValid
+		cond.Message = "selector is well-formed"
+	}
+	meta.SetStatusCondition(conditions, cond)
+}
+
+// setAppliedAndDegraded evaluates the Applied and Degraded conditions
+// together, since both are derived from the same won/failing split, and
+// returns the raw counts and failing sample the caller needs for the rest
+// of the status. "Applied" is defined vacuously true when this policy
+// currently wins for no claims at all (ReasonNoMatchingClaims) — the same
+// convention docs/quotapolicy-design.md §5 states for the type: "every claim
+// this policy currently wins for has the quota enforced" is trivially
+// satisfied when there are no such claims.
+func setAppliedAndDegraded(conditions *[]metav1.Condition, policy *v1alpha1.QuotaPolicy, outcomes []ClaimOutcome, now metav1.Time) (appliedCount, wonCount int, failing []ClaimOutcome) {
+	for _, o := range outcomes {
+		if !o.Won {
+			continue
+		}
+		wonCount++
+		if o.EnforcementErr != nil {
+			failing = append(failing, o)
+			continue
+		}
+		appliedCount++
+	}
+
+	applied := metav1.Condition{
+		Type:               v1alpha1.ConditionApplied,
+		ObservedGeneration: policy.Generation,
+		LastTransitionTime: now,
+	}
+	degraded := metav1.Condition{
+		Type:               v1alpha1.ConditionDegraded,
+		ObservedGeneration: policy.Generation,
+		LastTransitionTime: now,
+	}
+
+	switch {
+	case wonCount == 0:
+		applied.Status = metav1.ConditionTrue
+		applied.Reason = v1alpha1.ReasonNoMatchingClaims
+		applied.Message = "this policy currently wins for no claims"
+		degraded.Status = metav1.ConditionFalse
+		degraded.Reason = v1alpha1.ReasonNoMatchingClaims
+		degraded.Message = "no won claims to fail"
+	case len(failing) == 0:
+		applied.Status = metav1.ConditionTrue
+		applied.Reason = v1alpha1.ReasonAllClaimsApplied
+		applied.Message = "every claim this policy won for is enforced"
+		degraded.Status = metav1.ConditionFalse
+		degraded.Reason = v1alpha1.ReasonAllClaimsApplied
+		degraded.Message = "no enforcement failures"
+	default:
+		applied.Status = metav1.ConditionFalse
+		applied.Reason = v1alpha1.ReasonPartiallyApplied
+		applied.Message = "one or more won claims are not currently enforced"
+		degraded.Status = metav1.ConditionTrue
+		degraded.Reason = failingReason(failing)
+		degraded.Message = "one or more won claims are failing enforcement; see status.failingClaims"
+	}
+
+	meta.SetStatusCondition(conditions, applied)
+	meta.SetStatusCondition(conditions, degraded)
+	return appliedCount, wonCount, failing
+}
+
+// failingReason picks the Degraded condition's Reason from the failing
+// outcomes: their own EnforcementReason when every failure agrees, or the
+// generic ReasonEnforcementFailed when they don't (or none was set) — the
+// Reason field is a single value, so a mixed batch can't report more than
+// one specific cause.
+func failingReason(failing []ClaimOutcome) string {
+	if len(failing) == 0 {
+		return v1alpha1.ReasonEnforcementFailed
+	}
+	reason := failing[0].EnforcementReason
+	if reason == "" {
+		return v1alpha1.ReasonEnforcementFailed
+	}
+	for _, o := range failing[1:] {
+		if o.EnforcementReason != reason {
+			return v1alpha1.ReasonEnforcementFailed
+		}
+	}
+	return reason
+}
+
+// setLimitRangeConflict evaluates the LimitRangeConflict condition per
+// docs/quotapolicy-design.md §3: the policy still wins and is still
+// enforced even when it conflicts, so this only ever reports the
+// disagreement — it never changes what quota gets applied.
+func setLimitRangeConflict(conditions *[]metav1.Condition, policy *v1alpha1.QuotaPolicy, lr LimitRangeInfo, now metav1.Time) {
+	cond := metav1.Condition{
+		Type:               v1alpha1.ConditionLimitRangeConflict,
+		ObservedGeneration: policy.Generation,
+		LastTransitionTime: now,
+	}
+
+	switch {
+	case !lr.Present:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = v1alpha1.ReasonNoLimitRange
+		cond.Message = "namespace has no LimitRange PVC max to compare against"
+	case policy.Spec.MaxQuota != nil && policy.Spec.MaxQuota.Value() > lr.MaxBytes:
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = v1alpha1.ReasonExceedsLimitRangeMax
+		cond.Message = "spec.maxQuota exceeds the namespace LimitRange PVC max; QuotaPolicy still wins and is still enforced (see docs/quotapolicy-design.md §3)"
+	default:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = v1alpha1.ReasonWithinLimitRange
+		cond.Message = "spec.maxQuota is within the namespace LimitRange PVC max"
+	}
+
+	meta.SetStatusCondition(conditions, cond)
+}
+
+// capFailingClaims converts up to maxStatusSampleEntries failing outcomes
+// into the bounded, most-recent-first FailingClaim sample. "Most recent" is
+// simply this cycle's encounter order — there is no history across cycles
+// to sort by (docs/quotapolicy-design.md §6: this is a triage sample, not a
+// log).
+func capFailingClaims(failing []ClaimOutcome) []v1alpha1.FailingClaim {
+	if len(failing) == 0 {
+		return nil
+	}
+	n := len(failing)
+	if n > maxStatusSampleEntries {
+		n = maxStatusSampleEntries
+	}
+	now := metav1.Now()
+	out := make([]v1alpha1.FailingClaim, 0, n)
+	for _, o := range failing[:n] {
+		reason := o.EnforcementReason
+		if reason == "" {
+			reason = v1alpha1.ReasonEnforcementFailed
+		}
+		message := ""
+		if o.EnforcementErr != nil {
+			message = o.EnforcementErr.Error()
+		}
+		out = append(out, v1alpha1.FailingClaim{
+			Namespace:          o.Claim.Namespace,
+			Name:               o.Claim.Name,
+			Reason:             reason,
+			Message:            message,
+			LastTransitionTime: &now,
+		})
+	}
+	return out
+}
+
+// capMatchedClaims converts up to maxStatusSampleEntries outcomes into the
+// bounded MatchedClaimSample, winner(s) first so the sample favors the
+// claims this policy actually governs over ones it merely lost.
+func capMatchedClaims(outcomes []ClaimOutcome) []v1alpha1.MatchedClaim {
+	if len(outcomes) == 0 {
+		return nil
+	}
+	ordered := append([]ClaimOutcome(nil), outcomes...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Won && !ordered[j].Won
+	})
+
+	n := len(ordered)
+	if n > maxStatusSampleEntries {
+		n = maxStatusSampleEntries
+	}
+	out := make([]v1alpha1.MatchedClaim, 0, n)
+	for _, o := range ordered[:n] {
+		out = append(out, v1alpha1.MatchedClaim{
+			Namespace:  o.Claim.Namespace,
+			Name:       o.Claim.Name,
+			MatchKind:  o.MatchKind,
+			Won:        o.Won,
+			ResolvedBy: o.ResolvedBy,
+		})
+	}
+	return out
+}

--- a/internal/quotapolicy/status_test.go
+++ b/internal/quotapolicy/status_test.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quotapolicy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+)
+
+func findCondition(conds []metav1.Condition, t string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == t {
+			return &conds[i]
+		}
+	}
+	return nil
+}
+
+func TestBuildStatus_ReadyReflectsSelectorValidity(t *testing.T) {
+	valid := namedPolicy("ns", "valid", 100, v1alpha1.QuotaPolicySelector{})
+	status := BuildStatus(&valid, nil, LimitRangeInfo{}, nil, metav1.Now())
+	ready := findCondition(status.Conditions, v1alpha1.ConditionReady)
+	if ready == nil || ready.Status != metav1.ConditionTrue || ready.Reason != v1alpha1.ReasonSelectorValid {
+		t.Fatalf("expected Ready=True/SelectorValid, got %+v", ready)
+	}
+
+	invalid := namedPolicy("ns", "invalid", 100, v1alpha1.QuotaPolicySelector{
+		LabelSelector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "k", Operator: "NotReal"}},
+		},
+	})
+	status = BuildStatus(&invalid, nil, LimitRangeInfo{}, nil, metav1.Now())
+	ready = findCondition(status.Conditions, v1alpha1.ConditionReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != v1alpha1.ReasonSelectorInvalid {
+		t.Fatalf("expected Ready=False/SelectorInvalid, got %+v", ready)
+	}
+}
+
+func TestBuildStatus_AppliedVacuousWhenNoMatches(t *testing.T) {
+	p := namedPolicy("ns", "p", 100, v1alpha1.QuotaPolicySelector{})
+	status := BuildStatus(&p, nil, LimitRangeInfo{}, nil, metav1.Now())
+
+	applied := findCondition(status.Conditions, v1alpha1.ConditionApplied)
+	if applied == nil || applied.Status != metav1.ConditionTrue || applied.Reason != v1alpha1.ReasonNoMatchingClaims {
+		t.Fatalf("expected Applied=True/NoMatchingClaims, got %+v", applied)
+	}
+	degraded := findCondition(status.Conditions, v1alpha1.ConditionDegraded)
+	if degraded == nil || degraded.Status != metav1.ConditionFalse {
+		t.Fatalf("expected Degraded=False, got %+v", degraded)
+	}
+	if status.MatchedClaims != 0 || status.AppliedClaims != 0 || status.ShadowedClaims != 0 {
+		t.Fatalf("expected all-zero counts, got %+v", status)
+	}
+}
+
+func TestBuildStatus_CountsAndConditions(t *testing.T) {
+	p := namedPolicy("ns", "p", 100, v1alpha1.QuotaPolicySelector{})
+	outcomes := []ClaimOutcome{
+		{Claim: Claim{Namespace: "ns", Name: "a"}, MatchKind: v1alpha1.MatchKindNamespaceWide, Won: true},
+		{Claim: Claim{Namespace: "ns", Name: "b"}, MatchKind: v1alpha1.MatchKindNamespaceWide, Won: true},
+		{Claim: Claim{Namespace: "ns", Name: "c"}, MatchKind: v1alpha1.MatchKindPVCName, Won: false, ResolvedBy: "other"},
+	}
+
+	status := BuildStatus(&p, outcomes, LimitRangeInfo{}, nil, metav1.Now())
+
+	if status.MatchedClaims != 3 {
+		t.Fatalf("MatchedClaims = %d, want 3", status.MatchedClaims)
+	}
+	if status.AppliedClaims != 2 {
+		t.Fatalf("AppliedClaims = %d, want 2", status.AppliedClaims)
+	}
+	if status.ShadowedClaims != 1 {
+		t.Fatalf("ShadowedClaims = %d, want 1", status.ShadowedClaims)
+	}
+	applied := findCondition(status.Conditions, v1alpha1.ConditionApplied)
+	if applied == nil || applied.Status != metav1.ConditionTrue || applied.Reason != v1alpha1.ReasonAllClaimsApplied {
+		t.Fatalf("expected Applied=True/AllClaimsApplied, got %+v", applied)
+	}
+}
+
+func TestBuildStatus_FailingClaimsMarkDegraded(t *testing.T) {
+	p := namedPolicy("ns", "p", 100, v1alpha1.QuotaPolicySelector{})
+	outcomes := []ClaimOutcome{
+		{Claim: Claim{Namespace: "ns", Name: "a"}, Won: true},
+		{Claim: Claim{Namespace: "ns", Name: "b"}, Won: true, EnforcementErr: errors.New("disk full"), EnforcementReason: v1alpha1.ReasonEnforcementFailed},
+	}
+
+	status := BuildStatus(&p, outcomes, LimitRangeInfo{}, nil, metav1.Now())
+
+	applied := findCondition(status.Conditions, v1alpha1.ConditionApplied)
+	if applied == nil || applied.Status != metav1.ConditionFalse || applied.Reason != v1alpha1.ReasonPartiallyApplied {
+		t.Fatalf("expected Applied=False/PartiallyApplied, got %+v", applied)
+	}
+	degraded := findCondition(status.Conditions, v1alpha1.ConditionDegraded)
+	if degraded == nil || degraded.Status != metav1.ConditionTrue || degraded.Reason != v1alpha1.ReasonEnforcementFailed {
+		t.Fatalf("expected Degraded=True/EnforcementFailed, got %+v", degraded)
+	}
+	if len(status.FailingClaims) != 1 || status.FailingClaims[0].Name != "b" {
+		t.Fatalf("expected exactly one failing claim 'b', got %+v", status.FailingClaims)
+	}
+}
+
+func TestBuildStatus_LimitRangeConflict(t *testing.T) {
+	p := namedPolicy("ns", "p", 100, v1alpha1.QuotaPolicySelector{})
+	p.Spec.MaxQuota = gi(20)
+
+	// Exceeds the namespace LimitRange max.
+	status := BuildStatus(&p, nil, LimitRangeInfo{Present: true, MaxBytes: 10 * 1024 * 1024 * 1024}, nil, metav1.Now())
+	cond := findCondition(status.Conditions, v1alpha1.ConditionLimitRangeConflict)
+	if cond == nil || cond.Status != metav1.ConditionTrue || cond.Reason != v1alpha1.ReasonExceedsLimitRangeMax {
+		t.Fatalf("expected LimitRangeConflict=True/ExceedsLimitRangeMax, got %+v", cond)
+	}
+
+	// Within the namespace LimitRange max.
+	status = BuildStatus(&p, nil, LimitRangeInfo{Present: true, MaxBytes: 30 * 1024 * 1024 * 1024}, nil, metav1.Now())
+	cond = findCondition(status.Conditions, v1alpha1.ConditionLimitRangeConflict)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != v1alpha1.ReasonWithinLimitRange {
+		t.Fatalf("expected LimitRangeConflict=False/WithinLimitRange, got %+v", cond)
+	}
+
+	// No LimitRange at all.
+	status = BuildStatus(&p, nil, LimitRangeInfo{Present: false}, nil, metav1.Now())
+	cond = findCondition(status.Conditions, v1alpha1.ConditionLimitRangeConflict)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != v1alpha1.ReasonNoLimitRange {
+		t.Fatalf("expected LimitRangeConflict=False/NoLimitRange, got %+v", cond)
+	}
+}
+
+// TestBuildStatus_FailingClaimsSampleCappedAt20 also proves the *rest* of
+// the status still lands when the sample is capped: verified live against a
+// Kubernetes 1.35 API server, writing 21 status.matchedClaimSample entries
+// doesn't just get the extra entry rejected — it fails the whole
+// UpdateStatus ("Too many: 21: must have at most 20 items" plus "some
+// validation rules were not checked because the object was invalid"),
+// taking counts and conditions down with it. Capping in Go before the call
+// (maxStatusSampleEntries) is what avoids ever sending an oversized list in
+// the first place, so this asserts the call actually succeeds end-to-end
+// through WriteStatus, not just that BuildStatus's return value is capped
+// in memory.
+func TestBuildStatus_FailingClaimsSampleCappedAt20(t *testing.T) {
+	p := namedPolicy("ns-a", "p", 100, v1alpha1.QuotaPolicySelector{})
+	var outcomes []ClaimOutcome
+	for i := 0; i < 25; i++ {
+		outcomes = append(outcomes, ClaimOutcome{
+			Claim:             Claim{Namespace: "ns-a", Name: "pvc"},
+			Won:               true,
+			EnforcementErr:    errors.New("fail"),
+			EnforcementReason: v1alpha1.ReasonEnforcementFailed,
+		})
+	}
+
+	status := BuildStatus(&p, outcomes, LimitRangeInfo{}, nil, metav1.Now())
+	if len(status.FailingClaims) != maxStatusSampleEntries {
+		t.Fatalf("FailingClaims len = %d, want %d", len(status.FailingClaims), maxStatusSampleEntries)
+	}
+	if status.MatchedClaims != 25 || status.AppliedClaims != 0 {
+		t.Fatalf("unbounded counts wrong despite the cap: matched=%d applied=%d, want 25/0", status.MatchedClaims, status.AppliedClaims)
+	}
+	if len(status.Conditions) == 0 {
+		t.Fatalf("expected conditions to still be populated alongside the capped sample")
+	}
+
+	client := newFakeDynamicClient(t, &p)
+	if err := WriteStatus(context.Background(), client, &p, status); err != nil {
+		t.Fatalf("WriteStatus with a 20-entry-capped sample must succeed, got: %v", err)
+	}
+	got, err := client.Resource(GroupVersionResource).Namespace("ns-a").Get(context.Background(), "p", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get after WriteStatus: %v", err)
+	}
+	matched, found, _ := unstructured.NestedInt64(got.Object, "status", "matchedClaims")
+	if !found || matched != 25 {
+		t.Fatalf("matchedClaims after write = %v (found=%v), want 25 — the rest of status must land alongside the capped sample", matched, found)
+	}
+	failing, found, _ := unstructured.NestedSlice(got.Object, "status", "failingClaims")
+	if !found || len(failing) != maxStatusSampleEntries {
+		t.Fatalf("failingClaims after write: found=%v len=%d, want %d", found, len(failing), maxStatusSampleEntries)
+	}
+}
+
+// TestBuildStatus_MatchedClaimSampleCappedAt20 is the matchedClaimSample
+// counterpart to the failingClaims test above — see its doc comment for why
+// asserting an end-to-end WriteStatus matters, not just BuildStatus's
+// in-memory return value.
+func TestBuildStatus_MatchedClaimSampleCappedAt20(t *testing.T) {
+	p := namedPolicy("ns-a", "p", 100, v1alpha1.QuotaPolicySelector{})
+	var outcomes []ClaimOutcome
+	for i := 0; i < 30; i++ {
+		outcomes = append(outcomes, ClaimOutcome{
+			Claim:     Claim{Namespace: "ns-a", Name: "pvc"},
+			MatchKind: v1alpha1.MatchKindNamespaceWide,
+			Won:       i%2 == 0,
+		})
+	}
+
+	status := BuildStatus(&p, outcomes, LimitRangeInfo{}, nil, metav1.Now())
+	if len(status.MatchedClaimSample) != maxStatusSampleEntries {
+		t.Fatalf("MatchedClaimSample len = %d, want %d", len(status.MatchedClaimSample), maxStatusSampleEntries)
+	}
+	if status.MatchedClaims != 30 {
+		t.Fatalf("MatchedClaims (unbounded count) = %d, want 30", status.MatchedClaims)
+	}
+	if status.AppliedClaims != 15 || status.ShadowedClaims != 15 {
+		t.Fatalf("AppliedClaims/ShadowedClaims wrong despite the cap: got %d/%d, want 15/15", status.AppliedClaims, status.ShadowedClaims)
+	}
+
+	client := newFakeDynamicClient(t, &p)
+	if err := WriteStatus(context.Background(), client, &p, status); err != nil {
+		t.Fatalf("WriteStatus with a 20-entry-capped sample must succeed, got: %v", err)
+	}
+	got, err := client.Resource(GroupVersionResource).Namespace("ns-a").Get(context.Background(), "p", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get after WriteStatus: %v", err)
+	}
+	matched, found, _ := unstructured.NestedInt64(got.Object, "status", "matchedClaims")
+	if !found || matched != 30 {
+		t.Fatalf("matchedClaims after write = %v (found=%v), want 30 — the rest of status must land alongside the capped sample", matched, found)
+	}
+	sample, found, _ := unstructured.NestedSlice(got.Object, "status", "matchedClaimSample")
+	if !found || len(sample) != maxStatusSampleEntries {
+		t.Fatalf("matchedClaimSample after write: found=%v len=%d, want %d", found, len(sample), maxStatusSampleEntries)
+	}
+}
+
+func TestBuildStatus_PreservesLastTransitionTimeWhenUnchanged(t *testing.T) {
+	p := namedPolicy("ns", "p", 100, v1alpha1.QuotaPolicySelector{})
+	earlier := metav1.NewTime(metav1.Now().Add(-1 * 60 * 60 * 1e9)) // 1h before "now" below, in ns
+	previous := []metav1.Condition{
+		{Type: v1alpha1.ConditionReady, Status: metav1.ConditionTrue, Reason: v1alpha1.ReasonSelectorValid, Message: "ok", LastTransitionTime: earlier},
+	}
+
+	status := BuildStatus(&p, nil, LimitRangeInfo{}, previous, metav1.Now())
+	ready := findCondition(status.Conditions, v1alpha1.ConditionReady)
+	if ready == nil {
+		t.Fatalf("expected a Ready condition")
+	}
+	if !ready.LastTransitionTime.Equal(&earlier) {
+		t.Fatalf("expected LastTransitionTime to be preserved at %v, got %v", earlier, ready.LastTransitionTime)
+	}
+}

--- a/internal/quotapolicy/zz_independent_verify_test.go
+++ b/internal/quotapolicy/zz_independent_verify_test.go
@@ -1,0 +1,106 @@
+package quotapolicy
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+)
+
+func p(ns, name string, prio int32, sel v1alpha1.QuotaPolicySelector) v1alpha1.QuotaPolicy {
+	return v1alpha1.QuotaPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec:       v1alpha1.QuotaPolicySpec{Selector: sel, Priority: prio},
+	}
+}
+func namePtr(s string) *string { return &s }
+
+// Mirrors the fixture applied to a live cluster: specificity and priority
+// are deliberately set in OPPOSITE order, so an implementation that checks
+// priority before specificity picks a different winner.
+func TestIndependent_SpecificityBeatsPriority(t *testing.T) {
+	policies := []v1alpha1.QuotaPolicy{
+		p("qp-test", "qp-by-name", 100, v1alpha1.QuotaPolicySelector{PVCName: namePtr("target-pvc")}),
+		p("qp-test", "qp-by-label", 0, v1alpha1.QuotaPolicySelector{
+			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "gold"}}}),
+		p("qp-test", "qp-namespace-wide", 0, v1alpha1.QuotaPolicySelector{}),
+		// decoy: identical name+selector in another namespace
+		p("qp-other", "qp-by-name", 0, v1alpha1.QuotaPolicySelector{PVCName: namePtr("target-pvc")}),
+	}
+
+	got := Resolve(Claim{Namespace: "qp-test", Name: "target-pvc",
+		Labels: map[string]string{"tier": "gold"}}, policies)
+
+	if got.Winner == nil {
+		t.Fatal("no winner")
+	}
+	if got.Winner.Name != "qp-by-name" || got.Winner.Namespace != "qp-test" {
+		t.Errorf("winner = %s/%s, want qp-test/qp-by-name (priority-first impl picks qp-by-label or qp-namespace-wide)",
+			got.Winner.Namespace, got.Winner.Name)
+	}
+	if got.MatchKind != v1alpha1.MatchKindPVCName {
+		t.Errorf("matchKind = %q, want PVCName", got.MatchKind)
+	}
+	if len(got.Losers) != 2 {
+		t.Errorf("losers = %d, want 2 (the decoy in qp-other must not appear)", len(got.Losers))
+	}
+	for _, l := range got.Losers {
+		if l.Policy.Namespace != "qp-test" {
+			t.Errorf("cross-namespace policy %s/%s leaked into losers", l.Policy.Namespace, l.Policy.Name)
+		}
+	}
+	t.Logf("winner=%s kind=%s losers=%d", got.Winner.Name, got.MatchKind, len(got.Losers))
+	for _, l := range got.Losers {
+		t.Logf("  lost: %s -- %s", l.Policy.Name, l.Reason)
+	}
+}
+
+// Equal specificity, name order deliberately OPPOSITE to priority order.
+// zzz-strong has the lower (stronger) priority but sorts last by name.
+func TestIndependent_LowerPriorityWinsNotNameOrder(t *testing.T) {
+	policies := []v1alpha1.QuotaPolicy{
+		p("qp-test", "aaa-weak", 100, v1alpha1.QuotaPolicySelector{}),
+		p("qp-test", "zzz-strong", 0, v1alpha1.QuotaPolicySelector{}),
+	}
+	got := Resolve(Claim{Namespace: "qp-test", Name: "any"}, policies)
+	if got.Winner == nil || got.Winner.Name != "zzz-strong" {
+		t.Errorf("winner = %v, want zzz-strong (name-first or reversed priority picks aaa-weak)", got.Winner)
+	}
+}
+
+// tier=silver must not match the gold label selector, so the namespace-wide
+// policy wins even though it is the least specific.
+func TestIndependent_NonMatchingLabelFallsThrough(t *testing.T) {
+	policies := []v1alpha1.QuotaPolicy{
+		p("qp-test", "qp-by-label", 0, v1alpha1.QuotaPolicySelector{
+			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "gold"}}}),
+		p("qp-test", "qp-namespace-wide", 100, v1alpha1.QuotaPolicySelector{}),
+	}
+	got := Resolve(Claim{Namespace: "qp-test", Name: "other-pvc",
+		Labels: map[string]string{"tier": "silver"}}, policies)
+	if got.Winner == nil || got.Winner.Name != "qp-namespace-wide" {
+		t.Errorf("winner = %v, want qp-namespace-wide", got.Winner)
+	}
+	if len(got.Losers) != 0 {
+		t.Errorf("losers = %d, want 0 (the gold selector should not have matched)", len(got.Losers))
+	}
+}
+
+// An unparseable selector must be reported, not silently treated as a
+// non-match.
+func TestIndependent_InvalidSelectorIsReported(t *testing.T) {
+	bad := p("qp-test", "qp-bad", 0, v1alpha1.QuotaPolicySelector{
+		LabelSelector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "tier", Operator: "BogusOperator", Values: []string{"gold"}},
+			}}})
+	got := Resolve(Claim{Namespace: "qp-test", Name: "x"}, []v1alpha1.QuotaPolicy{bad})
+	if len(got.Invalid) != 1 {
+		t.Fatalf("invalid = %d, want 1 -- an unparseable selector was silently dropped", len(got.Invalid))
+	}
+	if got.Winner != nil {
+		t.Errorf("winner = %v, want nil", got.Winner)
+	}
+	t.Logf("reported: %v", got.Invalid[0].Err)
+}

--- a/internal/quotapolicy/zz_livecluster_verify_test.go
+++ b/internal/quotapolicy/zz_livecluster_verify_test.go
@@ -1,0 +1,116 @@
+//go:build livecluster
+
+package quotapolicy
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+)
+
+// Runs against a REAL API server (build tag `livecluster`, KUBECONTEXT env).
+// A fake dynamic client accepts any status object, so it cannot prove the
+// capped status is actually writable: the CRD's MaxItems=20 rejects the
+// ENTIRE status update when exceeded, taking counts and conditions down
+// with the oversized sample. That failure mode only appears against a real
+// API server, which is why this test exists alongside the unit tests.
+func TestLive_CappedStatusIsAcceptedByAPIServer(t *testing.T) {
+	ctxName := os.Getenv("KUBECONTEXT")
+	if ctxName == "" {
+		t.Skip("set KUBECONTEXT")
+	}
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{CurrentContext: ctxName}).ClientConfig()
+	if err != nil {
+		t.Fatalf("kubeconfig: %v", err)
+	}
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("dynamic client: %v", err)
+	}
+	ctx := context.Background()
+
+	policies, err := List(ctx, dc)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	t.Logf("listed %d QuotaPolicy objects from the live cluster", len(policies))
+
+	var target *v1alpha1.QuotaPolicy
+	for i := range policies {
+		if policies[i].Namespace == "qp-test" && policies[i].Name == "qp-namespace-wide" {
+			target = &policies[i]
+		}
+	}
+	if target == nil {
+		t.Fatal("fixture qp-test/qp-namespace-wide not found; apply the e2e fixture first")
+	}
+
+	// 25 outcomes -> both sample lists must be capped to 20, or the whole
+	// update is rejected.
+	outcomes := make([]ClaimOutcome, 0, 25)
+	for i := 0; i < 25; i++ {
+		outcomes = append(outcomes, ClaimOutcome{
+			Claim:     Claim{Namespace: "qp-test", Name: "pvc-" + string(rune('a'+i%26))},
+			MatchKind: v1alpha1.MatchKindNamespaceWide,
+			Won:       true,
+		})
+	}
+	st := BuildStatus(target, outcomes, LimitRangeInfo{}, target.Status.Conditions, metav1.Now())
+
+	if got := len(st.MatchedClaimSample); got > 20 {
+		t.Fatalf("matchedClaimSample not capped: %d", got)
+	}
+	if got := st.MatchedClaims; got != 25 {
+		t.Errorf("matchedClaims = %d, want 25 -- the COUNT must stay truthful even though the sample is capped", got)
+	}
+
+	if err := WriteStatus(ctx, dc, target, st); err != nil {
+		t.Fatalf("WriteStatus rejected by the real API server: %v", err)
+	}
+
+	back, err := dc.Resource(GroupVersionResource).Namespace("qp-test").
+		Get(ctx, "qp-namespace-wide", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	status, found, _ := unstructuredNestedMap(back.Object, "status")
+	if !found {
+		t.Fatal("status was not persisted")
+	}
+	t.Logf("persisted status keys: %v", keysOf(status))
+	if mc, ok := status["matchedClaims"]; !ok {
+		t.Error("matchedClaims missing from persisted status -- counts were lost")
+	} else {
+		t.Logf("persisted matchedClaims = %v", mc)
+	}
+	if conds, ok := status["conditions"].([]interface{}); !ok || len(conds) == 0 {
+		t.Error("conditions missing from persisted status")
+	} else {
+		t.Logf("persisted %d conditions", len(conds))
+	}
+}
+
+func unstructuredNestedMap(obj map[string]interface{}, key string) (map[string]interface{}, bool, error) {
+	v, ok := obj[key]
+	if !ok {
+		return nil, false, nil
+	}
+	m, ok := v.(map[string]interface{})
+	return m, ok, nil
+}
+
+func keysOf(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Completes the controller half of the QuotaPolicy work started in #28/#29 (types + CRD only): resolution, effective-quota bounding, watch integration, and status write-back, gated behind `--enable-quota-policy` / `quotaPolicy.enabled` (default off).

Closes/contributes to:
- **#13** — QuotaPolicy CRD: controller half completed (types/CRD were already in main).
- **#14** — Policy semantics: implements the described layering (`QuotaPolicy` = filesystem enforcement, distinct from `ResourceQuota`/`LimitRange`), specificity/priority resolution, default/min/max bounding, and a `LimitRangeConflict` status condition.
- **#12** — Watch resilience: fixes a reconnect-backoff-never-resets hot loop and a self-undo race between the watch path and QuotaPolicy enforcement (see below). Does not add the work-queue/keyed-reconciliation/resourceVersion-resume layer #12 also asks for — left as follow-up.
- **#26** — separate commit; see its own description.

## Defects found and fixed (each mutation-verified: revert the fix, confirm the regression test fails; restore, confirm it passes)

1. **Watch self-undo.** `ensureQuota`'s own status-annotation write triggers a `Modified` event for the same PV. The watch handler resolved policy against a hardcoded `0`, immediately re-applying raw capacity and undoing a QuotaPolicy clamp the last sync had just enforced. Fixed with `resolveFromSnapshot`, which resolves against the last sync cycle's cached policy set.
2. **False `Applied=True`.** `ensureQuota` returns `nil` (not an error) when a PV's local directory doesn't exist — correct for "this node doesn't back this claim" on a multi-node DaemonSet, but that silence was being counted as a successful enforcement. Fixed with an explicit `errLocalDirectoryMissing` substitution when `--quota-policy-single-writer` is set (no other node to attribute the gap to).
3. **Backoff never engages on instant-death connections.** The watch reconnect loop reset backoff on any successful `Watch()` call, including one that dies immediately — a persistently rejected stream produced an unthrottled reconnect loop (measured: ~31 reconnects/500ms before the fix). Fixed with a `minHealthyDuration` gate before the backoff resets.
4. **Data race in a test.** `TestWatchPVsLogsWatchErrorEvent` read/wrote a bare `bytes.Buffer` from two goroutines; `-race` (which CI runs) failed it 4/5 times. Fixed with a mutex-guarded buffer.
5. **No admission-time floor on quota fields.** `defaultQuota`/`minQuota`/`maxQuota` had no non-negativity check — a negative `maxQuota` was only caught by a runtime `> 0` guard in `ensureQuota`. Added a `quantity(self) >= 0` CEL rule per field; verified live against an applied CRD that `maxQuota: "-1Gi"` is now rejected at admission.

## RBAC

`persistentvolumeclaims` (get/list/watch, needed for label-selector matching) and the pre-existing `quotapolicies`/`quotapolicies/status` rules are now gated behind `{{- if .Values.quotaPolicy.enabled }}` — verified by rendering the chart both ways (default: none of the three rules present; `enabled=true`: all three). Also trimmed the `patch` verb off `quotapolicies/status`, since `WriteStatus` only ever calls `UpdateStatus`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./... -count=1 -race` — all 13 packages pass
- [x] `KUBECONTEXT=colima go test -tags livecluster ./internal/quotapolicy/...` against a real k3s API server
- [x] Each of the 5 defects above independently mutation-verified (fix reverted -> regression test fails -> fix restored -> passes)
- [x] `helm template` rendered with `quotaPolicy.enabled=false` and `=true`, diffed for RBAC leakage
- [x] Negative `maxQuota` rejection verified against a live-applied CRD (admission, not just unit test)
- [x] Independent adversarial review pass (opus) on the RBAC/argv/negative-value/race-condition surface; all findings addressed above

## Deliberately out of scope

- Real leader election (`coordination.k8s.io` Lease) for multi-writer status — left `quotaPolicySingleWriter` as an explicit opt-in instead; documented in `docs/quotapolicy-design.md` §11.
- `Drifted` status condition — would need a filesystem read-back (`xfs_quota report`/`repquota`/btrfs qgroup) this PR doesn't add.
- `--default-quota`/`--enforce-max-quota` flag dead-code question (found during this investigation, unrelated to QuotaPolicy) — flagged separately, awaiting a product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT