### PR TITLE
feat(release): machine-readable compatibility matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,6 +131,21 @@ jobs:
           diff -u THIRD_PARTY_LICENSES.md /tmp/THIRD_PARTY_LICENSES.md || \
             (echo "::error::THIRD_PARTY_LICENSES.md is stale — run 'make license' and commit the result" && exit 1)
 
+  compat-matrix:
+    name: Compatibility Matrix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate hack/compatibility-matrix.json shape
+        run: make compat-matrix
+
   generate:
     name: Generate Check
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ We use a `Makefile` to automate common development workflows. The primary make t
 - `make license`       - Regenerates `THIRD_PARTY_LICENSES.md` from `go.mod`/`go.sum` and fails if any dependency's license isn't in `hack/allowed-licenses.txt`.
 - `make sbom`          - Generates an SBOM (SPDX + CycloneDX) for the Go dependency tree via `trivy` (if installed).
 - `make generate`      - Regenerates deepcopy code and the CRD manifest for `internal/apis/quota/v1alpha1` via `controller-gen`.
+- `make compat-matrix`  - Validates `hack/compatibility-matrix.json` (the machine-readable filesystem/architecture/Kubernetes-version support matrix, #5) has the required shape.
 
 If a PR changes `go.mod` or `go.sum`, run `make license` and commit the regenerated `THIRD_PARTY_LICENSES.md` — CI fails the `License Check` job if it goes stale.
 
@@ -33,6 +34,7 @@ Every job in [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml) has a loca
 | `License Check` | `make license` (regenerates `THIRD_PARTY_LICENSES.md` in place and checks every dependency's license against `hack/allowed-licenses.txt`; if the file changed, `git diff` shows what CI's separate staleness check would have failed on — commit the update) |
 | `Generate Check` | `make generate`, then `git diff --exit-code` on `internal/apis/quota/v1alpha1/zz_generated.deepcopy.go` and `charts/nfs-quota-agent/crds/quota.nfs.io_quotapolicies.yaml` |
 | `Helm Lint` | `make helm-lint`, then `helm template ./charts/nfs-quota-agent --set metrics.serviceMonitor.enabled=true --set metrics.prometheusRule.enabled=true --set podDisruptionBudget.enabled=true` for the same smoke-test coverage CI runs |
+| `Compatibility Matrix` | `make compat-matrix` (shape-only check — every entry in `hack/compatibility-matrix.json` has a `status` and `evidence` field. It cannot verify the `status` values themselves are still true; keep them honest by hand when new evidence appears, same as `hack/allowed-licenses.txt`.) |
 | `Security Scan` | **No local make target yet, and `govulncheck` is not a `go tool` dependency of this module** (unlike `go-licenses`/`controller-gen`). CI runs `aquasecurity/trivy-action` (filesystem scan) and `golang/govulncheck-action`; reproduce manually with `trivy fs .` (if `trivy` is installed) and `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`. Tracked as a gap in #16. |
 
 ## Testing Conventions

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ VERSION?=latest
 PLATFORMS?=linux/amd64,linux/arm64,linux/arm/v7
 
 .PHONY: all build build-linux clean test test-coverage fmt vet tidy lint \
-	license sbom generate \
+	license sbom generate compat-matrix \
 	docker-build docker-push docker-buildx \
 	helm-lint helm-package helm-install helm-uninstall
 
@@ -93,6 +93,20 @@ sbom:
 	trivy fs --format spdx-json --output sbom/sbom.spdx.json .
 	trivy fs --format cyclonedx --output sbom/sbom.cyclonedx.json .
 	@echo "SBOM written to sbom/sbom.spdx.json and sbom/sbom.cyclonedx.json"
+
+# Validate hack/compatibility-matrix.json is well-formed and every entry
+# carries a status and evidence field -- the machine-readable
+# filesystem/architecture/Kubernetes-version support matrix #5 asks for.
+# This only checks shape, not truth: keeping "status" honest against what
+# has actually been observed is a human judgment call made when editing
+# the file, same as hack/allowed-licenses.txt.
+compat-matrix:
+	@python3 -c "\
+import json, sys; \
+data = json.load(open('hack/compatibility-matrix.json')); \
+sections = ['filesystemBackends', 'architectures', 'kubernetesVersions']; \
+missing = [(s, e) for s in sections for e in data.get(s, []) if 'status' not in e or 'evidence' not in e]; \
+sys.exit('missing status/evidence in: ' + repr(missing)) if missing else print('compatibility-matrix.json OK (' + str(sum(len(data.get(s, [])) for s in sections)) + ' entries)')"
 
 # Build Docker image
 docker-build:

--- a/hack/compatibility-matrix.json
+++ b/hack/compatibility-matrix.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": 1,
+  "description": "Machine-readable record of what has actually been observed to work, as of the evidence cited per entry -- not a claim about what should work. status values: verified (real cluster/host, evidence cited), build-verified (compiles and passes stubbed-runner unit tests only, no real filesystem/cluster exercised), unverified (implemented, never exercised), known-gap (a specific, named blocker exists).",
+  "filesystemBackends": [
+    {
+      "backend": "xfs",
+      "status": "verified",
+      "evidence": "nfs-quota-agent#4 E2E session: real prjquota-mounted XFS loopback host, quota apply/rolling-upgrade/idempotent-resync all observed via xfs_quota report and /etc/projects,/etc/projid contents.",
+      "notes": "Primary target filesystem for this project; the only backend with real end-to-end verification."
+    },
+    {
+      "backend": "ext4",
+      "status": "known-gap",
+      "evidence": "nfs-quota-agent#4 E2E session: unit tests pass (stubbed CommandRunner), but a real ext4 prjquota mount attempt failed with a kernel error (\"Failed to enable quota tracking (type=2, err=-3, ino=12)\") even after e2fsck -fy on the test host; root cause not diagnosed, session moved to XFS instead.",
+      "notes": "Not a known code defect in internal/quota/ext4.go -- the failure was at the mkfs/mount layer of the one test host tried. Needs a second, dedicated attempt on a host confirmed to support ext4 project quota before this can move to verified."
+    },
+    {
+      "backend": "btrfs",
+      "status": "known-gap",
+      "evidence": "CLAUDE.md gotcha: the shipped container image's apk add line never installs btrfs-progs, so btrfs.go's shelled-out btrfs calls fail inside the container regardless of host kernel support.",
+      "notes": "Also requires the target path to already be a subvolume with `btrfs quota enable` run -- a host precondition this agent does not set up itself. Unit tests pass (stubbed runner) but no in-container or real-host E2E exists."
+    }
+  ],
+  "architectures": [
+    {
+      "arch": "linux/amd64",
+      "status": "build-verified",
+      "evidence": "release.yaml cross-compiles and multi-arch buildx-builds this target on every tagged release; no functional E2E has been run on this architecture."
+    },
+    {
+      "arch": "linux/arm64",
+      "status": "verified",
+      "evidence": "nfs-quota-agent#4 E2E session ran on Apple Silicon (arm64) via colima -- full agent deploy, quota enforcement, rolling upgrade all observed on this architecture."
+    },
+    {
+      "arch": "linux/arm/v7",
+      "status": "build-verified",
+      "evidence": "release.yaml cross-compiles and multi-arch buildx-builds this target on every tagged release; no functional E2E has been run on this architecture."
+    }
+  ],
+  "kubernetesVersions": [
+    {
+      "version": "1.35",
+      "distribution": "k3s",
+      "status": "verified",
+      "evidence": "nfs-quota-agent#4 E2E session (prior to the 1.36 pass documented in the same issue): DaemonSet/PDB/RBAC/CRD/CEL admission all exercised."
+    },
+    {
+      "version": "1.36",
+      "distribution": "k3s (v1.36.3+k3s1)",
+      "status": "verified",
+      "evidence": "nfs-quota-agent#4 E2E session: same coverage as 1.35, plus the DaemonSet+PDB scale-subresource limitation documented there (issues/4 comment)."
+    }
+  ],
+  "knownLimitations": [
+    {
+      "id": "daemonset-pdb-scale-subresource",
+      "summary": "PodDisruptionBudget against a DaemonSet-managed pod fails closed (blocks all Eviction API disruption) on k3s v1.36.3 due to a k8s core limitation (\"daemonsets.apps does not implement the scale subresource\"). helm-upgrade-driven rolling replacement is unaffected -- it does not go through the Eviction API.",
+      "evidence": "nfs-quota-agent#4"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Addresses #5's "supported-version matrix machine-readable output" acceptance item.

`hack/compatibility-matrix.json` records filesystem backend (xfs/ext4/btrfs), architecture (amd64/arm64/armv7), and Kubernetes-version (1.35/1.36) support with a `status` (`verified` / `build-verified` / `unverified` / `known-gap`) and an `evidence` citation per entry. Populated only from evidence that actually exists:

- **xfs**: `verified` — real prjquota host E2E in #4
- **ext4**: `known-gap` — a real mount attempt in #4 hit a host-level kernel error, not diagnosed as a code defect
- **btrfs**: `known-gap` — the container image doesn't ship `btrfs-progs` (existing CLAUDE.md gotcha)
- **arm64 + k3s 1.35/1.36**: `verified` — #4's E2E sessions ran on Apple Silicon
- **amd64/armv7**: `build-verified` only — release.yaml cross-compiles/pushes them but no functional E2E has run on either

`make compat-matrix` (new target) and a new CI `Compatibility Matrix` job validate the file's shape (every entry has `status` + `evidence`) — same as `hack/allowed-licenses.txt`, this can't verify the status values are still true, that's a human judgment call when new evidence appears.

## Test plan
- [x] `make compat-matrix` — passes, reports 8 entries
- [x] `actionlint .github/workflows/ci.yaml` — clean
- [x] `python3 -c "import json; json.load(...)"` — valid JSON
- [x] `go build ./...` — unaffected (no Go changes)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT