### PR TITLE
docs(chart): document the DaemonSet PDB scale-subresource limitation

### DIFF
--- a/charts/nfs-quota-agent/templates/pdb.yaml
+++ b/charts/nfs-quota-agent/templates/pdb.yaml
@@ -1,4 +1,17 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+# Known limitation (observed on k3s v1.36.3, #4): the disruption controller
+# cannot compute expectedPods/currentHealthy/disruptionsAllowed for a
+# DaemonSet-backed PDB ("daemonsets.apps does not implement the scale
+# subresource" -- see `kubectl describe pdb` events), so
+# disruptionsAllowed stays permanently 0 and every direct Eviction API
+# call against this pod returns 429 DisruptionBudget, regardless of
+# maxUnavailable's value. `kubectl drain` is unaffected (it skips
+# DaemonSet pods entirely, PDB or not), and so is `helm upgrade`'s
+# rolling replacement (DaemonSet-controller-driven delete+create, not the
+# Eviction API). Only a caller that evicts directly -- cluster-autoscaler,
+# descheduler, a custom controller -- is blocked, and fails safe (retries
+# forever rather than force-removing the pod). Root cause is in
+# Kubernetes core, not this chart; see #4 for the reproduction.
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
## Summary
#4's E2E session (isolated k3s v1.36.3 cluster) found a real, reproducible k8s-core limitation: a DaemonSet-backed PDB's `disruptionsAllowed` stays permanently 0 because the disruption controller can't compute `expectedPods` for a DaemonSet ("daemonsets.apps does not implement the scale subresource" — visible in `kubectl describe pdb` events). Any direct Eviction API call against the pod returns 429 regardless of `maxUnavailable`.

`kubectl drain` and `helm upgrade`'s rolling replacement are both unaffected — neither goes through the Eviction API for a DaemonSet-managed pod.

Documents this directly in `pdb.yaml` where an operator confused by a permanently-stuck eviction would actually look, rather than leaving it only in the #4 issue thread.

## Test plan
- [x] `helm lint ./charts/nfs-quota-agent` — clean
- [x] `helm template ./charts/nfs-quota-agent --set podDisruptionBudget.enabled=true` — PDB still renders correctly, comment doesn't affect output

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT