### PR TITLE
feat(ui): read-only REST facade for QuotaPolicy (/api/quota-policies)

### DIFF
--- a/cmd/nfs-quota-agent/main.go
+++ b/cmd/nfs-quota-agent/main.go
@@ -306,11 +306,17 @@ func runAgent(args []string) {
 	ag.SetQuotaPolicyEnabled(enableQuotaPolicy)
 	ag.SetQuotaPolicySingleWriter(quotaPolicySingleWriter)
 	ag.SetHAActiveFile(haActiveFile)
+	// Declared here (not inside the if block) so the UI server below can
+	// also use it for the /api/quota-policies read-only facade (#13) --
+	// the same client the agent's own sync cycle lists QuotaPolicy
+	// objects with, not a second one.
+	var dynamicClient dynamic.Interface
 	if enableQuotaPolicy {
-		dynamicClient, err := dynamic.NewForConfig(config)
+		dc, err := dynamic.NewForConfig(config)
 		if err != nil {
 			slog.Error("Failed to create dynamic Kubernetes client for QuotaPolicy; quota policy enforcement will be skipped", "error", err)
 		} else {
+			dynamicClient = dc
 			ag.SetDynamicClient(dynamicClient)
 		}
 	}
@@ -356,6 +362,7 @@ func runAgent(args []string) {
 				Client:        client,
 				Agent:         ag,
 				HistoryStore:  historyStore,
+				DynamicClient: dynamicClient,
 			}); err != nil {
 				slog.Error("Web UI server failed", "error", err)
 			}

--- a/docs/quotapolicy-design.md
+++ b/docs/quotapolicy-design.md
@@ -244,6 +244,26 @@ recommend bounding list-shaped status.
 `QuotaPolicy` status answers "is this policy currently working," not "how
 has usage under it changed."
 
+## 6.5. REST facade (`/api/quota-policies`)
+
+Issue #13 asks for a REST compatibility facade over the CRD, not a
+separate API surface with its own state. `internal/ui/server.go`'s
+`GET /api/quota-policies` is exactly that: it calls the same
+`quotapolicy.List` the agent's own sync cycle uses, via the same
+`dynamic.Interface` (`main.go` passes the one already constructed for
+`--enable-quota-policy` into `ui.Options.DynamicClient` -- not a second
+client), and returns the typed `v1alpha1.QuotaPolicy` objects as JSON
+directly. There is no write path: the CRD (`kubectl apply` / GitOps) is
+the only way to create or modify a `QuotaPolicy`, matching this design's
+"CRD is the source of truth" principle (§1) -- a REST-side write path
+would just be a second place `.spec` could be set from, which is exactly
+what this design avoids. `enabled` in the response reflects whether a
+dynamic client was configured at all (i.e. `--enable-quota-policy`), not
+a separate flag that could drift from it. Returns `enabled: false` and an
+empty list when unconfigured, including for the standalone `ui`
+subcommand (`nfs-quota-agent ui`), which has no Kubernetes client of any
+kind.
+
 ## 7. Relationship to what exists today
 
 | Existing mechanism | Superseded? | Still works? |

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -35,13 +35,16 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
 	"github.com/dasomel/nfs-quota-agent/internal/audit"
 	"github.com/dasomel/nfs-quota-agent/internal/history"
 	"github.com/dasomel/nfs-quota-agent/internal/policy"
 	"github.com/dasomel/nfs-quota-agent/internal/pvpath"
 	"github.com/dasomel/nfs-quota-agent/internal/quota"
+	"github.com/dasomel/nfs-quota-agent/internal/quotapolicy"
 	"github.com/dasomel/nfs-quota-agent/internal/status"
 	"github.com/dasomel/nfs-quota-agent/internal/util"
 )
@@ -107,6 +110,16 @@ type Options struct {
 	Client        kubernetes.Interface
 	Agent         AgentInterface
 	HistoryStore  *history.Store
+	// DynamicClient backs /api/quota-policies (see #13's REST-facade
+	// acceptance item). nil (the default, and always nil for the
+	// standalone `ui` subcommand, which has no Kubernetes client at all)
+	// degrades that endpoint to enabled:false/an empty list, the same
+	// degrade-gracefully convention handleAPIPolicies already uses for a
+	// nil Client. Deliberately the same *dynamic.Interface main.go
+	// constructs for the agent when --enable-quota-policy is set, not a
+	// second one — its presence/absence here is what "enabled" means for
+	// this endpoint, with no separate flag to keep in sync.
+	DynamicClient dynamic.Interface
 }
 
 // Server serves the web UI
@@ -119,6 +132,7 @@ type Server struct {
 	client        kubernetes.Interface
 	agent         AgentInterface
 	historyStore  *history.Store
+	dynamicClient dynamic.Interface
 }
 
 // StartServer starts the web UI server with the given options
@@ -132,6 +146,7 @@ func StartServer(opts Options) error {
 		client:        opts.Client,
 		agent:         opts.Agent,
 		historyStore:  opts.HistoryStore,
+		dynamicClient: opts.DynamicClient,
 	}
 
 	mux := http.NewServeMux()
@@ -148,6 +163,7 @@ func StartServer(opts Options) error {
 	mux.HandleFunc("/api/trends", ui.authMiddleware(ui.handleAPITrends))
 	mux.HandleFunc("/api/policies", ui.authMiddleware(ui.handleAPIPolicies))
 	mux.HandleFunc("/api/violations", ui.authMiddleware(ui.handleAPIViolations))
+	mux.HandleFunc("/api/quota-policies", ui.authMiddleware(ui.handleAPIQuotaPolicies))
 	mux.HandleFunc("/api/files", ui.authMiddleware(ui.handleAPIFiles))
 
 	slog.Info("Starting Web UI", "addr", opts.Addr, "url", fmt.Sprintf("http://localhost%s", opts.Addr))
@@ -683,6 +699,41 @@ func (ui *Server) handleAPIViolations(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"violations": violations,
 		"count":      len(violations),
+	})
+}
+
+// handleAPIQuotaPolicies is the REST facade #13's acceptance criteria ask
+// for: it returns exactly what quotapolicy.List reads from the CRD (the
+// same dynamic-client List call the agent's own sync cycle makes), never
+// a separately maintained copy of quota policy state. There is
+// deliberately no write path here -- the CRD (kubectl/GitOps) is the only
+// way to create or modify a QuotaPolicy; this endpoint is read-only.
+func (ui *Server) handleAPIQuotaPolicies(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if ui.dynamicClient == nil {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"enabled": false,
+			"items":   []v1alpha1.QuotaPolicy{},
+		})
+		return
+	}
+
+	ctx := r.Context()
+	policies, err := quotapolicy.List(ctx, ui.dynamicClient)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": err.Error(),
+			"items": []v1alpha1.QuotaPolicy{},
+		})
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"enabled": true,
+		"items":   policies,
+		"count":   len(policies),
 	})
 }
 

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -31,10 +31,16 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1"
 	"github.com/dasomel/nfs-quota-agent/internal/audit"
 	"github.com/dasomel/nfs-quota-agent/internal/history"
+	"github.com/dasomel/nfs-quota-agent/internal/quotapolicy"
 	"github.com/dasomel/nfs-quota-agent/internal/status"
 )
 
@@ -698,6 +704,84 @@ func TestHandleAPIViolations(t *testing.T) {
 		decodeJSON(t, w.Body, &resp)
 		if resp["count"] != float64(0) {
 			t.Fatalf("count = %v, want 0 for empty cluster", resp["count"])
+		}
+	})
+}
+
+// TestHandleAPIQuotaPolicies is the REST-facade test for #13's acceptance
+// item: the endpoint must return the same state quotapolicy.List reads
+// from the CRD, not a separately maintained copy.
+func TestHandleAPIQuotaPolicies(t *testing.T) {
+	t.Run("no dynamic client", func(t *testing.T) {
+		srv := &Server{}
+		req := httptest.NewRequest(http.MethodGet, "/api/quota-policies", nil)
+		w := httptest.NewRecorder()
+		srv.handleAPIQuotaPolicies(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+		}
+		var resp map[string]interface{}
+		decodeJSON(t, w.Body, &resp)
+		if resp["enabled"] != false {
+			t.Fatalf("enabled = %v, want false", resp["enabled"])
+		}
+		items, ok := resp["items"].([]interface{})
+		if !ok || len(items) != 0 {
+			t.Fatalf("expected empty items, got %#v", resp["items"])
+		}
+	})
+
+	t.Run("with dynamic client", func(t *testing.T) {
+		max := *resource.NewQuantity(5*1024*1024*1024, resource.BinarySI)
+		qp := &v1alpha1.QuotaPolicy{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "quota.nfs.io/v1alpha1", Kind: "QuotaPolicy"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "p", Generation: 1},
+			Spec: v1alpha1.QuotaPolicySpec{
+				Selector: v1alpha1.QuotaPolicySelector{}, Priority: 100,
+				MaxQuota: &max, EnforceMax: true,
+			},
+			Status: v1alpha1.QuotaPolicyStatus{ObservedGeneration: 1},
+		}
+		u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(qp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+			map[schema.GroupVersionResource]string{quotapolicy.GroupVersionResource: "QuotaPolicyList"},
+			&unstructured.Unstructured{Object: u})
+
+		srv := &Server{dynamicClient: dc}
+		req := httptest.NewRequest(http.MethodGet, "/api/quota-policies", nil)
+		w := httptest.NewRecorder()
+		srv.handleAPIQuotaPolicies(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+		}
+		var resp struct {
+			Enabled bool                   `json:"enabled"`
+			Count   int                    `json:"count"`
+			Items   []v1alpha1.QuotaPolicy `json:"items"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if !resp.Enabled {
+			t.Fatalf("enabled = %v, want true", resp.Enabled)
+		}
+		if resp.Count != 1 || len(resp.Items) != 1 {
+			t.Fatalf("expected exactly 1 item, got count=%d items=%d", resp.Count, len(resp.Items))
+		}
+		got := resp.Items[0]
+		if got.Namespace != "default" || got.Name != "p" {
+			t.Errorf("got %s/%s, want default/p", got.Namespace, got.Name)
+		}
+		if got.Spec.MaxQuota == nil || got.Spec.MaxQuota.Value() != max.Value() {
+			t.Errorf("spec.maxQuota = %v, want %v -- the endpoint must return the same spec the CRD has, not a summarized/lossy copy", got.Spec.MaxQuota, max.Value())
+		}
+		if got.Status.ObservedGeneration != 1 {
+			t.Errorf("status.observedGeneration = %d, want 1 -- status must round-trip too, not just spec", got.Status.ObservedGeneration)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Closes one of #13's two remaining hard gaps (verified against the actual code before starting — see the issue comment). The other, the `Drifted` status condition, needs real filesystem quota read-back against a prjquota-mounted host to implement against reliably and stays deferred, same reasoning already documented for #10/#11.

`GET /api/quota-policies` returns exactly what `quotapolicy.List` reads from the CRD, via the *same* `dynamic.Interface` `main.go` already constructs when `--enable-quota-policy` is set (hoisted out of that `if` block so both the agent and the UI server can use it) — not a second client, no separately maintained copy of policy state. There is deliberately no write path: the CRD (`kubectl apply` / GitOps) remains the only way to create or modify a `QuotaPolicy`, matching this design's "CRD is the source of truth" principle (`docs/quotapolicy-design.md` §1).

`enabled` in the response reflects whether a dynamic client is configured at all, which already exactly tracks `--enable-quota-policy` — no second flag to keep in sync. Degrades to `enabled: false` / an empty list when no dynamic client is configured, including for the standalone `ui` subcommand (`nfs-quota-agent ui`), which has no Kubernetes client of any kind.

No RBAC changes needed — this reuses the `get/list/watch` on `quotapolicies` the chart already grants when `quotaPolicy.enabled` is true.

## Test plan

- [x] `TestHandleAPIQuotaPolicies/no_dynamic_client` — nil client degrades to `enabled: false`, empty items
- [x] `TestHandleAPIQuotaPolicies/with_dynamic_client` — a fake dynamic client seeded with one `QuotaPolicy` round-trips through the endpoint: namespace/name, `spec.maxQuota`, and `status.observedGeneration` all match what was seeded (not a summarized/lossy copy)
- [x] Mutation-verified: made the handler drop all items while still compiling, confirmed the test fails for the right reason, restored, confirmed it passes
- [x] `go build/vet/test -race ./...`, `gofmt -l .`, `golangci-lint run` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT