### PR TITLE
ci(security): egress auditing on every job, pin floating Helm version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,15 @@
+# Every job's first step is step-security/harden-runner in audit mode
+# (#26): it records every outbound network call this runner makes without
+# blocking any of it, visible afterward in each run's "Harden Runner"
+# step summary (and, once this workflow has run enough for a pattern to
+# aggregate, in the repo's Security > Supply chain view). audit, not
+# block: this repo has never observed and allowlisted its own real CI
+# egress (module proxy, sum.golang.org, ghcr.io, Docker Hub for the
+# Dockerfile's base images, GitHub's own API/artifact endpoints, the Trivy
+# vulnerability DB, ...), and shipping a guessed allowlist risks silently
+# breaking every future CI run instead of catching a real compromise.
+# Graduating to egress-policy: block with a real allowlist is the natural
+# follow-up once a few runs' worth of audit data exists to build one from.
 name: CI
 
 on:
@@ -11,6 +23,11 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -36,6 +53,11 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -57,6 +79,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, lint]
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -81,6 +108,11 @@ jobs:
     name: License Check
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -103,6 +135,11 @@ jobs:
     name: Generate Check
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -131,13 +168,18 @@ jobs:
     name: Helm Lint
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: 'latest'
+          version: 'v4.2.4'
 
       - name: Lint Helm chart
         run: helm lint ./charts/nfs-quota-agent
@@ -152,6 +194,11 @@ jobs:
       contents: read
       security-events: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,5 @@
+# Every job's first step is step-security/harden-runner in audit mode --
+# see the identical block in ci.yaml for why audit rather than block.
 name: Release
 
 on:
@@ -14,6 +16,11 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -32,6 +39,11 @@ jobs:
     outputs:
       changelog: ${{ steps.changelog.outputs.content }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -61,6 +73,11 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -110,6 +127,11 @@ jobs:
       contents: read
       security-events: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -129,6 +151,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -179,6 +206,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -192,7 +224,7 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: 'latest'
+          version: 'v4.2.4'
 
       - name: Package Helm chart
         run: |
@@ -211,6 +243,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Summary

Continues #26's supply-chain hardening (GitHub Actions and Docker base images were already pinned to digest in PR #30/#48).

**Egress auditing**: adds `step-security/harden-runner` (pinned to commit SHA, verified against the real upstream `v2.21.0` tag via `git ls-remote`) as the first step of every job in `ci.yaml` and `release.yaml`, in `egress-policy: audit` mode. It records every outbound network call each runner makes without blocking any of it. Deliberately **audit, not block**: this repo has never observed and allowlisted its own real CI egress (module proxy, ghcr.io, Docker Hub for the Dockerfile's base images, Trivy's vulnerability DB, ...), and shipping a guessed allowlist risks silently breaking every future CI run instead of catching a real compromise. Graduating to block mode with a real allowlist is the natural follow-up once actual audit data exists to build one from -- see the comment at the top of each workflow file.

**Floating Helm version**: both workflows' `azure/setup-helm` steps requested `version: 'latest'` -- the action reference itself was already pinned to a SHA, but the *Helm version it installs* was still a floating input, exactly the "reject latest/floating release inputs" gap #26 asks about. Pinned to `v4.2.4`, the version `latest` currently resolves to (verified via the GitHub API), so this freezes current behavior rather than silently upgrading to whatever Helm ships next.

## What this does NOT do (documented as follow-up, not silently dropped)

- Egress **blocking** -- needs a real, observed allowlist first (see above)
- Rust module inventory -- no Rust code in this repo (#7)
- Dependency diff review / cooling policy for new package versions -- process work, not started
- Quarantine/rollback procedure for a compromised dependency -- not started
- Binary/image SBOM ↔ provenance linkage -- overlaps #16, partially covered there

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on both files -- valid YAML
- [x] `actionlint` on both files -- zero new findings (the one reported finding, a pre-existing shellcheck SC2035 nit on an unrelated `sha256sum *` line, predates this change and is untouched by it)
- [x] Verified `step-security/harden-runner`'s `v2.21.0` tag resolves to the exact commit SHA pinned, via `git ls-remote --tags`
- [x] Verified `v4.2.4` is Helm's actual latest release via the GitHub API (same version `latest` already resolved to, so no behavior change beyond removing the float)
- [x] Confirmed one `Harden Runner` step per job (7 jobs in each file, 7 steps in each file) and that it's the literal first step in every job, including `release.yaml`'s `security-scan` job which has no checkout step at all
- [ ] CI itself is the real verification for whether harden-runner interferes with anything -- watching after this PR opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT