### PR TITLE
feat(agent): expose enforced quota limit distinctly from requested capacity

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -50,6 +50,13 @@ const (
 	AnnotationProjectName = "nfs.io/project-name"
 	// AnnotationQuotaStatus is the annotation key representing the quota application status on PVs.
 	AnnotationQuotaStatus = "nfs.io/quota-status"
+	// AnnotationEnforcedLimitBytes records the filesystem project quota hard
+	// limit actually enforced for this PV, in bytes. This can differ from
+	// PV.Spec.Capacity (the requested capacity) when a QuotaPolicy (#13)
+	// clamps the effective limit -- exposing it separately keeps
+	// "what Kubernetes was asked for" and "what the filesystem enforces"
+	// from being confused with each other (#14 acceptance).
+	AnnotationEnforcedLimitBytes = "nfs.io/enforced-limit-bytes"
 
 	// QuotaStatusPending indicates the quota application is pending.
 	QuotaStatusPending = "pending"
@@ -919,7 +926,7 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, e
 		if a.auditLogger != nil {
 			a.auditLogger.LogProjectIDAllocationFailure(pv.Name, namespace, pvcName, localPath, projectName, err)
 		}
-		a.updateQuotaStatus(ctx, pv, QuotaStatusFailed)
+		a.updateQuotaStatus(ctx, pv, QuotaStatusFailed, 0)
 		return fmt.Errorf("failed to allocate project ID for PV %s: %w", pv.Name, err)
 	}
 
@@ -937,12 +944,12 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, e
 	}
 
 	if err != nil {
-		a.updateQuotaStatus(ctx, pv, QuotaStatusFailed)
+		a.updateQuotaStatus(ctx, pv, QuotaStatusFailed, 0)
 		return err
 	}
 
 	a.appliedQuotas[localPath] = sizeBytes
-	a.updateQuotaStatus(ctx, pv, QuotaStatusApplied)
+	a.updateQuotaStatus(ctx, pv, QuotaStatusApplied, sizeBytes)
 
 	slog.Info("Quota applied successfully",
 		"pv", pv.Name,
@@ -1107,8 +1114,13 @@ func (a *QuotaAgent) applyQuota(path, projectName string, projectID uint32, size
 	}
 }
 
-// updateQuotaStatus updates the quota status annotation on the PV
-func (a *QuotaAgent) updateQuotaStatus(ctx context.Context, pv *v1.PersistentVolume, st string) {
+// updateQuotaStatus updates the quota status annotation on the PV, and --
+// when st is QuotaStatusApplied and enforcedBytes is known (> 0) -- the
+// enforced-limit annotation alongside it. A failed/pending write leaves any
+// existing enforced-limit annotation untouched: it still reflects the last
+// value actually enforced on the filesystem, which remains true regardless
+// of this attempt's outcome.
+func (a *QuotaAgent) updateQuotaStatus(ctx context.Context, pv *v1.PersistentVolume, st string, enforcedBytes int64) {
 	if ctx.Err() != nil {
 		// Expected during the reconcile queue's shutdown drain (see
 		// pvReconcileQueue.process): the filesystem quota mutation this
@@ -1129,6 +1141,9 @@ func (a *QuotaAgent) updateQuotaStatus(ctx context.Context, pv *v1.PersistentVol
 		freshPV.Annotations = make(map[string]string)
 	}
 	freshPV.Annotations[AnnotationQuotaStatus] = st
+	if st == QuotaStatusApplied && enforcedBytes > 0 {
+		freshPV.Annotations[AnnotationEnforcedLimitBytes] = strconv.FormatInt(enforcedBytes, 10)
+	}
 
 	_, err = a.client.CoreV1().PersistentVolumes().Update(ctx, freshPV, metav1.UpdateOptions{})
 	if err != nil {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -959,7 +959,37 @@ func TestUpdateQuotaStatusMissingPV(t *testing.T) {
 	a := newTestAgent(t, fake.NewSimpleClientset())
 	pv := &v1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: "does-not-exist"}}
 	// Should log and return without panicking when the Get fails.
-	a.updateQuotaStatus(context.Background(), pv, QuotaStatusFailed)
+	a.updateQuotaStatus(context.Background(), pv, QuotaStatusFailed, 0)
+}
+
+func TestUpdateQuotaStatusEnforcedLimitAnnotation(t *testing.T) {
+	pv := &v1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: "pv-enforced-limit"}}
+	clientset := fake.NewSimpleClientset(pv)
+	a := newTestAgent(t, clientset)
+
+	a.updateQuotaStatus(context.Background(), pv, QuotaStatusApplied, 1073741824)
+
+	got, err := clientset.CoreV1().PersistentVolumes().Get(context.Background(), pv.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Annotations[AnnotationEnforcedLimitBytes] != "1073741824" {
+		t.Fatalf("enforced-limit-bytes annotation = %q, want %q", got.Annotations[AnnotationEnforcedLimitBytes], "1073741824")
+	}
+
+	// A subsequent failed attempt must not clobber the last known enforced
+	// value -- it's still what the filesystem actually enforces.
+	a.updateQuotaStatus(context.Background(), pv, QuotaStatusFailed, 0)
+	got, err = clientset.CoreV1().PersistentVolumes().Get(context.Background(), pv.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Annotations[AnnotationEnforcedLimitBytes] != "1073741824" {
+		t.Fatalf("enforced-limit-bytes annotation after failed update = %q, want unchanged %q", got.Annotations[AnnotationEnforcedLimitBytes], "1073741824")
+	}
+	if got.Annotations[AnnotationQuotaStatus] != QuotaStatusFailed {
+		t.Fatalf("quota-status annotation = %q, want %q", got.Annotations[AnnotationQuotaStatus], QuotaStatusFailed)
+	}
 }
 
 func TestRecordHistoryNilStore(t *testing.T) {


### PR DESCRIPTION
## Summary
Part of #14's acceptance criteria: "`requestedCapacity`, `enforcedLimit`, `actualUsage`가 혼동되지 않는다."

Previously the only PV-visible quota state was `nfs.io/quota-status` (applied/pending/failed). The byte value actually enforced on the filesystem lived only in the agent's in-memory `appliedQuotas` cache — invisible outside logs. When a QuotaPolicy (#13) clamps the effective limit above/below `PV.Spec.Capacity` (the requested value), that clamp was unobservable from the PV object.

`nfs.io/enforced-limit-bytes` now records that value, written alongside `quota-status` only on a successful apply. A failed/pending attempt leaves it untouched — it still reflects the last value genuinely enforced on disk.

`requestedCapacity` (`PV.Spec.Capacity`, standard k8s field) and `actualUsage` (existing `/metrics` `nfs_quota_used_bytes` + web UI, both backed by `internal/status.GetDirUsages`, which reads real project-quota usage) already have established exposure paths — this PR only adds the missing piece, not a parallel/duplicate one.

## Test plan
- [x] `TestUpdateQuotaStatusEnforcedLimitAnnotation` — new test: successful apply sets the annotation; a subsequent failed update does not clobber the last known value
- [x] Mutation-verified: broke the annotation write while still compiling, confirmed the test fails for the right reason, restored, confirmed it passes
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l .` all clean

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT