### PR TITLE
test(quota): add a native fuzz test for validateQuotaArg

### DIFF
--- a/internal/quota/validate_test.go
+++ b/internal/quota/validate_test.go
@@ -130,7 +130,7 @@ func FuzzValidateQuotaArg(f *testing.F) {
 		"project&&echo",
 		"project\t1",
 		"프로젝트1",
-		"project​1", // zero-width space: not unicode.IsSpace or IsControl
+		"project\u200b1", // zero-width space: not unicode.IsSpace or IsControl
 	} {
 		f.Add(seed)
 	}

--- a/internal/quota/validate_test.go
+++ b/internal/quota/validate_test.go
@@ -19,6 +19,7 @@ package quota
 import (
 	"strings"
 	"testing"
+	"unicode"
 )
 
 func TestValidateQuotaArg(t *testing.T) {
@@ -105,3 +106,49 @@ func TestValidateQuotaArg(t *testing.T) {
 // delegation to validateQuotaArg); AddProject-level and ensureQuota-level
 // reachability are covered by TestAddProjectRejectsDelimiterInName and
 // TestEnsureQuota_ProjectNameWithColonFromAnnotationRejected respectively.
+
+// FuzzValidateQuotaArg targets the one function every operator-controlled
+// string (project name, path) must pass before it can reach argv -- see
+// CLAUDE.md's "High-risk paths". The table above only exercises the cases
+// someone thought to write down; this explores the space around them
+// (multi-byte whitespace/control runes, mixed valid/invalid runs, near-miss
+// shell metacharacters that aren't quotes or whitespace) for a panic or an
+// input that should be rejected but isn't.
+func FuzzValidateQuotaArg(f *testing.F) {
+	for _, seed := range []string{
+		"/data/project1",
+		"/data/project 1",
+		"proj\"ect1",
+		"proj'ect1",
+		"project\n1",
+		"project\x001",
+		"",
+		"project;rm -rf /",
+		"project`whoami`",
+		"project$(whoami)",
+		"project|cat",
+		"project&&echo",
+		"project\t1",
+		"프로젝트1",
+		"project​1", // zero-width space: not unicode.IsSpace or IsControl
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, value string) {
+		err := validateQuotaArg("fuzz", value)
+		if err == nil {
+			// Accepted: every rune must be non-space, non-quote, non-control,
+			// and the value must be non-empty -- the exact contract
+			// validateQuotaArg documents.
+			if value == "" {
+				t.Fatalf("accepted an empty value")
+			}
+			for _, r := range value {
+				if unicode.IsSpace(r) || unicode.IsControl(r) || r == '\'' || r == '"' {
+					t.Fatalf("accepted %q containing rejected rune %q", value, r)
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Contributes evidence toward #7's "malformed input/path safety tests" and "filesystem/error parser fuzz tests" acceptance criteria — before evaluating a Rust helper boundary, checks whether the current Go validator already holds up under fuzzing.
- `validateQuotaArg` (`internal/quota/validate.go`) is the single gate every operator-controlled string (project name from the `nfs.io/project-name` annotation, filesystem path) must pass before reaching argv — see `CLAUDE.md`'s "High-risk paths". It had table-driven unit tests but no fuzz coverage.
- `FuzzValidateQuotaArg` seeds the existing cases plus adversarial extras (shell metacharacters that aren't quotes/whitespace, multi-byte Unicode, a zero-width space) and asserts the documented contract on every *accepted* value: non-empty, no whitespace/control rune, no quote.

## Test plan
- [x] `go test ./internal/quota/ -run TestValidateQuotaArg -count=1` — existing table tests still pass
- [x] `go test ./internal/quota/ -fuzz FuzzValidateQuotaArg -fuzztime 30s` — 12.3M executions, no crash, no contract violation found
- [x] `go build ./... && go vet ./... && gofmt -l .` clean
- [x] `go test ./... -count=1 -race` — all 13 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT