### PR TITLE
build(docker): pin base images to digests, add dependabot docker ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,22 @@ updates:
     commit-message:
       prefix: "ci"
 
-  # Deliberately NOT enabling the gomod or docker ecosystems here.
-  # CI fails the License Check job whenever THIRD_PARTY_LICENSES.md is
-  # stale relative to go.mod (.github/workflows/ci.yaml), and `make license`
-  # has to be run and committed by hand. A gomod ecosystem would therefore
-  # open dependency PRs that are red on arrival, every week, training
-  # everyone to ignore a gate that exists to catch real license changes.
-  # Enable it only together with automation that regenerates the inventory
-  # in the same PR.
+  # Dockerfile's two FROM lines are pinned to digests, not floating tags
+  # (golang:1.26-alpine, alpine:3.21) -- same trade as github-actions above:
+  # pinning closes the repointable-tag risk but freezes the base image
+  # permanently without something proposing updates.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build"
+
+  # Deliberately NOT enabling the gomod ecosystem here. CI fails the
+  # License Check job whenever THIRD_PARTY_LICENSES.md is stale relative to
+  # go.mod (.github/workflows/ci.yaml), and `make license` has to be run
+  # and committed by hand. A gomod ecosystem would therefore open
+  # dependency PRs that are red on arrival, every week, training everyone
+  # to ignore a gate that exists to catch real license changes. Enable it
+  # only together with automation that regenerates the inventory in the
+  # same PR.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26-alpine@sha256:28d89ee9cc0ff9fec75c82ca201e6bf7fdf9a679d4b7b24dfa04f2bb766bb468 AS builder
 
 RUN apk add --no-cache git
 
@@ -16,7 +16,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o /nfs-quota-agent ./cmd/nfs-quota-agent
 
 # Runtime stage
-FROM alpine:3.21
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
 LABEL maintainer="dasomell@gmail.com" \
       org.opencontainers.image.licenses="Apache-2.0" \
@@ -31,8 +31,12 @@ LABEL maintainer="dasomell@gmail.com" \
 # quota.CommandRunner), never linked into the Go binary. Record the exact
 # installed name-version and license of each here, at build time, so the
 # Corresponding Source pointer in NOTICE always matches what actually
-# shipped in this image — apk pulls whatever alpine:3.21 currently carries,
-# which drifts with upstream security patches even though the tag is pinned.
+# shipped in this image. The base image is now pinned to a digest (see the
+# FROM line above), not a floating tag, so apk resolves against a fixed
+# package index rather than one that silently drifts with upstream security
+# patches -- dependabot.yml's docker ecosystem is what keeps that digest
+# from going stale, proposing a bump (and therefore a fresh manifest here)
+# on its own schedule rather than never updating at all.
 # An empty manifest would mean shipping GPL binaries with no record of which
 # source corresponds to them, so verify it came out non-empty and fail the build
 # loudly rather than letting grep's exit status decide, or silencing it with


### PR DESCRIPTION
## Summary
- Contributes to #26's "Pin toolchains, builder images, GitHub Actions and downloaded utilities to immutable versions/digests. Reject latest/floating release inputs" — the GitHub Actions half was done earlier this session (18 actions SHA-pinned); the Dockerfile's two `FROM` lines were still floating tags (`golang:1.26-alpine`, `alpine:3.21`), the same repointable-tag risk in the container base image instead of a workflow step.
- Pinned both to the digest their tag currently resolves to, verified via `docker buildx imagetools inspect` to be the OCI image **index** digest covering the full `linux/amd64`+`arm64`+`arm/v7` manifest list `release.yaml`'s buildx build needs — not a single-arch digest that would silently break non-amd64 builds.
- Added the `docker` ecosystem to `dependabot.yml`, same trade as the `github-actions` entry: pinning closes the compromise risk but freezes the image permanently without something proposing updates.

## Test plan
- [x] `docker build .` succeeds with both digests pinned
- [x] Resulting image runs — `docker run --rm <image> --help` produces real CLI output
- [x] The image's own non-empty-file check for the OS package license manifest passes for real (11 lines, GPL/LGPL/BSD/MIT entries present)
- [x] `go build/vet/test`, `golangci-lint run` clean (unrelated to this change, confirmed nothing else broke)
- [x] `.github/dependabot.yml` validated as parseable YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT