### PR TITLE
fix(agent): stop discarding orphan metadata-cleanup errors

### DIFF
--- a/internal/agent/orphan.go
+++ b/internal/agent/orphan.go
@@ -18,6 +18,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -218,7 +219,17 @@ func (a *QuotaAgent) trackOrphan(path, dirName string, now time.Time) *ui.Orphan
 // RemoveOrphan removes an orphaned directory
 func (a *QuotaAgent) RemoveOrphan(orphan ui.OrphanInfo) error {
 	if a.fsType != "" {
-		a.removeQuotaForPath(orphan.Path)
+		// A failure here leaves a stale projects/projid entry rather than a
+		// corrupted one (RemoveLineFromFile's own crash-recovery already
+		// guards the file), so it does not block removing the directory --
+		// but it must not vanish silently either, or nothing ever explains
+		// why that path's project ID later gets rejected by
+		// checkProjectIdentityConflict's path->id check when a new PV
+		// claims the same path.
+		if err := a.removeQuotaForPath(orphan.Path); err != nil {
+			slog.Error("Failed to remove project metadata for orphan; directory removal will still proceed",
+				"path", orphan.Path, "error", err)
+		}
 	}
 
 	if err := os.RemoveAll(orphan.Path); err != nil {
@@ -241,10 +252,10 @@ func (a *QuotaAgent) RemoveOrphan(orphan ui.OrphanInfo) error {
 }
 
 // removeQuotaForPath removes quota for a specific path
-func (a *QuotaAgent) removeQuotaForPath(path string) {
+func (a *QuotaAgent) removeQuotaForPath(path string) error {
 	projectsData, err := os.ReadFile(a.projectsFile)
 	if err != nil {
-		return
+		return nil
 	}
 
 	var projectID string
@@ -263,7 +274,7 @@ func (a *QuotaAgent) removeQuotaForPath(path string) {
 	}
 
 	if projectID == "" {
-		return
+		return nil
 	}
 
 	projidData, err := os.ReadFile(a.projidFile)
@@ -281,11 +292,18 @@ func (a *QuotaAgent) removeQuotaForPath(path string) {
 		}
 	}
 
-	_ = quota.RemoveLineFromFile(a.projectsFile, projectID+":", a.stateDir)
+	var errs []error
+	if err := quota.RemoveLineFromFile(a.projectsFile, projectID+":", a.stateDir); err != nil {
+		errs = append(errs, fmt.Errorf("remove project id %s from %s: %w", projectID, a.projectsFile, err))
+	}
 
 	if projectName != "" {
-		_ = quota.RemoveLineFromFile(a.projidFile, projectName+":", a.stateDir)
+		if err := quota.RemoveLineFromFile(a.projidFile, projectName+":", a.stateDir); err != nil {
+			errs = append(errs, fmt.Errorf("remove project name %s from %s: %w", projectName, a.projidFile, err))
+		}
 	}
+
+	return errors.Join(errs...)
 }
 
 // GetOrphans returns list of orphaned directories (for API)

--- a/internal/agent/orphan_test.go
+++ b/internal/agent/orphan_test.go
@@ -228,7 +228,86 @@ func TestRemoveQuotaForPath(t *testing.T) {
 	}
 
 	// Unknown path should be a no-op, not a panic.
-	a.removeQuotaForPath("/no/such/path")
+	if err := a.removeQuotaForPath("/no/such/path"); err != nil {
+		t.Fatalf("unknown path should be a no-op, got error: %v", err)
+	}
+}
+
+// TestRemoveQuotaForPathSurfacesRemoveLineFromFileFailure guards the fix for
+// the bug flagged on nfs-quota-agent#10: removeQuotaForPath used to discard
+// both of its RemoveLineFromFile errors (`_ = quota.RemoveLineFromFile(...)`),
+// so a partial metadata cleanup during orphan removal left a stale
+// projects/projid entry with nothing in the logs to explain why -- and, since
+// PR #56 added the path->id identity check, that stale entry now makes any
+// new PV that later claims the same path get permanently rejected.
+func TestRemoveQuotaForPathSurfacesRemoveLineFromFileFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: file permission bits are not enforced, so the injected failure would not occur")
+	}
+	a := newTestAgent(t, fake.NewSimpleClientset())
+
+	if err := os.WriteFile(a.projectsFile, []byte("5:/data/x\n"), 0644); err != nil {
+		t.Fatalf("write projects: %v", err)
+	}
+	if err := os.WriteFile(a.projidFile, []byte("myproj:5\n"), 0644); err != nil {
+		t.Fatalf("write projid: %v", err)
+	}
+
+	// RemoveLineFromFile rewrites the file in place; making it read-only
+	// makes that rewrite fail while the earlier os.ReadFile lookups (which
+	// only need read access) still succeed.
+	if err := os.Chmod(a.projectsFile, 0444); err != nil {
+		t.Fatalf("chmod projects read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(a.projectsFile, 0644) })
+
+	err := a.removeQuotaForPath("/data/x")
+	if err == nil {
+		t.Fatalf("expected removeQuotaForPath to surface the RemoveLineFromFile failure, got nil")
+	}
+	if !strings.Contains(err.Error(), a.projectsFile) {
+		t.Fatalf("expected error to name the file that failed (%s), got %q", a.projectsFile, err.Error())
+	}
+
+	projects, readErr := os.ReadFile(a.projectsFile)
+	if readErr != nil {
+		t.Fatalf("read projects: %v", readErr)
+	}
+	if !strings.Contains(string(projects), "5:/data/x") {
+		t.Fatalf("failed rewrite should have left the original entry in place, got %q", projects)
+	}
+}
+
+func TestRemoveOrphanProceedsWhenMetadataCleanupFails(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: file permission bits are not enforced, so the injected failure would not occur")
+	}
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.fsType = quota.FSTypeXFS
+
+	dir := filepath.Join(a.nfsBasePath, "to-remove")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	a.orphanLastSeen[dir] = time.Now()
+
+	if err := os.WriteFile(a.projectsFile, []byte("5:"+dir+"\n"), 0644); err != nil {
+		t.Fatalf("write projects: %v", err)
+	}
+	if err := os.Chmod(a.projectsFile, 0444); err != nil {
+		t.Fatalf("chmod projects read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(a.projectsFile, 0644) })
+
+	// A metadata-cleanup failure must not block directory removal: the
+	// directory is real and orphaned regardless of whether its stale
+	// projects/projid entry could be cleaned up.
+	if err := a.RemoveOrphan(ui.OrphanInfo{Path: dir, DirName: "to-remove"}); err != nil {
+		t.Fatalf("RemoveOrphan should still succeed when only metadata cleanup fails: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("expected directory to be removed despite the metadata cleanup failure")
+	}
 }
 
 func TestRunAutoCleanupTicks(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the finding flagged on #10 during PR #56's opus review: `removeQuotaForPath` (`internal/agent/orphan.go`) discarded both of its `RemoveLineFromFile` errors.

```go
_ = quota.RemoveLineFromFile(a.projectsFile, projectID+":", a.stateDir)
if projectName != "" {
    _ = quota.RemoveLineFromFile(a.projidFile, projectName+":", a.stateDir)
}
```

If a `projects`/`projid` line removal fails during orphan cleanup, the stale entry stayed in the file with nothing in the logs to explain why. Since PR #56 (#15) added the path→id identity check, that stale entry now makes any new PV that later claims the same path get **permanently** rejected by `checkProjectIdentityConflict` — safer than the prior silent corruption, but not self-healing, and previously invisible.

## Fix

`removeQuotaForPath` now returns the joined errors from both `RemoveLineFromFile` calls instead of discarding them. `RemoveOrphan` logs the failure via `slog.Error` but still proceeds to remove the directory — the directory is orphaned regardless of whether its metadata could be cleaned up, and this keeps the existing behavior of not blocking cleanup on a metadata write failure (same design tradeoff PR #25 already made for `/etc/projects`/`/etc/projid` being individually bind-mounted, not atomically replaceable).

## Test plan

- [x] `TestRemoveQuotaForPathSurfacesRemoveLineFromFileFailure` (new) — makes `projects` read-only so the rewrite fails while the earlier read succeeds; mutation-verified (reverted the fix, confirmed the test fails for the right reason: `got nil` instead of the file-permission error; restored, confirmed it passes)
- [x] `TestRemoveOrphanProceedsWhenMetadataCleanupFails` (new) — confirms directory removal still proceeds when metadata cleanup fails
- [x] Existing `TestRemoveQuotaForPath`/`TestRemoveOrphan` still pass unchanged
- [x] `go build/vet/test -race`, `gofmt -l .`, `golangci-lint run` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT