### PR TITLE
chore(chart): reconcile appVersion with the last actual release tag

### DIFF
--- a/charts/nfs-quota-agent/Chart.yaml
+++ b/charts/nfs-quota-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: nfs-quota-agent
 description: A Kubernetes agent that enforces filesystem project quotas for NFS PersistentVolumes
 type: application
 version: 0.4.0
-appVersion: "0.2.2"
+appVersion: "0.3.0"
 keywords:
   - nfs
   - quota


### PR DESCRIPTION
## Summary
- `CLAUDE.md` flagged this drift before ("Chart.yaml currently carries version: 0.3.0 against appVersion: 0.2.2 — reconcile that during any release change"). It's gotten worse since: chart `version` is now 0.4.0 while `appVersion` was still pinned to 0.2.2 — three releases behind the last actual tag.
- `appVersion` now reads `0.3.0`, matching the last real release tag (`v0.3.0`, 2026-07-19) and `CHANGELOG.md`'s newest entry.
- Not bumping to anything newer: no new version tag has been cut this session, and `appVersion` should track what was actually released, not what's merged to `main` but unreleased.

## Test plan
- [x] `helm lint ./charts/nfs-quota-agent` clean
- [x] `helm template` renders `app.kubernetes.io/version: "0.3.0"` everywhere it's used

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT