### PR TITLE
docs(contributing): add make target <-> CI job mapping table

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,13 +13,27 @@ We use a `Makefile` to automate common development workflows. The primary make t
 - `make fmt`           - Formats code according to standards using `go fmt`.
 - `make vet`           - Runs static analysis check via `go vet`.
 - `make lint`          - Runs quality checks via `golangci-lint` (if installed).
-- `make license`       - Regenerates `THIRD_PARTY_LICENSES.md` from `go.mod`/`go.sum` and fails on forbidden/unknown dependency licenses.
+- `make license`       - Regenerates `THIRD_PARTY_LICENSES.md` from `go.mod`/`go.sum` and fails if any dependency's license isn't in `hack/allowed-licenses.txt`.
 - `make sbom`          - Generates an SBOM (SPDX + CycloneDX) for the Go dependency tree via `trivy` (if installed).
 - `make generate`      - Regenerates deepcopy code and the CRD manifest for `internal/apis/quota/v1alpha1` via `controller-gen`.
 
 If a PR changes `go.mod` or `go.sum`, run `make license` and commit the regenerated `THIRD_PARTY_LICENSES.md` — CI fails the `License Check` job if it goes stale.
 
 If a PR changes `internal/apis/quota/v1alpha1/types.go`, run `make generate` and commit the regenerated `zz_generated.deepcopy.go` and `charts/nfs-quota-agent/crds/quota.nfs.io_quotapolicies.yaml` — CI fails the `Generate Check` job if either goes stale. Never hand-edit either generated file; fix the kubebuilder markers in `types.go` and regenerate instead.
+
+### Make target ↔ CI job mapping
+
+Every job in [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml) has a local equivalent you can run before pushing, except where noted:
+
+| CI job | Local equivalent |
+|---|---|
+| `Test` | `make test-coverage` (CI additionally runs with `-race`: `go test -race ./...`) |
+| `Lint` | `make lint` (CI pins `golangci-lint` to the version in `ci.yaml`'s `version:` field — install the same version locally with `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@<version>` to avoid false negatives/positives from a version drift) |
+| `Build` | `make build-linux` (CI builds `linux/amd64` + `linux/arm64` only; `build-linux` additionally builds `linux/arm/v7`) |
+| `License Check` | `make license` (regenerates `THIRD_PARTY_LICENSES.md` in place and checks every dependency's license against `hack/allowed-licenses.txt`; if the file changed, `git diff` shows what CI's separate staleness check would have failed on — commit the update) |
+| `Generate Check` | `make generate`, then `git diff --exit-code` on `internal/apis/quota/v1alpha1/zz_generated.deepcopy.go` and `charts/nfs-quota-agent/crds/quota.nfs.io_quotapolicies.yaml` |
+| `Helm Lint` | `make helm-lint`, then `helm template ./charts/nfs-quota-agent --set metrics.serviceMonitor.enabled=true --set metrics.prometheusRule.enabled=true --set podDisruptionBudget.enabled=true` for the same smoke-test coverage CI runs |
+| `Security Scan` | **No local make target yet, and `govulncheck` is not a `go tool` dependency of this module** (unlike `go-licenses`/`controller-gen`). CI runs `aquasecurity/trivy-action` (filesystem scan) and `golang/govulncheck-action`; reproduce manually with `trivy fs .` (if `trivy` is installed) and `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`. Tracked as a gap in #16. |
 
 ## Testing Conventions
 


### PR DESCRIPTION
## Summary
- Contributes to #16's "Make target과 CI stage mapping이 문서화된다" acceptance item (flagged partial in an earlier comment).
- Added one row per CI job (`.github/workflows/ci.yaml`) mapping it to its local `make`/command equivalent, verifying each command actually runs.
- Found and documented a real gap: `govulncheck` isn't a `go tool` dependency of this module, so "Security Scan" has no local make target today — said so plainly instead of implying parity.
- Fixed a stale line: `make license` was still described as failing on "forbidden/unknown dependency licenses" (the old default classification), superseded by the explicit `hack/allowed-licenses.txt` allowlist from an earlier PR this session.

## Test plan
- [x] Ran every command in the new table locally: `make test-coverage`, `make lint`, `make build-linux`, `make license`, `make generate` + diff, `make helm-lint` + the chart's smoke-test template invocation, and the suggested `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` fallback for Security Scan
- [x] `go build/vet/test`, `golangci-lint run` clean (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT