### PR TITLE
ci(license): enforce an explicit dependency license allowlist

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,8 +90,8 @@ jobs:
           go-version: '1.26'
           cache: true
 
-      - name: Check for forbidden/unknown dependency licenses
-        run: go tool go-licenses check ./...
+      - name: Check dependency licenses against the explicit allowlist
+        run: go tool go-licenses check ./... --allowed_licenses="$(paste -sd, hack/allowed-licenses.txt)"
 
       - name: Verify THIRD_PARTY_LICENSES.md is up to date
         run: |

--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,17 @@ tidy:
 lint:
 	golangci-lint run
 
-# Regenerate THIRD_PARTY_LICENSES.md from go.mod/go.sum and fail on forbidden/unknown licenses.
-# Generate into a temp file first: a plain `> THIRD_PARTY_LICENSES.md` truncates the existing
-# inventory before go-licenses runs, so a failed run would leave an empty file behind.
+# Regenerate THIRD_PARTY_LICENSES.md from go.mod/go.sum and fail on any dependency license not
+# in hack/allowed-licenses.txt. Generate into a temp file first: a plain `> THIRD_PARTY_LICENSES.md`
+# truncates the existing inventory before go-licenses runs, so a failed run would leave an empty
+# file behind. The explicit allowlist (rather than go-licenses' default forbidden/unknown
+# classification) is the machine-readable license policy #16 asks for -- a new dependency under a
+# license not already reviewed and added to that file fails the build instead of silently passing
+# because it happens not to be in go-licenses' built-in forbidden set.
 license:
 	go tool go-licenses report ./... --template hack/third-party-licenses.tmpl > THIRD_PARTY_LICENSES.md.tmp
 	mv THIRD_PARTY_LICENSES.md.tmp THIRD_PARTY_LICENSES.md
-	go tool go-licenses check ./...
+	go tool go-licenses check ./... --allowed_licenses="$$(paste -sd, hack/allowed-licenses.txt)"
 
 # Regenerate deepcopy methods and the CRD manifest for internal/apis/quota/v1alpha1
 # from its kubebuilder markers. Must be re-run (and the result committed) whenever

--- a/hack/allowed-licenses.txt
+++ b/hack/allowed-licenses.txt
@@ -1,0 +1,4 @@
+Apache-2.0
+BSD-3-Clause
+ISC
+MIT


### PR DESCRIPTION
## Summary
- Contributes to #16's "machine-readable license policy" acceptance item (flagged partial in an earlier comment: "정책이 go-licenses 기본 분류에 암묵적으로 의존").
- License Check previously relied on go-licenses' default `--disallowed_types=forbidden,unknown`, which passes any license that merely isn't in go-licenses' own forbidden/unknown buckets — a new dependency under a permissive-but-unreviewed license would pass silently without anyone deciding it's acceptable.
- `hack/allowed-licenses.txt` now lists the exact 4 licenses this repo's dependency tree carries today (Apache-2.0, BSD-3-Clause, ISC, MIT — verified via `go tool go-licenses report`), and both `make license` and CI's License Check job pass it as `--allowed_licenses`.

## Test plan
- [x] `make license` runs clean, `THIRD_PARTY_LICENSES.md` unchanged (no drift from switching the check mode)
- [x] Negative check: removing MIT from the allowlist correctly fails and names every MIT-licensed dependency (go-restful, cbor, json-iterator, float16, yaml.in/yaml, sigs.k8s.io/yaml)
- [x] `go build ./... && go vet ./... && gofmt -l . && golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT