### PR TITLE
fix(quota): reject a path claimed under a second project ID

### DIFF
--- a/internal/quota/project.go
+++ b/internal/quota/project.go
@@ -89,8 +89,9 @@ func AddProject(path, projectName string, projectID uint32, projectsFile, projid
 // agrees with whatever projectsFile and projidFile currently record, without
 // writing anything. projidFile and projectsFile are both keyed by project
 // ID (ReadProjidFile/ReadProjectsFile already return id -> value maps), so
-// the ID-keyed checks are a single map lookup; the name -> ID direction
-// requires a scan since projid has no reverse index.
+// the ID-keyed checks are a single map lookup; the name -> ID and path -> ID
+// directions each require a scan since neither file carries a reverse
+// index.
 func checkProjectIdentityConflict(path, projectName string, projectID uint32, projectsFile, projidFile string) error {
 	projidByID, err := ReadProjidFile(projidFile) // id -> name
 	if err != nil {
@@ -107,6 +108,22 @@ func checkProjectIdentityConflict(path, projectName string, projectID uint32, pr
 		if name == projectName && id != idStr {
 			return fmt.Errorf("%w: project name %q is already mapped to id %s in %s, refusing to also map it to id %d",
 				ErrProjectConflict, projectName, id, projidFile, projectID)
+		}
+	}
+
+	// path -> id: the reverse of the id -> path check below. Without this,
+	// two AddProject calls for the same path under different ids both pass
+	// individually (each id has no prior path recorded yet) and the path
+	// ends up listed under both — the case the PV rebind/replacement /
+	// nfs.io/project-name-rename in #15's own investigation describes, not
+	// a corrupted-file edge case. A directory can only carry one XFS/ext4
+	// project id at a time, so the losing entry silently goes stale the
+	// moment either id's quota is actually applied, while /etc/projects
+	// keeps listing both as if they were live.
+	for id, existingPath := range projectsByID {
+		if existingPath == path && id != idStr {
+			return fmt.Errorf("%w: path %q is already mapped to id %s in %s, refusing to also map it to id %d",
+				ErrProjectConflict, path, id, projectsFile, projectID)
 		}
 	}
 

--- a/internal/quota/project_test.go
+++ b/internal/quota/project_test.go
@@ -119,6 +119,67 @@ func TestAddProject_IDRemappedToDifferentPath(t *testing.T) {
 	}
 }
 
+// TestAddProject_PathRemappedToDifferentID covers the fourth direction the
+// other three checks don't: the same path claimed under a second, different
+// id. This is #15's own "path -> ID 방향 검증" gap, reachable without any
+// file corruption -- an nfs.io/project-name annotation rename on a PV keeps
+// the same NFS path but generates a new name, and therefore (via
+// generateProjectID) a new id, for the exact same directory. A directory
+// can only carry one XFS/ext4 project id at a time, so without this check
+// /etc/projects would end up listing the same path under two ids, one of
+// which goes stale as soon as either quota is actually applied.
+func TestAddProject_PathRemappedToDifferentID(t *testing.T) {
+	dir := t.TempDir()
+	projectsFile := filepath.Join(dir, "projects")
+	projidFile := filepath.Join(dir, "projid")
+
+	if err := AddProject("/export/pvc-a", "pvc_a", 3, projectsFile, projidFile); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+
+	// Same path, different name+id -- simulates an annotation rename.
+	err := AddProject("/export/pvc-a", "pvc_a_renamed", 7, projectsFile, projidFile)
+	if err == nil {
+		t.Fatal("expected an error when a path is remapped to a different id")
+	}
+	if !errors.Is(err, ErrProjectConflict) {
+		t.Errorf("expected ErrProjectConflict, got: %v", err)
+	}
+
+	projectsData, _ := os.ReadFile(projectsFile)
+	if string(projectsData) != "3:/export/pvc-a\n" {
+		t.Errorf("projects file must be left unmodified (no second id claiming the same path), got %q", string(projectsData))
+	}
+	projidData, _ := os.ReadFile(projidFile)
+	if strings.Contains(string(projidData), "pvc_a_renamed") {
+		t.Errorf("projid file must not have been written for the rejected conflict, got %q", string(projidData))
+	}
+}
+
+// TestAddProject_SameIDSamePathIsIdempotent guards against the new path->id
+// check in TestAddProject_PathRemappedToDifferentID above rejecting the
+// ordinary case it must not touch: re-adding the exact same (path, name,
+// id) tuple -- e.g. a resync re-processing a PV whose quota is already
+// applied -- has to stay a no-op, not start erroring because the path is
+// "already mapped" to the very id being requested.
+func TestAddProject_SameIDSamePathIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	projectsFile := filepath.Join(dir, "projects")
+	projidFile := filepath.Join(dir, "projid")
+
+	if err := AddProject("/export/pvc-a", "pvc_a", 3, projectsFile, projidFile); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	if err := AddProject("/export/pvc-a", "pvc_a", 3, projectsFile, projidFile); err != nil {
+		t.Fatalf("expected the identical re-add to be a no-op, got: %v", err)
+	}
+
+	projectsData, _ := os.ReadFile(projectsFile)
+	if string(projectsData) != "3:/export/pvc-a\n" {
+		t.Errorf("projects file should be unchanged after an idempotent re-add, got %q", string(projectsData))
+	}
+}
+
 // Colon/newline-in-name rejection at the AddProject level (neither file
 // touched) is covered by TestAddProjectRejectsDelimiterInName, and the
 // ordinary-name-still-works case by TestAddProjectAcceptsOrdinaryName, both


### PR DESCRIPTION
## Summary

Closes #15's own flagged gap: "path→ID 방향 검증 — 이번에 검증한 3개 조건 밖". The name→id, id→name, and id→path identity checks (PR #27) validate three of the four directions between a project's name/ID/path triple, but nothing stopped the same **path** from being claimed under a second, different ID.

## Reproduced first (no file corruption needed)

Renaming a PV's `nfs.io/project-name` annotation keeps its NFS path unchanged but generates a new name — and therefore, via `generateProjectID`, a new project ID — for the same directory:

```
AddProject("/export/pvc-a", "pvc_a", 3, ...)          -> ok
AddProject("/export/pvc-a", "pvc_a_renamed", 7, ...)  -> ok (before this fix)

projects: 3:/export/pvc-a
          7:/export/pvc-a
```

A directory can only carry one XFS/ext4 project ID at a time, so one entry goes stale the moment either ID's quota is actually applied — but `/etc/projects` keeps listing both as if live. Reachable through ordinary operation, not just file damage.

## Fix

Added the fourth direction (path→id) to `checkProjectIdentityConflict`, same rejection shape as the other three (`ErrProjectConflict`, neither file touched when it fires).

## Independent review

This touches `/etc/projects`/`/etc/projid` writes — CLAUDE.md's highest-risk path — so I got an independent opus review. It reproduced the defect itself (before/after), confirmed no new concurrency assumption (`AddProject` is only called from `xfs.go`/`ext4.go`, both serialized under `ensureQuota`'s `a.mu`), and confirmed the idempotent re-add case is unaffected.

It also surfaced a related, separate finding worth tracking on its own (not fixed here, flagging on #10): `internal/agent/orphan.go` discards `RemoveLineFromFile`'s error on both its calls (`_ = quota.RemoveLineFromFile(...)`). If a `projects`-file deletion during orphan cleanup fails, the stale entry it leaves behind would now be *permanently* rejected under any new ID trying to claim that path — safer than the prior silent corruption, but not self-healing.

## Test plan

- [x] Reproduced the defect directly against temp files before the fix
- [x] `TestAddProject_PathRemappedToDifferentID` (new) — mutation-verified: comment out the new check, confirm it fails; restore, confirm it passes
- [x] `TestAddProject_SameIDSamePathIsIdempotent` (new) — guards the idempotent re-add case the new check must not break
- [x] `go build/vet/test -race`, `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT