### PR TITLE
ci(release): publish chart as release asset and release manifest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,6 +72,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -107,6 +110,7 @@ jobs:
             type=sha
 
       - name: Build and push multi-arch image
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -199,12 +203,22 @@ jobs:
             dist/sbom.spdx.json
           generate_release_notes: false
 
+      - name: Upload binary checksums for manifest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binary-checksums
+          path: dist/checksums.txt
+
   helm-release:
     name: Release Helm Chart
     runs-on: ubuntu-latest
     needs: [test, changelog]
     permissions:
       contents: write
+    outputs:
+      chart_file: ${{ steps.package.outputs.chart_file }}
+      chart_version: ${{ steps.package.outputs.chart_version }}
+      chart_sha256: ${{ steps.checksum.outputs.chart_sha256 }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -227,14 +241,80 @@ jobs:
           version: 'v4.2.4'
 
       - name: Package Helm chart
+        id: package
         run: |
           helm package ./charts/nfs-quota-agent -d .helm-releases
+          chart_file=$(basename .helm-releases/*.tgz)
+          echo "chart_file=${chart_file}" >> "$GITHUB_OUTPUT"
+          echo "chart_version=$(helm show chart ./charts/nfs-quota-agent | awk '/^version:/ {print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Checksum Helm chart
+        id: checksum
+        run: |
+          cd .helm-releases
+          sha256sum "${{ steps.package.outputs.chart_file }}" > "${{ steps.package.outputs.chart_file }}.sha256"
+          echo "chart_sha256=$(cut -d' ' -f1 "${{ steps.package.outputs.chart_file }}.sha256")" >> "$GITHUB_OUTPUT"
 
       - name: Upload Helm chart artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: helm-chart
           path: .helm-releases/*.tgz
+
+      - name: Publish Helm chart as release asset
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          files: |
+            .helm-releases/${{ steps.package.outputs.chart_file }}
+            .helm-releases/${{ steps.package.outputs.chart_file }}.sha256
+          generate_release_notes: false
+
+  release-manifest:
+    name: Publish Release Manifest
+    runs-on: ubuntu-latest
+    needs: [build-and-push, release-binaries, helm-release]
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Download binary checksums
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: binary-checksums
+
+      - name: Generate release manifest
+        id: manifest
+        run: |
+          jq -n \
+            --arg tag "${{ github.ref_name }}" \
+            --arg commit "${{ github.sha }}" \
+            --arg workflow_run "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg image "${{ needs.build-and-push.outputs.image }}" \
+            --arg image_digest "${{ needs.build-and-push.outputs.digest }}" \
+            --arg chart_file "${{ needs.helm-release.outputs.chart_file }}" \
+            --arg chart_version "${{ needs.helm-release.outputs.chart_version }}" \
+            --arg chart_sha256 "${{ needs.helm-release.outputs.chart_sha256 }}" \
+            --slurpfile binaries <(awk '{print "{\"file\":\""$2"\",\"sha256\":\""$1"\"}"}' checksums.txt | jq -s .) \
+            '{
+              schemaVersion: 1,
+              tag: $tag,
+              sourceCommit: $commit,
+              workflowRun: $workflow_run,
+              image: { repository: $image, digest: $image_digest },
+              chart: { file: $chart_file, version: $chart_version, sha256: $chart_sha256 },
+              binaries: $binaries[0]
+            }' > release-manifest.json
+          cat release-manifest.json
+
+      - name: Publish release manifest
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          files: release-manifest.json
+          generate_release_notes: false
 
   update-changelog:
     name: Update CHANGELOG.md


### PR DESCRIPTION
## Summary
- `build-and-push` now exposes the pushed multi-arch image's digest as a job output (`docker/build-push-action` already provides it; it just wasn't captured before).
- `helm-release` now checksums the packaged chart and publishes the `.tgz` + `.sha256` as GitHub Release assets — previously the chart only existed as an ephemeral `actions/upload-artifact` (90-day retention, not part of the public release).
- New `release-manifest` job assembles a single `release-manifest.json` (tag, source commit SHA, workflow run URL, image repo+digest, chart version+sha256, binary sha256s) and attaches it to the same release, so every artifact's digest is traceable back to the commit/workflow that produced it.

Addresses two items from #16's acceptance criteria:
- "binary/container/chart/CRD release artifacts have immutable identity" — chart now has one (CRD ships inside the chart tgz, no separate top-level artifact exists).
- "artifact digest and source commit/workflow run provenance can be tracked" — via `release-manifest.json`.

## Test plan
- [x] `actionlint .github/workflows/release.yaml` — no new findings vs. main (one pre-existing shellcheck note on an unrelated line, unchanged by this PR)
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML
- [x] `helm show chart ./charts/nfs-quota-agent | awk ...` — chart-version extraction command verified against the real chart
- [x] jq/awk manifest-assembly pipeline dry-run with synthetic inputs
- [ ] Full run only exercises on an actual `v*` tag push (release workflow trigger) — not exercised end-to-end here; recommend watching the first tagged release after merge

Sample manifest shape verified locally:
\`\`\`json
{
  "schemaVersion": 1,
  "tag": "v0.4.0",
  "sourceCommit": "deadbeef",
  "workflowRun": "https://github.com/dasomel/nfs-quota-agent/actions/runs/123",
  "image": { "repository": "ghcr.io/dasomel/nfs-quota-agent", "digest": "sha256:abcdef" },
  "chart": { "file": "nfs-quota-agent-0.4.0.tgz", "version": "0.4.0", "sha256": "ffff999" },
  "binaries": [{ "file": "nfs-quota-agent-linux-amd64", "sha256": "aaaa111" }]
}
\`\`\`

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT