### PR TITLE
fix(audit): log project ID allocation failures, not just apply failures

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -734,9 +734,18 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, e
 		return nil
 	}
 
+	var namespace, pvcName string
+	if pv.Spec.ClaimRef != nil {
+		namespace = pv.Spec.ClaimRef.Namespace
+		pvcName = pv.Spec.ClaimRef.Name
+	}
+
 	projectName := a.getProjectName(pv)
 	projectID, err := a.generateProjectID(projectName)
 	if err != nil {
+		if a.auditLogger != nil {
+			a.auditLogger.LogProjectIDAllocationFailure(pv.Name, namespace, pvcName, localPath, projectName, err)
+		}
 		a.updateQuotaStatus(ctx, pv, QuotaStatusFailed)
 		return fmt.Errorf("failed to allocate project ID for PV %s: %w", pv.Name, err)
 	}
@@ -745,12 +754,6 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, e
 	isUpdate := oldQuota > 0 && oldQuota != sizeBytes
 
 	err = a.applyQuota(localPath, projectName, projectID, sizeBytes)
-
-	var namespace, pvcName string
-	if pv.Spec.ClaimRef != nil {
-		namespace = pv.Spec.ClaimRef.Namespace
-		pvcName = pv.Spec.ClaimRef.Name
-	}
 
 	if a.auditLogger != nil {
 		if isUpdate {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -19,6 +19,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -850,6 +851,67 @@ func TestEnsureQuotaUpdateFlowWithAuditLogger(t *testing.T) {
 	}
 	if len(data) == 0 {
 		t.Fatalf("expected audit log entries to be written")
+	}
+}
+
+// TestEnsureQuota_ProjectIDExhaustionIsAudited guards #15's "allocation/
+// release/reuse/collision 이벤트가 audit에 남는다" acceptance item for the
+// exhaustion case: generateProjectID's error returns before ensureQuota
+// ever reaches its LogQuotaCreate/LogQuotaUpdate call, so without a
+// dedicated audit call on that path, an exhaustion failure left no audit
+// trail at all -- silently invisible to anyone reviewing the audit log for
+// why a PV never got its quota applied.
+func TestEnsureQuota_ProjectIDExhaustionIsAudited(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, pv, _ := ensureQuotaFixture(t, 1)
+	a.fsType = quota.FSTypeXFS
+
+	auditPath := filepath.Join(t.TempDir(), "audit.log")
+	logger, err := audit.NewLogger(audit.Config{Enabled: true, FilePath: auditPath, NodeName: "n", AgentID: "a"})
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	a.SetAuditLogger(logger)
+
+	// Exhaust every ID generateProjectID would probe for this PV's project
+	// name (see TestGenerateProjectIDExhaustion for the same technique).
+	projectName := a.getProjectName(pv)
+	id := a.hashProjectName(projectName)
+	a.knownProjectIDs = make(map[uint32]string)
+	for i := 0; i <= maxProjectIDProbe; i++ {
+		a.knownProjectIDs[id] = fmt.Sprintf("someone-else-%d", i)
+		id++
+		if id == 0 {
+			id = 1
+		}
+	}
+
+	ctx := context.Background()
+	if err := a.ensureQuota(ctx, pv, 0); err == nil {
+		t.Fatal("expected ensureQuota to fail when the project ID range is exhausted")
+	}
+	logger.Close()
+
+	data, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	nl := bytes.IndexByte(data, '\n')
+	if nl < 0 {
+		t.Fatalf("expected an audit entry for the exhaustion failure, got no newline-terminated entry in: %q", data)
+	}
+	var entry audit.Entry
+	if err := json.Unmarshal(data[:nl], &entry); err != nil {
+		t.Fatalf("failed to parse audit entry: %v\nraw: %s", err, data)
+	}
+	if entry.Action != audit.ActionAllocate {
+		t.Errorf("Action = %q, want %q", entry.Action, audit.ActionAllocate)
+	}
+	if entry.Success {
+		t.Error("Success = true, want false")
+	}
+	if entry.ProjectName != projectName {
+		t.Errorf("ProjectName = %q, want %q", entry.ProjectName, projectName)
 	}
 }
 

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -18,6 +18,7 @@ package audit
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -52,6 +53,7 @@ func TestAuditLogger(t *testing.T) {
 	logger.LogQuotaCreate("pv-test-1", "default", "pvc-test-1", "/data/test-1", "project_test_1", 1001, 1024*1024*1024, "xfs", nil)
 	logger.LogQuotaUpdate("pv-test-2", "/data/test-2", "project_test_2", 1002, 512*1024*1024, 1024*1024*1024, "xfs", nil)
 	logger.LogQuotaDelete("pv-test-3", "/data/test-3", "project_test_3", 1003, nil)
+	logger.LogProjectIDAllocationFailure("pv-test-4", "default", "pvc-test-4", "/data/test-4", "project_test_4", errors.New("project ID range exhausted"))
 
 	// Close and verify
 	logger.Close()
@@ -91,8 +93,61 @@ func TestAuditLogger(t *testing.T) {
 		}
 	}
 
-	if lines != 3 {
-		t.Errorf("Expected 3 log entries, got %d", lines)
+	if lines != 4 {
+		t.Errorf("Expected 4 log entries, got %d", lines)
+	}
+}
+
+// TestLogProjectIDAllocationFailure guards #15's "allocation/release/reuse/
+// collision 이벤트가 audit에 남는다" acceptance item for the allocation-failure
+// case specifically: ensureQuota's generateProjectID error path returns
+// before it ever has a projectID to pass to LogQuotaCreate, so a distinct
+// method (and entry shape) is needed rather than reusing LogQuotaCreate with
+// a zero project ID, which would be indistinguishable from a real ID 0.
+func TestLogProjectIDAllocationFailure(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "audit-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logPath := filepath.Join(tmpDir, "audit.log")
+	logger, err := NewLogger(Config{Enabled: true, FilePath: logPath, MaxFileSize: 10 * 1024 * 1024})
+	if err != nil {
+		t.Fatalf("Failed to create audit logger: %v", err)
+	}
+
+	logger.LogProjectIDAllocationFailure("pv-exhausted", "ns", "pvc-exhausted", "/data/exhausted", "project_exhausted", errors.New("project ID range exhausted"))
+	logger.Close()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("Failed to read audit log: %v", err)
+	}
+
+	var entry Entry
+	lines := splitLines(data)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", len(lines))
+	}
+	if err := json.Unmarshal(lines[0], &entry); err != nil {
+		t.Fatalf("failed to parse audit entry: %v", err)
+	}
+
+	if entry.Action != ActionAllocate {
+		t.Errorf("Action = %q, want %q", entry.Action, ActionAllocate)
+	}
+	if entry.Success {
+		t.Error("Success = true, want false for an allocation failure")
+	}
+	if entry.Error == "" {
+		t.Error("Error should be populated")
+	}
+	if entry.ProjectID != 0 {
+		t.Errorf("ProjectID = %d, want 0 (never allocated)", entry.ProjectID)
+	}
+	if entry.PVName != "pv-exhausted" || entry.Namespace != "ns" || entry.PVCName != "pvc-exhausted" || entry.Path != "/data/exhausted" || entry.ProjectName != "project_exhausted" {
+		t.Errorf("unexpected entry fields: %+v", entry)
 	}
 }
 

--- a/internal/audit/entry.go
+++ b/internal/audit/entry.go
@@ -22,10 +22,11 @@ import "time"
 type Action string
 
 const (
-	ActionCreate  Action = "CREATE"
-	ActionUpdate  Action = "UPDATE"
-	ActionDelete  Action = "DELETE"
-	ActionCleanup Action = "CLEANUP"
+	ActionCreate   Action = "CREATE"
+	ActionUpdate   Action = "UPDATE"
+	ActionDelete   Action = "DELETE"
+	ActionCleanup  Action = "CLEANUP"
+	ActionAllocate Action = "ALLOCATE"
 )
 
 // Entry represents a single audit log entry

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -154,6 +154,27 @@ func (l *Logger) LogQuotaCreate(pvName, namespace, pvcName, path, projectName st
 	}
 }
 
+// LogProjectIDAllocationFailure logs a failure to allocate a project ID for
+// path (e.g. exhaustion of the configured ID range) -- distinct from
+// LogQuotaCreate/LogQuotaUpdate, which both require a projectID that, by
+// definition, doesn't exist yet when allocation itself is what failed. Only
+// ever called with a non-nil err; Success is always false.
+func (l *Logger) LogProjectIDAllocationFailure(pvName, namespace, pvcName, path, projectName string, err error) {
+	entry := Entry{
+		Action:      ActionAllocate,
+		PVName:      pvName,
+		Namespace:   namespace,
+		PVCName:     pvcName,
+		Path:        path,
+		ProjectName: projectName,
+		Success:     false,
+		Error:       err.Error(),
+	}
+	if err := l.Log(entry); err != nil {
+		slog.Warn("Failed to write audit log entry", "action", entry.Action, "error", err)
+	}
+}
+
 // LogQuotaUpdate logs quota update
 func (l *Logger) LogQuotaUpdate(pvName, path, projectName string, projectID uint32, oldQuota, newQuota int64, fsType string, err error) {
 	entry := Entry{


### PR DESCRIPTION
## Summary
- Contributes to #15's "allocation/release/reuse/collision 이벤트가 audit에 남는다" acceptance item.
- Collision rejection was already audited (`AddProject`'s `ErrProjectConflict` flows through to `LogQuotaCreate`/`LogQuotaUpdate`'s `err` parameter), but **exhaustion was not**: `ensureQuota` returns immediately after `generateProjectID` fails, before reaching the audit-logging block further down — there's no `projectID` yet to log. A PV that never got its quota applied because the ID range was exhausted left zero trace in the audit log, only an application-level `slog` line and the PV's own `Failed` status annotation.
- Added `audit.Logger.LogProjectIDAllocationFailure` and a new `ActionAllocate` entry type, called from `ensureQuota`'s `generateProjectID` error branch.

## Test plan
- [x] `TestLogProjectIDAllocationFailure` (new, `internal/audit`) — asserts the entry shape (Action, Success=false, Error populated, ProjectID=0)
- [x] `TestEnsureQuota_ProjectIDExhaustionIsAudited` (new, `internal/agent`) — drives `ensureQuota` end-to-end with an exhausted ID range, asserts an audit entry lands
- [x] Mutation-verified: removing the new audit call makes the new agent-level test fail cleanly ("expected an audit entry ... got no newline-terminated entry"); restoring it passes
- [x] `go build/vet/test -race`, `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT