### PR TITLE
feat(metrics): add a critical PrometheusRule alert for quota exhaustion

### DIFF
--- a/charts/nfs-quota-agent/templates/prometheusrule.yaml
+++ b/charts/nfs-quota-agent/templates/prometheusrule.yaml
@@ -21,6 +21,14 @@ spec:
           annotations:
             summary: "NFS Quota usage high for directory {{ `{{ $labels.directory }}` }}"
             description: "Directory {{ `{{ $labels.directory }}` }} is using {{ `{{ $value | printf \"%.1f\" }}` }}% of its quota limit."
+        - alert: NFSQuotaUsageExceeded
+          expr: nfs_quota_used_percent >= 100
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "NFS Quota exceeded for directory {{ `{{ $labels.directory }}` }}"
+            description: "Directory {{ `{{ $labels.directory }}` }} is at {{ `{{ $value | printf \"%.1f\" }}` }}% of its quota limit -- writes into it are being rejected by the filesystem."
         - alert: NFSQuotaAgentDown
           expr: absent(nfs_quota_agent_info) == 1
           for: 1m


### PR DESCRIPTION
## Summary
- Contributes to #3's "PrometheusRule로 warning/critical 임계치 기본 제공" acceptance item: the chart only had a warning-severity alert (`NFSQuotaUsageHigh` at 90%); nothing critical-severity fires for actual quota exhaustion. `NFSQuotaAgentDown` is critical but covers agent liveness, a different failure mode.
- Both `xfs.go` and `ext4.go` set a hard block limit only (no soft limit) — `nfs_quota_used_percent >= 100` therefore means the filesystem is already rejecting writes (EDQUOT/ENOSPC), not just approaching the limit.

## Test plan
- [x] `helm template --set metrics.prometheusRule.enabled=true --show-only templates/prometheusrule.yaml` renders both alerts correctly (warning at >90%, new critical at >=100%)
- [x] Verified in source that both quota backends this repo supports (xfs, ext4) enforce a hard limit, not a soft one, so the "writes are being rejected" wording in the alert description is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT