### PR TITLE
feat(agent): HA active/standby quota mutation gate

### DIFF
--- a/charts/nfs-quota-agent/templates/daemonset.yaml
+++ b/charts/nfs-quota-agent/templates/daemonset.yaml
@@ -65,6 +65,9 @@ spec:
             - --provisioner-name={{ .Values.config.provisionerName }}
             - --sync-interval={{ .Values.config.syncInterval }}
             - --state-dir={{ .Values.state.path }}
+            {{- if .Values.ha.activeFile }}
+            - --ha-active-file={{ .Values.ha.activeFile }}
+            {{- end }}
             {{- if .Values.config.metricsAddr }}
             - --metrics-addr={{ .Values.config.metricsAddr }}
             {{- end }}

--- a/charts/nfs-quota-agent/values.yaml
+++ b/charts/nfs-quota-agent/values.yaml
@@ -78,6 +78,18 @@ state:
   # unless you know why you're changing it.
   path: /var/lib/nfs-quota-agent
 
+# NFS server active/standby HA gate -- see docs/ha-dr.md. This agent does
+# not implement election, fencing, or replication itself: it only refuses
+# quota mutation when the given file is absent. An external HA tool
+# (Pacemaker resource agent, a DRBD promote/demote hook, a custom script)
+# creates/removes the file to declare this node active/standby.
+ha:
+  # Empty (default) disables HA gating entirely -- this instance always
+  # enforces, unchanged from every release before this flag existed. Set
+  # to a path under state.path (already a host-backed volume, no extra
+  # mount needed) to enable, e.g. "/var/lib/nfs-quota-agent/ha-active".
+  activeFile: ""
+
 # Usage history and trend tracking
 history:
   enabled: false

--- a/cmd/nfs-quota-agent/main.go
+++ b/cmd/nfs-quota-agent/main.go
@@ -172,6 +172,9 @@ func runAgent(args []string) {
 		// QuotaPolicy (quota.nfs.io/v1alpha1) options
 		enableQuotaPolicy       bool
 		quotaPolicySingleWriter bool
+
+		// HA active/standby options (#11)
+		haActiveFile string
 	)
 
 	fs.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (optional, uses in-cluster config if not set)")
@@ -228,6 +231,16 @@ func runAgent(args []string) {
 	// this to true — do so only when exactly one --enable-quota-policy
 	// agent runs in the cluster.
 	fs.BoolVar(&quotaPolicySingleWriter, "quota-policy-single-writer", false, "Declare this the only QuotaPolicy-enabled agent in the cluster, enabling status write-back (see docs/quotapolicy-design.md)")
+
+	// HA active/standby flag (#11). Empty (default) disables HA gating
+	// entirely, so existing single-node/no-HA deployments are unaffected.
+	// This agent does not implement election, fencing, or replication
+	// itself -- it only reads whether the given path exists. An external
+	// HA tool (a Pacemaker resource agent, a DRBD promote/demote hook, a
+	// custom script) creates/removes that file to declare this node
+	// active/standby. Point it at a path under --state-dir, which is
+	// already a host-backed volume in the chart.
+	fs.StringVar(&haActiveFile, "ha-active-file", "", "Path whose existence marks this instance as the active HA owner of quota enforcement; a standby instance (path absent) refuses all quota mutation. Empty disables HA gating (default)")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: nfs-quota-agent run [flags]")
@@ -292,6 +305,7 @@ func runAgent(args []string) {
 	// never turns this on.
 	ag.SetQuotaPolicyEnabled(enableQuotaPolicy)
 	ag.SetQuotaPolicySingleWriter(quotaPolicySingleWriter)
+	ag.SetHAActiveFile(haActiveFile)
 	if enableQuotaPolicy {
 		dynamicClient, err := dynamic.NewForConfig(config)
 		if err != nil {

--- a/docs/ha-dr.md
+++ b/docs/ha-dr.md
@@ -1,0 +1,226 @@
+# NFS Server HA/DR — Active/Standby Quota Mutation Gate
+
+Status: `--ha-active-file` implements the acceptance item every other #11
+item depends on ("standby agent는 ownership이 확인되기 전 quota mutation을
+수행하지 않는다") plus a failover reconciliation trigger independent of
+`--sync-interval`'s cadence. Implementation is
+[`internal/agent/ha.go`](../internal/agent/ha.go); the gate call sites are
+`ensureQuota` and `RemoveOrphan` (`internal/agent/agent.go`,
+`internal/agent/orphan.go`), plus the web UI's orphan-delete handlers
+(`internal/ui/server.go`). Everything else #11 asked for — fencing
+enforcement, read-back verification, RPO/RTO measurement, a replication
+backend compatibility matrix, split-brain testing — is **not**
+implemented; see §6.
+
+This design was reviewed independently before merge (per this repo's
+practice for concurrency-sensitive/safety-critical changes — see
+`CLAUDE.md`), which found and led to fixing three real defects: a
+QuotaPolicy status "applied lie" on standby (§3), the failover trigger
+racing `syncAllQuotas` onto a second goroutine (§3), and the same trigger
+silently reconciling nothing because of a stale cache (§3). What follows
+describes the reviewed, fixed design — see the PR history for the
+pre-review version if you want the contrast.
+
+## 1. What this agent does and does not own
+
+`nfs-quota-agent` reconciles Kubernetes PV state with local filesystem
+project quotas on one NFS server node. It has never implemented, and this
+change does not add, NFS data replication, cluster membership, leader
+election, or fencing. Those are the job of an external HA/DR layer —
+DRBD, storage-array replication, Pacemaker, a custom failover script —
+and always will be: see #11's own "범위 제외" (out of scope) list.
+
+What this agent *can* own is narrower and mechanical: given an external
+signal saying "you are (not) the active node," stop mutating shared quota
+metadata (`/etc/projects`, `/etc/projid`, actual filesystem quota limits)
+when that signal says standby. That's the whole of what's implemented
+here.
+
+## 2. The signal: a file, not a protocol
+
+`--ha-active-file <path>` (env/flag, default empty = disabled) points at
+a path this agent only ever *reads*, never writes. Its existence means
+"this instance is active"; its absence means "standby, refuse mutation."
+`HAActive()` (`internal/agent/ha.go`) is the read; nothing in this
+package creates, removes, or touches the file.
+
+Why a file and not a Kubernetes `Lease` or similar API object: this
+problem is about NFS *server*-level active/standby (see #11's title), a
+concept that already has mature, external tooling (Pacemaker resource
+agents, DRBD `promote`/`demote` hooks) built around exactly this
+primitive — a promote/demote script that creates or removes a marker
+file is the natural integration point, requires no new RBAC, and works
+whether or not the fencing layer is Kubernetes-aware at all. A `Lease`
+would tie this agent's HA behavior to the Kubernetes API being reachable,
+which is an availability dependency the NFS-server-level failover this
+issue is about shouldn't need. See #11's design principles: "split-brain에서
+두 agent가 동시에 quota mutation을 수행하지 않도록 fencing/ownership gate를
+둔다" — provide the gate, not the fencing decision.
+
+Point `--ha-active-file` (`ha.activeFile` in the Helm chart) at a path
+under `--state-dir` (`/var/lib/nfs-quota-agent` by default), which is
+already a host-backed volume in the chart (see the PR #25 comment in
+`internal/quota/project.go` for why that volume exists and is mounted the
+way it is) — no new volume mount is needed as long as the promote/demote
+script and the agent container can both reach that host path.
+
+## 3. What "gate" actually means here
+
+- `ensureQuota` (`internal/agent/agent.go`) checks `HAActive()` before
+  taking `a.mu`, before doing anything else. Standby: log at Debug, return
+  `ErrHAStandby` — **not** `nil`. An earlier version of this returned `nil`
+  (the same "skip, not an error" convention `ensureQuota` uses for a PV
+  whose local directory doesn't exist yet), which an independent review
+  caught as a real bug: `syncAllQuotas`'s QuotaPolicy accounting
+  (`recordEnforcement`, `policy.go`) treats a `nil` `ensureQuota` error as
+  a successfully applied claim, so a standby node was publishing
+  `Applied=True` on QuotaPolicy status while enforcing nothing — the exact
+  "applied lie" class `docs/quotapolicy-design.md` §11 and
+  `zz_f7_applied_lie_test.go` already exist to prevent for the
+  missing-local-directory case. `ErrHAStandby` gets its own
+  `v1alpha1.ReasonHAStandby` in `classifyEnforcementError` (`policy.go`) so
+  a standby claim now correctly shows up as a `failingClaims` entry with an
+  honest reason instead of a lie. No filesystem command runs,
+  `appliedQuotas` isn't touched, the PV's status annotation isn't written.
+- `syncAllQuotas` and `pvReconcileQueue.process` (the watch/reconcile-queue
+  path, `internal/agent/reconcile_queue.go`) both special-case
+  `ErrHAStandby`: excluded from `syncedCount`/`nfs_quota_agent_reconcile_total`
+  (it isn't a successful reconcile) and from
+  `nfs_quota_agent_reconcile_errors_total` (nothing went wrong either) --
+  and `syncAllQuotas` logs one `Warn`-level summary per cycle
+  (`"Skipped quota mutation for PVs: this instance is HA standby"`,
+  with a count) instead of a per-PV line, so a misconfigured
+  `--ha-active-file` (see §5) is visible without spamming a per-PV Debug
+  line nobody's watching at that log level.
+- `RemoveOrphan` (`internal/agent/orphan.go`) checks the same thing and
+  also returns `ErrHAStandby` (the same sentinel, shared from
+  `internal/agent/ha.go`) so `cleanupOrphans` can log and skip accurately
+  instead of either claiming a false success (auditing a cleanup that
+  never happened) or logging a standby refusal as if it were a real
+  failure. This also covers the web UI's manual "delete this orphan"
+  action (`internal/ui/server.go`): `ui.AgentInterface` gained its own
+  `HAActive()` method (mirroring `metrics.AgentInfo`'s) so the UI handlers
+  check it directly and return `409 Conflict` with an honest message
+  before ever calling `RemoveOrphan` -- `agent` importing `ui` (not the
+  reverse) means the UI package can't type-check `ErrHAStandby` itself, so
+  checking the same underlying state directly is what makes the UI's
+  refusal message accurate rather than `RemoveOrphan`'s generic-error
+  path turning it into an opaque `500`.
+- `runHAActivePolling` (`internal/agent/ha.go`) polls `HAActive()` every
+  2s (independent of, and much shorter than, `--sync-interval`'s default
+  30s). It does **not** call `syncAllQuotas` itself -- an earlier version
+  did, and an independent review found that made `syncAllQuotas`
+  concurrent for the first time (this goroutine's call racing `Run()`'s
+  own ticker-driven call), which corrupts `knownProjectIDs` (replaced
+  wholesale per cycle, not merged: a project ID one cycle allocates can
+  read as free to a concurrently-running cycle and get handed to a second
+  project) and can race two `finishQuotaPolicyCycle`/`WriteStatus` calls
+  against the same object. Instead it sends a non-blocking signal on a
+  buffered channel that `Run()`'s own single sync-loop goroutine consumes
+  alongside its regular ticker -- reconciliation still only ever runs from
+  that one goroutine, the invariant `syncAllQuotas`'s own doc comment
+  already asserted before this feature existed. On the reverse
+  (active→standby) transition it clears `appliedQuotas` under `a.mu`:
+  without that, `ensureQuota`'s cache-hit shortcut would make the *next*
+  active-triggered sync silently re-apply nothing for any PV whose
+  capacity hadn't changed, since the cache's entire validity assumption
+  ("this process is the only writer of this filesystem") is exactly what
+  HA existing at all means isn't always true. It only runs when
+  `--ha-active-file` is set -- the common no-HA deployment pays nothing
+  for it.
+- Readiness (`ReadinessOK`, used by the `/ready` probe) is **not** gated
+  on `HAActive()`. A standby node is a legitimate, intentionally
+  non-enforcing state, not an unhealthy one — folding it into readiness
+  would make Kubernetes treat a correctly-behaving standby as a probe
+  failure. `HAActive()` is exposed separately, as its own thing: the
+  `nfs_quota_agent_ha_active` Prometheus gauge (1 active / 0 standby,
+  always 1 when HA gating is off). **This means the three metrics above
+  stay green on a standby node by design** (nothing failed) -- any
+  enforcement-health alert built on them must also check
+  `nfs_quota_agent_ha_active`, or "last full sync is recent" can read as
+  healthy on a node enforcing nothing.
+
+## 4. Fail-safe direction
+
+`HAActive()` treats *any* `os.Stat` error on the active-file path — not
+just "does not exist" — as standby: a permission error or a transient
+stat failure also reads as "refuse to mutate." A false negative here
+(wrongly treating an active node as standby, and so wrongly skipping
+enforcement for one poll/sync cycle) is cheap: the next successful
+`HAActive()` read or the next full resync corrects it. A false positive
+(wrongly treating a standby node as active) risks two nodes mutating the
+same shared quota metadata — the actual split-brain #11 is about. Given
+that asymmetry, failing toward standby is the only defensible default.
+
+## 5. Applicability boundary: the standby node must still have the export mounted
+
+`Run()` calls `detectFilesystemType`/`checkQuotaAvailable` and exits with
+an error (CrashLoopBackOff under the DaemonSet) if either fails --
+*before* `runHAActivePolling` ever starts, let alone reaches a point where
+`HAActive()` matters. On a DRBD-style pair where the standby node's export
+is genuinely unmounted (the primary integration model §2 describes), the
+agent never reaches the gate at all; it dies at startup detection instead.
+This gate only actually functions in a topology where both nodes keep the
+filesystem mounted (shared storage, or a replication mode that exposes a
+read-only mount on standby) and rely on this gate — not on the mount
+itself being absent — to prevent standby mutation. Making startup
+detection degrade to not-ready instead of fatal when `--ha-active-file` is
+set is a real improvement but a larger, separate change; not attempted
+here.
+
+## 6. Deliberately not implemented
+
+Everything below is real #11 scope this change does not attempt, because
+each needs either a decision only an operator/deployment can make, or a
+real multi-node DR test environment this repository doesn't have access
+to (same limitation this repo's `CLAUDE.md` already notes for filesystem
+read-back verification generally):
+
+- **Fencing enforcement.** This agent trusts the file. It cannot detect
+  or prevent two nodes from both seeing "active" simultaneously (e.g. a
+  split-brain in the external HA layer itself) — that guarantee has to
+  come from whatever creates/removes the file (STONITH, quorum, etc.).
+- **Filesystem quota read-back verification.** Comparing actual
+  `xfs_quota report`/`repquota`/`btrfs qgroup show` output against desired
+  state after a failover needs a real prjquota-mounted host to implement
+  against reliably; not attempted here, same reasoning as #10's and
+  QuotaPolicy's `Drifted` condition.
+- **Replication lag / quota metadata RPO tracking**, **quota enforcement
+  RPO/RTO measurement**, and the **HA topology compatibility matrix** by
+  backend (DRBD / storage-array replication / rsync-based DR) — these
+  need a real multi-node deployment against a specific replication
+  backend to produce honest numbers or a real "supported/partial/
+  unavailable" matrix; a matrix asserted from this codebase alone without
+  ever running against real replication would just be guessing.
+- **`/etc/projects`/`/etc/projid` project ID/name/path consistency
+  validation specifically on failover.** `loadProjects`
+  (`internal/agent/agent.go`, `Run()`) already runs
+  `CheckProjectFileConsistency` at startup, but that's pre-existing,
+  runs once at process start, and isn't re-triggered by a standby→active
+  transition the way `syncAllQuotas` now is (§3) — whether that's
+  sufficient for a real failover (as opposed to a process restart) is
+  unverified without a real two-node test.
+- **Automatic post-failover reconciliation beyond re-applying quotas that
+  actually changed.** §3 now covers the specific bug an independent
+  review found here (a stale `appliedQuotas` cache making the failover
+  trigger apply nothing) — `syncAllQuotas`, once triggered, does
+  genuinely re-list every PV and re-apply any quota whose cached state no
+  longer matches. What's still unverified: whether the *actual filesystem
+  state* it's comparing against is trustworthy right after a real
+  failover (as opposed to `appliedQuotas` merely being empty in-memory) —
+  that's the read-back verification gap two bullets above, not something
+  this bullet claims to have closed.
+- **Failback consistency gate.** Symmetric to activation: this
+  implementation reacts identically to any standby→active transition,
+  whether it's an initial failover or a failback, and doesn't add extra
+  gating specific to "this was previously active, demoted, and is being
+  promoted back."
+- **Offline DR/failover test evidence.** The acceptance criteria's own
+  검증 steps (§ in #11) describe a real two-NFS-server test harness; none
+  of that exists in this repository or CI.
+
+If any of the above becomes the next priority, it needs its own scoped
+issue and, for the ones above that depend on a specific replication
+backend or a real multi-node cluster, a decision about which environment
+to validate against before code gets written against assumptions no one
+has confirmed.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -21,6 +21,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -80,6 +81,19 @@ type QuotaAgent struct {
 	appliedQuotas   map[string]int64
 	knownProjectIDs map[uint32]string // cache of projid file; refreshed once per sync cycle
 	auditLogger     *audit.Logger
+
+	// haActiveFile, when non-empty, gates every quota mutation (ensureQuota,
+	// RemoveOrphan) on this file's existence: present means this instance is
+	// the active/owning node for quota enforcement, absent means standby.
+	// Empty (the default) disables HA gating entirely -- existing
+	// single-node/no-HA deployments enforce unconditionally, unchanged. See
+	// #11: this agent deliberately does not implement its own
+	// election/fencing/replication -- an external cluster manager or HA
+	// tool (Pacemaker resource agent, a DRBD promote/demote hook, a custom
+	// script) owns deciding which node is active and communicates that
+	// decision by creating/removing this file. HAActive() is the read;
+	// nothing in this package ever creates or removes the file itself.
+	haActiveFile string
 
 	// policySnapshot is the QuotaPolicy set (and the PVC labels needed to
 	// match it) as of the most recent syncAllQuotas cycle, published by
@@ -517,6 +531,22 @@ func (a *QuotaAgent) Run(ctx context.Context) error {
 		go a.runAutoCleanup(ctx)
 	}
 
+	// Start HA active-marker polling if configured (#11): only when opted
+	// in, since the common single-node/no-HA deployment has nothing to
+	// poll for and shouldn't pay for an extra goroutine/ticker. haSyncNow
+	// carries only a coalescing signal (buffered 1, non-blocking send in
+	// runHAActivePolling) -- the actual syncAllQuotas call it triggers
+	// still runs from this function's own goroutine below, via the select
+	// loop's dedicated case, not from the polling goroutine itself. That
+	// matters: syncAllQuotas is documented (its own doc comment) and
+	// relied upon elsewhere (knownProjectIDs, policySnapshot) as having
+	// exactly one caller goroutine: calling it from a second goroutine
+	// concurrently was found, in review, to risk corrupting both.
+	haSyncNow := make(chan struct{}, 1)
+	if a.haActiveFile != "" {
+		go a.runHAActivePolling(ctx, haActivePollInterval, haSyncNow)
+	}
+
 	// Start history collection if enabled
 	if a.historyStore != nil {
 		go a.collectHistory(ctx)
@@ -536,6 +566,15 @@ func (a *QuotaAgent) Run(ctx context.Context) error {
 			a.recordHeartbeat()
 			if err := a.syncAllQuotas(ctx); err != nil {
 				slog.Error("Periodic quota sync failed", "error", err)
+				a.recordSyncResult(err)
+			} else {
+				a.recordSyncResult(nil)
+			}
+		case <-haSyncNow:
+			a.recordHeartbeat()
+			slog.Info("Running failover reconciliation triggered by an HA standby->active transition")
+			if err := a.syncAllQuotas(ctx); err != nil {
+				slog.Error("Failover reconciliation failed", "error", err)
 				a.recordSyncResult(err)
 			} else {
 				a.recordSyncResult(nil)
@@ -652,6 +691,7 @@ func (a *QuotaAgent) syncAllQuotas(ctx context.Context) error {
 	cycle := a.beginQuotaPolicyCycle(ctx)
 
 	syncedCount := 0
+	haSkippedCount := 0
 	live := make(map[string]struct{}, len(pvList.Items))
 	liveNames := make(map[string]struct{}, len(pvList.Items))
 	for _, pv := range pvList.Items {
@@ -717,11 +757,24 @@ func (a *QuotaAgent) syncAllQuotas(ctx context.Context) error {
 			// actual, honest outcome: matched, but not enforced.
 			cycle.recordEnforcement(winner, &pv, errLocalDirectoryMissing)
 		}
-		if err != nil {
+		switch {
+		case errors.Is(err, ErrHAStandby):
+			// Not counted as synced (nothing happened) and not logged as
+			// a failure (nothing went wrong) -- see haSkippedCount's
+			// summary log below instead of a per-PV line here, which
+			// would otherwise repeat once per PV every syncInterval for
+			// as long as this node stays standby.
+			haSkippedCount++
+		case err != nil:
 			slog.Error("Failed to ensure quota for PV", "pv", pv.Name, "error", err)
-		} else {
+		default:
 			syncedCount++
 		}
+	}
+
+	if haSkippedCount > 0 {
+		slog.Warn("Skipped quota mutation for PVs: this instance is HA standby",
+			"count", haSkippedCount, "activeFile", a.haActiveFile)
 	}
 
 	a.pruneAppliedQuotas(live)
@@ -810,6 +863,21 @@ func (a *QuotaAgent) getNFSPath(pv *v1.PersistentVolume) string {
 // the last sync just applied — see beginQuotaPolicyCycle's doc comment for
 // why that would otherwise oscillate forever).
 func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, effectiveBytes int64) error {
+	// Checked before taking a.mu: HAActive() is just a stat call, and a
+	// standby instance should never even contend for the lock over work
+	// it's about to skip. See haActiveFile's doc comment (#11) -- this is
+	// the actual mutation gate the acceptance criterion "standby agent는
+	// ownership이 확인되기 전 quota mutation을 수행하지 않는다" asks for;
+	// everywhere else (RemoveOrphan) has the identical check for the same
+	// reason. Returns ErrHAStandby, not nil -- see its doc comment
+	// (ha.go) for why a silent nil here would be a QuotaPolicy accounting
+	// lie, and every caller of ensureQuota for how each one must treat
+	// this specific error as "correctly skipped," not a failure.
+	if !a.HAActive() {
+		slog.Debug("Skipping quota mutation: this instance is HA standby", "pv", pv.Name)
+		return ErrHAStandby
+	}
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
 

--- a/internal/agent/ha.go
+++ b/internal/agent/ha.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"time"
+)
+
+// haActivePollInterval is how often runHAActivePolling re-checks
+// haActiveFile. Deliberately much shorter than syncInterval's default
+// (30s): the periodic full resync already exists as a watch-gap backstop
+// on that cadence, but a standby->active failover transition should
+// trigger reconciliation promptly, not wait up to 30s for the next
+// unrelated tick to notice it.
+const haActivePollInterval = 2 * time.Second
+
+// ErrHAStandby is returned by ensureQuota (agent.go) and RemoveOrphan
+// (orphan.go) when this instance is HA standby (see haActiveFile's doc
+// comment, #11) and refuses to perform quota mutation. Deliberately a real,
+// non-nil error rather than a silent nil "skip" (the convention ensureQuota
+// otherwise uses, e.g. for a PV whose local directory doesn't exist yet):
+// nil would make syncAllQuotas's QuotaPolicy accounting
+// (policy.go/recordEnforcement) treat a standby no-op as a successfully
+// applied claim -- the exact "applied lie" class docs/quotapolicy-design.md
+// §11 and zz_f7_applied_lie_test.go already exist to prevent for the
+// missing-local-directory case (see errLocalDirectoryMissing, policy.go).
+// Every caller that receives this must treat it as "correctly skipped, not
+// a failure" for logging/retry/metrics purposes: see syncAllQuotas
+// (agent.go), pvReconcileQueue.process (reconcile_queue.go), and
+// cleanupOrphans (orphan.go) for the three places that do.
+var ErrHAStandby = errors.New("this instance is HA standby; quota mutation refused")
+
+// SetHAActiveFile sets the path HAActive checks to decide whether this
+// instance is the active HA owner. Empty (the default) disables HA gating.
+// See haActiveFile's doc comment (agent.go) for the external-ownership
+// design this implements (#11).
+//
+// Must be called before Run(): haActiveFile itself is read (HAActive) from
+// several goroutines Run() starts (the sync loop, watch/reconcile-queue
+// workers, the metrics HTTP handler, runHAActivePolling) with no lock
+// protecting it, which is safe only because the write here happens-before
+// all of them start -- the same established pattern as every other
+// SetXxx config method on QuotaAgent (see NewQuotaAgent's callers), not
+// something specific to this field.
+func (a *QuotaAgent) SetHAActiveFile(v string) { a.haActiveFile = v }
+
+// HAActive reports whether this instance currently owns quota enforcement.
+// Always true when HA gating is disabled (haActiveFile unset). When
+// enabled, true iff haActiveFile exists -- any stat error (not just
+// os.IsNotExist, so a permission error or a transient stat failure also
+// fails safe rather than defaulting to "active") is treated as standby,
+// since a false negative here (wrongly skipping enforcement) is far
+// cheaper to recover from than a false positive (two nodes mutating the
+// same shared quota metadata split-brain).
+func (a *QuotaAgent) HAActive() bool {
+	if a.haActiveFile == "" {
+		return true
+	}
+	_, err := os.Stat(a.haActiveFile)
+	return err == nil
+}
+
+// runHAActivePolling watches haActiveFile for active/standby transitions.
+//
+// On standby->active, it does not call syncAllQuotas itself -- an earlier
+// version of this code did, and an independent review found that made
+// syncAllQuotas concurrent for the first time (this goroutine's call
+// racing the main sync loop's own ticker-driven call), which every
+// existing doc comment in this package assumes cannot happen (see
+// syncAllQuotas's own comment about "no second watch loop or work queue...
+// there is no concurrency for a queue to protect" -- true only as long as
+// nothing calls it from a second goroutine). Concurrent cycles can corrupt
+// knownProjectIDs (agent.go: replaced wholesale, not merged, so a project
+// ID one cycle allocated can appear "free" to the other and get handed to
+// a second project) and race policySnapshot/QuotaPolicy status writes.
+// Instead this sends a non-blocking signal on syncNow, which Run()'s own
+// single sync-loop goroutine consumes alongside its regular ticker --
+// reconciliation still only ever runs from that one goroutine.
+//
+// On active->standby, it clears appliedQuotas: that cache's entire
+// validity assumption is "this process is the only writer of this
+// filesystem," which HA existing at all means is not always true. Without
+// clearing it, ensureQuota's cache-hit shortcut
+// (`existingQuota == sizeBytes` -> return nil) makes the *next*
+// active-triggered syncAllQuotas silently re-apply nothing on every PV
+// whose capacity didn't change since this node was last active -- turning
+// "failover reconciliation" into a re-list with no re-apply, which is not
+// what it's advertised as doing (see docs/ha-dr.md §3).
+//
+// wasActive starts false unconditionally, even if this instance is
+// already active when polling starts: seeding it from a real HAActive()
+// read has a startup race (a transition landing between Run()'s initial
+// sync and this goroutine's first tick would then never be seen as an
+// edge, and the failover trigger would never fire for it). Starting false
+// means an already-active instance sends one spurious, harmless,
+// idempotent signal on its first tick instead -- see the trade-off this
+// makes explicit in code, not just in review notes.
+func (a *QuotaAgent) runHAActivePolling(ctx context.Context, pollInterval time.Duration, syncNow chan<- struct{}) {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	wasActive := false
+	slog.Info("HA active-marker polling started", "activeFile", a.haActiveFile, "pollInterval", pollInterval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			active := a.HAActive()
+			switch {
+			case active && !wasActive:
+				slog.Info("HA active marker present: became active, triggering failover reconciliation", "activeFile", a.haActiveFile)
+				select {
+				case syncNow <- struct{}{}:
+				default:
+					// A signal is already pending and hasn't been consumed
+					// yet; the sync loop will pick it up on its own, no
+					// need to queue a second one.
+				}
+			case !active && wasActive:
+				slog.Warn("HA active marker absent: became standby, quota mutation will be skipped until it returns", "activeFile", a.haActiveFile)
+				a.mu.Lock()
+				a.appliedQuotas = make(map[string]int64)
+				a.mu.Unlock()
+			}
+			wasActive = active
+		}
+	}
+}

--- a/internal/agent/ha_test.go
+++ b/internal/agent/ha_test.go
@@ -1,0 +1,401 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
+	"github.com/dasomel/nfs-quota-agent/internal/quota"
+	"github.com/dasomel/nfs-quota-agent/internal/quotapolicy"
+	"github.com/dasomel/nfs-quota-agent/internal/ui"
+)
+
+func TestHAActive_DefaultsToActiveWhenUnconfigured(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	if !a.HAActive() {
+		t.Error("expected HAActive to default to true when SetHAActiveFile was never called")
+	}
+}
+
+func TestHAActive_StandbyWhenFileMissing(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.SetHAActiveFile(filepath.Join(t.TempDir(), "does-not-exist"))
+	if a.HAActive() {
+		t.Error("expected HAActive to report false when the configured active-file does not exist")
+	}
+}
+
+func TestHAActive_ActiveWhenFileExists(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	dir := t.TempDir()
+	activeFile := filepath.Join(dir, "active")
+	if err := os.WriteFile(activeFile, nil, 0644); err != nil {
+		t.Fatalf("write active file: %v", err)
+	}
+	a.SetHAActiveFile(activeFile)
+	if !a.HAActive() {
+		t.Error("expected HAActive to report true when the configured active-file exists")
+	}
+}
+
+// TestEnsureQuota_SkipsMutationWhenStandby guards #11's core acceptance
+// item: "standby agent는 ownership이 확인되기 전 quota mutation을 수행하지
+// 않는다". No filesystem command may run and appliedQuotas must stay empty.
+func TestEnsureQuota_SkipsMutationWhenStandby(t *testing.T) {
+	runner := xfsHappyRunner()
+	withFakeRunner(t, runner)
+
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.fsType = quota.FSTypeXFS
+	a.SetHAActiveFile(filepath.Join(t.TempDir(), "does-not-exist"))
+
+	pv := newBoundPV("pv-standby", "/exports/pvc-standby", 1)
+	localPath := a.nfsPathToLocal("/exports/pvc-standby")
+	if err := os.MkdirAll(localPath, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	err := a.ensureQuota(context.Background(), pv, 0)
+	if !errors.Is(err, ErrHAStandby) {
+		t.Fatalf("expected ErrHAStandby, got: %v", err)
+	}
+
+	a.mu.Lock()
+	_, applied := a.appliedQuotas[localPath]
+	a.mu.Unlock()
+	if applied {
+		t.Error("expected no quota to be applied while standby")
+	}
+
+	runner.mu.Lock()
+	calls := len(runner.calls)
+	runner.mu.Unlock()
+	if calls != 0 {
+		t.Errorf("expected zero filesystem commands to run while standby, got %d", calls)
+	}
+}
+
+func TestEnsureQuota_AppliesWhenActive(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.fsType = quota.FSTypeXFS
+	activeFile := filepath.Join(t.TempDir(), "active")
+	if err := os.WriteFile(activeFile, nil, 0644); err != nil {
+		t.Fatalf("write active file: %v", err)
+	}
+	a.SetHAActiveFile(activeFile)
+
+	pv := newBoundPV("pv-active", "/exports/pvc-active", 1)
+	localPath := a.nfsPathToLocal("/exports/pvc-active")
+	if err := os.MkdirAll(localPath, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if err := a.ensureQuota(context.Background(), pv, 0); err != nil {
+		t.Fatalf("ensureQuota: %v", err)
+	}
+
+	a.mu.Lock()
+	_, applied := a.appliedQuotas[localPath]
+	a.mu.Unlock()
+	if !applied {
+		t.Error("expected quota to be applied while active")
+	}
+}
+
+// TestRemoveOrphan_RefusesWhenStandby guards the same acceptance item for
+// orphan cleanup: destructive removal is quota mutation too.
+func TestRemoveOrphan_RefusesWhenStandby(t *testing.T) {
+	runner := xfsHappyRunner()
+	withFakeRunner(t, runner)
+
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.fsType = quota.FSTypeXFS
+	a.SetHAActiveFile(filepath.Join(t.TempDir(), "does-not-exist"))
+
+	dir := filepath.Join(a.nfsBasePath, "to-remove")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	err := a.RemoveOrphan(ui.OrphanInfo{Path: dir, DirName: "to-remove"})
+	if !errors.Is(err, ErrHAStandby) {
+		t.Fatalf("expected ErrHAStandby, got %v", err)
+	}
+	if _, statErr := os.Stat(dir); statErr != nil {
+		t.Errorf("expected the orphan directory to survive a standby RemoveOrphan call, got stat error: %v", statErr)
+	}
+	runner.mu.Lock()
+	calls := len(runner.calls)
+	runner.mu.Unlock()
+	if calls != 0 {
+		t.Errorf("expected zero filesystem commands to run while standby, got %d", calls)
+	}
+}
+
+// TestCleanupOrphans_SkipsSilentlyWhenStandby guards cleanupOrphans's
+// handling of ErrHAStandby specifically: it must not log a false "Removed
+// orphan directory" success or audit-record one (see the errors.Is check
+// in cleanupOrphans, orphan.go) -- observed here via the directory
+// surviving and the orphan cache entry remaining tracked.
+func TestCleanupOrphans_SkipsSilentlyWhenStandby(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.fsType = quota.FSTypeXFS
+	a.SetHAActiveFile(filepath.Join(t.TempDir(), "does-not-exist"))
+	a.orphanGracePeriod = 0 // eligible for deletion immediately
+	a.cleanupDryRun = false // NewQuotaAgent defaults this true; standby must refuse for a real reason, not dry-run
+
+	dir := filepath.Join(a.nfsBasePath, "orphan-dir", "sub")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	a.cleanupOrphans(context.Background())
+
+	if _, statErr := os.Stat(dir); statErr != nil {
+		t.Errorf("expected the orphan directory to survive cleanupOrphans while standby, got stat error: %v", statErr)
+	}
+}
+
+// TestRunHAActivePolling_SignalsOnBecomingActive guards ha.go's fix for
+// the concurrency finding an independent review surfaced: runHAActivePolling
+// no longer calls syncAllQuotas itself (which raced it against Run()'s own
+// ticker-driven call, on a second goroutine, corrupting knownProjectIDs/
+// policySnapshot) -- it only ever sends a non-blocking signal on syncNow,
+// which Run()'s single sync-loop goroutine is responsible for consuming.
+// This test asserts exactly that contract: a signal arrives, nothing more.
+//
+// wasActive seeds false unconditionally (see runHAActivePolling's doc
+// comment for why), so the active file already existing *before* the
+// goroutine starts still produces a signal on the first tick -- no
+// goroutine-scheduling race to work around here, unlike the old version of
+// this test.
+func TestRunHAActivePolling_SignalsOnBecomingActive(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	activeFile := filepath.Join(t.TempDir(), "active")
+	if err := os.WriteFile(activeFile, nil, 0644); err != nil {
+		t.Fatalf("write active file: %v", err)
+	}
+	a.SetHAActiveFile(activeFile)
+
+	syncNow := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		a.runHAActivePolling(ctx, 5*time.Millisecond, syncNow)
+		close(done)
+	}()
+
+	select {
+	case <-syncNow:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected a signal on syncNow for the standby(false)->active transition")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("runHAActivePolling did not stop after context cancellation")
+	}
+}
+
+// TestRunHAActivePolling_ClearsAppliedQuotasOnBecomingStandby guards the
+// fix for the finding that the failover trigger was a near no-op: without
+// clearing appliedQuotas on the active->standby edge, ensureQuota's
+// cache-hit shortcut would make the *next* active-triggered sync silently
+// re-apply nothing for any PV whose capacity didn't change -- see
+// runHAActivePolling's doc comment (ha.go).
+func TestRunHAActivePolling_ClearsAppliedQuotasOnBecomingStandby(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	activeFile := filepath.Join(t.TempDir(), "active")
+	if err := os.WriteFile(activeFile, nil, 0644); err != nil {
+		t.Fatalf("write active file: %v", err)
+	}
+	a.SetHAActiveFile(activeFile)
+
+	a.mu.Lock()
+	a.appliedQuotas["/some/path"] = 123
+	a.mu.Unlock()
+
+	syncNow := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		a.runHAActivePolling(ctx, 5*time.Millisecond, syncNow)
+		close(done)
+	}()
+
+	// Drain the initial become-active signal (wasActive seeds false, so
+	// the file already being present produces one) before flipping to
+	// standby, so the two transitions aren't confused with each other.
+	select {
+	case <-syncNow:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected the initial become-active signal")
+	}
+
+	if err := os.Remove(activeFile); err != nil {
+		t.Fatalf("remove active file: %v", err)
+	}
+
+	waitFor(t, 2*time.Second, func() bool {
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		return len(a.appliedQuotas) == 0
+	})
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("runHAActivePolling did not stop after context cancellation")
+	}
+}
+
+func TestRunHAActivePolling_StopsOnContextCancel(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.SetHAActiveFile(filepath.Join(t.TempDir(), "does-not-exist"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	syncNow := make(chan struct{}, 1)
+	go func() {
+		a.runHAActivePolling(ctx, 5*time.Millisecond, syncNow)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("runHAActivePolling did not stop after context cancellation")
+	}
+}
+
+// TestAppliedMustNotCountClaimsWhenHAStandby is the HA-standby sibling of
+// zz_f7_applied_lie_test.go's TestAppliedMustNotCountClaimsWhoseDirectoryIsMissing:
+// an independent review found ensureQuota's original HA gate returned nil
+// (not an error) on standby, which recordEnforcement (policy.go) treats
+// exactly like a real, successful apply -- reporting a QuotaPolicy claim as
+// Applied=True on a node that enforced nothing. ensureQuota now returns
+// ErrHAStandby, a real error, specifically so this can't happen. Unlike the
+// missing-directory sibling test, the PV's local directory DOES exist here
+// (hasLocalDir is true, exercising syncAllQuotas's normal
+// `case hasLocalDir:` branch, not the singleWriter/no-local-dir one).
+func TestAppliedMustNotCountClaimsWhenHAStandby(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+
+	pv := newBoundPV("pv-standby-policy", "/exports/pvc-standby-policy", 10)
+	client := fake.NewSimpleClientset(pv)
+	a := newTestAgent(t, client)
+	a.fsType = quota.FSTypeXFS
+	a.SetProcessAllNFS(true)
+	a.SetHAActiveFile(filepath.Join(t.TempDir(), "does-not-exist")) // standby
+
+	localPath := a.nfsPathToLocal("/exports/pvc-standby-policy")
+	if err := os.MkdirAll(localPath, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	max := *resourceQuantity(5 * gib)
+	policy := &v1alpha1.QuotaPolicy{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "quota.nfs.io/v1alpha1", Kind: "QuotaPolicy"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "p", Generation: 1},
+		Spec: v1alpha1.QuotaPolicySpec{
+			Selector: v1alpha1.QuotaPolicySelector{}, Priority: 100,
+			MaxQuota: &max, EnforceMax: true,
+		},
+	}
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schemaGVR]string{quotapolicy.GroupVersionResource: "QuotaPolicyList"},
+		&unstructured.Unstructured{Object: u})
+
+	a.SetDynamicClient(dc)
+	a.SetQuotaPolicyEnabled(true)
+	// Without this, finishQuotaPolicyCycle no-ops and WriteStatus never
+	// runs -- same note as the sibling test in zz_f7_applied_lie_test.go.
+	a.SetQuotaPolicySingleWriter(true)
+
+	ctx := context.Background()
+	if err := a.syncAllQuotas(ctx); err != nil {
+		t.Fatalf("syncAllQuotas: %v", err)
+	}
+
+	got, err := dc.Resource(quotapolicy.GroupVersionResource).Namespace("default").
+		Get(ctx, "p", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, _ := got.Object["status"].(map[string]interface{})
+	applied := status["appliedClaims"]
+	var appliedCond, failReason string
+	if conds, ok := status["conditions"].([]interface{}); ok {
+		for _, c := range conds {
+			m := c.(map[string]interface{})
+			if m["type"] == "Applied" {
+				appliedCond = m["status"].(string)
+			}
+		}
+	}
+	if failing, ok := status["failingClaims"].([]interface{}); ok && len(failing) > 0 {
+		if m, ok := failing[0].(map[string]interface{}); ok {
+			failReason, _ = m["reason"].(string)
+		}
+	}
+
+	a.mu.Lock()
+	_, everApplied := a.appliedQuotas[localPath]
+	a.mu.Unlock()
+
+	t.Logf("quota actually applied to the filesystem: %v", everApplied)
+	t.Logf("status.appliedClaims=%v  Applied=%s  failingClaims[0].reason=%s", applied, appliedCond, failReason)
+
+	if everApplied {
+		t.Fatal("test setup wrong: the quota was applied, so there is nothing to catch")
+	}
+	if fmtInt(applied) != 0 {
+		t.Errorf("appliedClaims=%v but no quota was applied to any filesystem (this node is HA standby)", applied)
+	}
+	if appliedCond == "True" {
+		t.Errorf("Applied=True while nothing was enforced -- this node is HA standby and refused all mutation")
+	}
+	if failReason != v1alpha1.ReasonHAStandby {
+		t.Errorf("failingClaims[0].reason = %q, want %q", failReason, v1alpha1.ReasonHAStandby)
+	}
+}

--- a/internal/agent/orphan.go
+++ b/internal/agent/orphan.go
@@ -84,6 +84,10 @@ func (a *QuotaAgent) cleanupOrphans(ctx context.Context) {
 			)
 		} else {
 			if err := a.RemoveOrphan(orphan); err != nil {
+				if errors.Is(err, ErrHAStandby) {
+					slog.Debug("Skipping orphan removal: this instance is HA standby", "path", orphan.Path)
+					continue
+				}
 				slog.Error("Failed to remove orphan",
 					"path", orphan.Path,
 					"error", err,
@@ -218,6 +222,17 @@ func (a *QuotaAgent) trackOrphan(path, dirName string, now time.Time) *ui.Orphan
 
 // RemoveOrphan removes an orphaned directory
 func (a *QuotaAgent) RemoveOrphan(orphan ui.OrphanInfo) error {
+	// Same HA standby gate as ensureQuota (agent.go). Orphan removal is
+	// destructive filesystem mutation too, so a standby instance must not
+	// perform it just because it happened to notice an orphan before the
+	// active node did -- including when triggered manually via the web UI
+	// (internal/ui/server.go also calls this), since an operator acting
+	// against the wrong (standby) node's view of shared quota metadata is
+	// exactly the split-brain risk this gate exists to prevent.
+	if !a.HAActive() {
+		return ErrHAStandby
+	}
+
 	if a.fsType != "" {
 		// A failure here leaves a stale projects/projid entry rather than a
 		// corrupted one (RemoveLineFromFile's own crash-recovery already

--- a/internal/agent/policy.go
+++ b/internal/agent/policy.go
@@ -299,18 +299,20 @@ var errLocalDirectoryMissing = errors.New("PV local directory does not exist on 
 // classifyEnforcementError maps an ensureQuota error to one of the fixed
 // Reason* constants for FailingClaim/Degraded reporting, falling back to
 // the generic ReasonEnforcementFailed for anything not specifically
-// recognized. errProjectIDExhausted and errLocalDirectoryMissing are the
-// only cases distinguished today; docs/quotapolicy-design.md §5 already
-// anticipates ReasonProjectIDExhausted may turn out to be unreachable in
-// practice given the existing collision-fallback in generateProjectID — the
-// same "included for the vocabulary, may never fire" reasoning could apply
-// to either.
+// recognized. errProjectIDExhausted, errLocalDirectoryMissing, and
+// ErrHAStandby (ha.go) are the only cases distinguished today;
+// docs/quotapolicy-design.md §5 already anticipates ReasonProjectIDExhausted
+// may turn out to be unreachable in practice given the existing
+// collision-fallback in generateProjectID — the same "included for the
+// vocabulary, may never fire" reasoning could apply to any of the three.
 func classifyEnforcementError(err error) string {
 	switch {
 	case errors.Is(err, errProjectIDExhausted):
 		return v1alpha1.ReasonProjectIDExhausted
 	case errors.Is(err, errLocalDirectoryMissing):
 		return v1alpha1.ReasonFilesystemUnavailable
+	case errors.Is(err, ErrHAStandby):
+		return v1alpha1.ReasonHAStandby
 	default:
 		return v1alpha1.ReasonEnforcementFailed
 	}

--- a/internal/agent/reconcile_queue.go
+++ b/internal/agent/reconcile_queue.go
@@ -18,6 +18,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -243,14 +244,27 @@ func (q *pvReconcileQueue) process(ctx context.Context, key string) {
 
 	start := time.Now()
 	err := q.agent.ensureQuota(ctx, item.pv, item.effectiveBytes)
-	q.agent.recordReconcileResult(time.Since(start), err)
 
-	if err != nil {
+	switch {
+	case errors.Is(err, ErrHAStandby):
+		// Not fed into recordReconcileResult at all -- neither a success
+		// (nothing was reconciled) nor an error (nothing went wrong) for
+		// the nfs_quota_agent_reconcile_total/_errors_total metrics to
+		// reflect. Not retried via AddRateLimited either: retrying while
+		// still standby just churns the backoff for no benefit, and
+		// runHAActivePolling's failover trigger (ha.go) already
+		// re-reconciles every PV via syncAllQuotas the moment this node
+		// actually becomes active.
+		slog.Debug("Skipping reconcile: this instance is HA standby", "pv", item.pv.Name)
+		q.queue.Forget(key)
+	case err != nil:
+		q.agent.recordReconcileResult(time.Since(start), err)
 		slog.Error("Failed to ensure quota", "pv", item.pv.Name, "error", err)
 		q.queue.AddRateLimited(key)
-		return
+	default:
+		q.agent.recordReconcileResult(time.Since(start), nil)
+		q.queue.Forget(key)
 	}
-	q.queue.Forget(key)
 }
 
 // depth returns the current number of keys queued or in flight, for the

--- a/internal/apis/quota/v1alpha1/types.go
+++ b/internal/apis/quota/v1alpha1/types.go
@@ -116,6 +116,7 @@ const (
 	ReasonEnforcementFailed     = "EnforcementFailed"
 	ReasonFilesystemUnavailable = "FilesystemUnavailable"
 	ReasonProjectIDExhausted    = "ProjectIDExhausted"
+	ReasonHAStandby             = "HAStandby"
 
 	ReasonQuotaDriftDetected = "QuotaDriftDetected"
 	ReasonNoDrift            = "NoDrift"

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -61,6 +61,11 @@ type AgentInfo interface {
 	// LastSuccessfulFullSync returns when the periodic full reconciliation
 	// last completed without error, or the zero Time if it never has.
 	LastSuccessfulFullSync() time.Time
+	// HAActive reports whether this instance currently owns quota
+	// enforcement (see agent.QuotaAgent.HAActive). Always true when HA
+	// gating is disabled -- most deployments, which have no HA setup at
+	// all, will always read active.
+	HAActive() bool
 }
 
 // Collector collects quota metrics for Prometheus
@@ -225,7 +230,16 @@ func (c *Collector) updateMetrics() {
 	if lastSync := c.agent.LastSuccessfulFullSync(); !lastSync.IsZero() {
 		lastFullSyncUnix = lastSync.Unix()
 	}
-	fmt.Fprintf(&sb, "nfs_quota_agent_last_full_sync_timestamp_seconds %d\n", lastFullSyncUnix)
+	fmt.Fprintf(&sb, "nfs_quota_agent_last_full_sync_timestamp_seconds %d\n\n", lastFullSyncUnix)
+
+	// HA active/standby state (#11). Always 1 when HA gating is disabled.
+	sb.WriteString("# HELP nfs_quota_agent_ha_active Whether this instance currently owns quota enforcement (1) or is HA standby (0); always 1 when HA gating is not configured\n")
+	sb.WriteString("# TYPE nfs_quota_agent_ha_active gauge\n")
+	haActive := 0
+	if c.agent.HAActive() {
+		haActive = 1
+	}
+	fmt.Fprintf(&sb, "nfs_quota_agent_ha_active %d\n", haActive)
 
 	c.metrics = sb.String()
 	c.lastUpdate = time.Now()

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -42,6 +42,13 @@ type fakeAgent struct {
 	reconcileErrors        int64
 	reconcileDurationSecs  float64
 	lastSuccessfulFullSync time.Time
+
+	// haActive is a *bool (not bool) so its zero value ("unset") can mean
+	// "default to active" -- matching agent.QuotaAgent.HAActive's own
+	// default of true when HA gating isn't configured, rather than every
+	// existing test literal that doesn't set this field silently reading
+	// as standby.
+	haActive *bool
 }
 
 func (f *fakeAgent) BasePath() string       { return f.basePath }
@@ -68,6 +75,13 @@ func (f *fakeAgent) ReconcileStats() (total, errors int64, durationSeconds float
 }
 
 func (f *fakeAgent) LastSuccessfulFullSync() time.Time { return f.lastSuccessfulFullSync }
+
+func (f *fakeAgent) HAActive() bool {
+	if f.haActive == nil {
+		return true
+	}
+	return *f.haActive
+}
 
 func TestHandleMetrics_Basic(t *testing.T) {
 	dir := t.TempDir()
@@ -103,10 +117,26 @@ func TestHandleMetrics_Basic(t *testing.T) {
 		"nfs_quota_agent_reconcile_errors_total",
 		"nfs_quota_agent_reconcile_duration_seconds_sum",
 		"nfs_quota_agent_last_full_sync_timestamp_seconds",
+		"nfs_quota_agent_ha_active 1", // fakeAgent's haActive is unset -> defaults to active, same as HA gating disabled
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q\nfull body:\n%s", want, body)
 		}
+	}
+}
+
+func TestHandleMetrics_HAActiveReflectsStandby(t *testing.T) {
+	dir := t.TempDir()
+	standby := false
+	c := &Collector{agent: &fakeAgent{basePath: dir, haActive: &standby}}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	c.handleMetrics(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "nfs_quota_agent_ha_active 0") {
+		t.Errorf("expected nfs_quota_agent_ha_active 0 for a standby instance\nfull body:\n%s", body)
 	}
 }
 

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -56,6 +56,14 @@ type AgentInterface interface {
 	GetOrphans(ctx context.Context) []OrphanInfo
 	RemoveOrphan(orphan OrphanInfo) error
 	AuditLogger() *audit.Logger
+	// HAActive reports whether this instance currently owns quota
+	// enforcement (see agent.QuotaAgent.HAActive, #11). Always true when
+	// HA gating is disabled. Checked before a destructive orphan-delete
+	// action so the UI can refuse with an honest 409 instead of letting
+	// RemoveOrphan's own gate return agent.ErrHAStandby as a generic 500 --
+	// agent -> ui is the only allowed import direction, so that sentinel
+	// can't be checked by type from this package.
+	HAActive() bool
 }
 
 // OrphanInfo represents an orphaned directory
@@ -484,6 +492,19 @@ func (ui *Server) handleAPIOrphansDelete(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// RemoveOrphan itself also refuses (returning agent.ErrHAStandby) when
+	// standby, but agent isn't importable here (agent -> ui is the only
+	// allowed direction; see CLAUDE.md's "three placements" note) so that
+	// sentinel can't be checked by type from this package. Checking
+	// HAActive() directly gives the same refusal with an honest status
+	// code (409, not RemoveOrphan's generic-error 500) and message instead
+	// of round-tripping into RemoveOrphan just to get the same answer.
+	if !ui.agent.HAActive() {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "this instance is HA standby; quota mutation refused"})
+		return
+	}
+
 	var req struct {
 		Path string `json:"path"`
 	}
@@ -813,6 +834,17 @@ func (ui *Server) handleAPIOrphansCleanup(w http.ResponseWriter, r *http.Request
 		dryRun = *req.DryRun
 	} else if req.DryRun2 != nil {
 		dryRun = *req.DryRun2
+	}
+
+	// Same check and reasoning as handleAPIOrphansDelete's HAActive() gate
+	// above: refuse the whole request up front for a real (non-dry-run)
+	// cleanup attempt rather than let it loop over every orphan calling
+	// RemoveOrphan only to have each one individually refuse and get
+	// logged as if it were a real per-orphan failure.
+	if !dryRun && !ui.agent.HAActive() {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "this instance is HA standby; quota mutation refused"})
+		return
 	}
 
 	ctx := r.Context()

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -58,6 +58,12 @@ type fakeAgent struct {
 	removeErr         error
 	removedPaths      []string
 	logger            *audit.Logger
+
+	// haActive is a *bool (not bool) so its zero value ("unset") defaults
+	// to active, matching agent.QuotaAgent.HAActive's own default when HA
+	// gating isn't configured -- see the identical pattern in
+	// internal/metrics/metrics_test.go's fakeAgent.
+	haActive *bool
 }
 
 func (f *fakeAgent) EnableAutoCleanup() bool                     { return f.enableAutoCleanup }
@@ -74,6 +80,12 @@ func (f *fakeAgent) RemoveOrphan(o OrphanInfo) error {
 	return nil
 }
 func (f *fakeAgent) AuditLogger() *audit.Logger { return f.logger }
+func (f *fakeAgent) HAActive() bool {
+	if f.haActive == nil {
+		return true
+	}
+	return *f.haActive
+}
 
 func mustMkdir(t *testing.T, path string) {
 	t.Helper()


### PR DESCRIPTION
## Summary

Implements #11's foundational acceptance item -- "standby agent는 ownership이 확인되기 전 quota mutation을 수행하지 않는다" -- following the prior investigation's conclusion (posted on the issue) that there's no enforceable core to build without first deciding how an external active/standby signal reaches this agent. That decision (confirmed with the user): a **file**, not a Kubernetes Lease -- its existence marks this instance active, its absence marks standby and refuses all quota mutation. The agent only ever reads the file; an external HA tool (Pacemaker resource agent, DRBD promote/demote hook, custom script) creates/removes it.

Everything else #11 asks for -- fencing enforcement, filesystem read-back verification, RPO/RTO measurement, a replication-backend compatibility matrix, offline DR test evidence -- is explicitly **not** implemented. See `docs/ha-dr.md` for the full breakdown of what's here and why the rest needs either an operator decision or a real multi-node DR environment this repo doesn't have.

## Gate call sites

- `ensureQuota` (`internal/agent/agent.go`) -- checked before taking the lock
- `RemoveOrphan` (`internal/agent/orphan.go`) -- also covers automatic and UI-triggered orphan cleanup
- `--ha-active-file` flag / `ha.activeFile` Helm value, wired through the chart

A `runHAActivePolling` goroutine (`internal/agent/ha.go`) polls the file every 2s (independent of `--sync-interval`'s 30s default) and triggers prompt failover reconciliation on a standby→active transition.

## Independent review caught 3 real bugs before merge

Given this gates every quota mutation the daemon performs, I got an opus review (per CLAUDE.md's guidance for safety-critical/concurrency-sensitive changes). It found:

1. **QuotaPolicy "applied lie" on standby.** `ensureQuota` originally returned `nil` (not an error) on standby -- `syncAllQuotas`'s QuotaPolicy accounting treats a nil error as a successful apply, so a standby node published `Applied=True` while enforcing nothing. This is the exact bug class `docs/quotapolicy-design.md` §11 and `zz_f7_applied_lie_test.go` already exist to prevent for a different case (missing local directory), reopened through the new HA path. **Fixed**: `ensureQuota` now returns a real `ErrHAStandby` sentinel with its own `ReasonHAStandby` classification, so a standby claim shows up honestly in `failingClaims` instead of a lie. Metrics (`syncedCount`, reconcile total/error counters) exclude the standby-skip case too, with one `Warn`-level per-cycle summary instead of per-PV noise.

2. **Concurrent `syncAllQuotas`.** The polling goroutine called `syncAllQuotas` directly, making it concurrent with `Run()`'s own ticker-driven call for the first time -- `syncAllQuotas`'s own doc comments assume exactly one caller goroutine (`knownProjectIDs` is replaced wholesale per cycle, not merged; two concurrent cycles could hand the same project ID to two different projects). **Fixed**: the polling goroutine now only sends a non-blocking signal on a channel that `Run()`'s own select loop consumes -- `syncAllQuotas` still only ever runs from one goroutine.

3. **Failover trigger was a near no-op.** The active→standby transition never invalidated `appliedQuotas`, so `ensureQuota`'s cache-hit shortcut made the *next* active-triggered sync silently re-apply nothing for any PV whose capacity hadn't changed -- the advertised "failover reconciliation trigger" didn't actually reconcile. **Fixed**: the transition now clears the cache.

Also fixed from the same review: `ui.AgentInterface` gained `HAActive()` (no import cycle, mirrors `metrics.AgentInfo`'s addition) so the UI's delete handlers refuse with an honest `409` instead of `RemoveOrphan`'s generic-error `500`; `SetHAActiveFile` documents it must be called before `Run()`; a startup-ordering applicability boundary (an unmounted standby export CrashLoops at filesystem detection before ever reaching the gate) is documented rather than silently assumed away.

## Test plan

- [x] `ha_test.go` (new): `HAActive` default/standby/active; `ensureQuota` skipping cleanly with **zero filesystem commands** while standby and applying normally while active; `RemoveOrphan` returning `ErrHAStandby` and leaving the directory untouched; `cleanupOrphans` skipping silently (no false success/audit record); the polling goroutine signaling on a standby→active transition and clearing `appliedQuotas` on active→standby; **`TestAppliedMustNotCountClaimsWhenHAStandby`** -- the direct regression test for finding #1, mirroring the existing `zz_f7_applied_lie_test.go` pattern
- [x] Mutations verified: reverting `ensureQuota`'s HA gate, `RemoveOrphan`'s HA gate, and reverting `ensureQuota`'s standby return from `ErrHAStandby` back to `nil` (the original applied-lie bug) -- all three correctly caught by their guarding tests, then restored and re-verified passing
- [x] Finding #2 (concurrent `syncAllQuotas`) verified structurally: `grep` confirms all 3 `syncAllQuotas` call sites are inside `Run()`; the polling goroutine's signature changed to take a channel, so any regression back to a direct call would fail to compile against the new test
- [x] `go build/vet/test -race ./...`; agent/ui/metrics packages also run 5x with `-race` for flake-hunting, all green
- [x] `helm lint` and `helm template --set ha.activeFile=...` both verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT