### PR TITLE
feat(quota): read back and verify filesystem quota state after apply

### DIFF
--- a/charts/nfs-quota-agent/templates/pdb.yaml
+++ b/charts/nfs-quota-agent/templates/pdb.yaml
@@ -1,4 +1,17 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+# Known limitation (observed on k3s v1.36.3, #4): the disruption controller
+# cannot compute expectedPods/currentHealthy/disruptionsAllowed for a
+# DaemonSet-backed PDB ("daemonsets.apps does not implement the scale
+# subresource" -- see `kubectl describe pdb` events), so
+# disruptionsAllowed stays permanently 0 and every direct Eviction API
+# call against this pod returns 429 DisruptionBudget, regardless of
+# maxUnavailable's value. `kubectl drain` is unaffected (it skips
+# DaemonSet pods entirely, PDB or not), and so is `helm upgrade`'s
+# rolling replacement (DaemonSet-controller-driven delete+create, not the
+# Eviction API). Only a caller that evicts directly -- cluster-autoscaler,
+# descheduler, a custom controller -- is blocked, and fails safe (retries
+# forever rather than force-removing the pod). Root cause is in
+# Kubernetes core, not this chart; see #4 for the reproduction.
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -245,6 +245,17 @@ func (a *QuotaAgent) SetProjectsFile(v string) { a.projectsFile = v }
 // SetProjidFile sets the projid file path.
 func (a *QuotaAgent) SetProjidFile(v string) { a.projidFile = v }
 
+// ProjectsFile returns the configured projects file path, for callers
+// (internal/metrics, internal/ui) that need to read the same real
+// on-disk quota state ensureQuota's own verification does, rather than
+// assume the standard /etc/projects -- see the CLAUDE.md gotcha on
+// GetDirUsages' hardcoded defaults for why this matters under a
+// non-default --projects-file.
+func (a *QuotaAgent) ProjectsFile() string { return a.projectsFile }
+
+// ProjidFile returns the configured projid file path. See ProjectsFile.
+func (a *QuotaAgent) ProjidFile() string { return a.projidFile }
+
 // SetStateDir sets the host-backed directory used for crash-recovery backup
 // sidecars of projectsFile/projidFile. An empty value disables the sidecar
 // (see quota.RemoveLineFromFile/RecoverProjectFile), degrading gracefully
@@ -1265,7 +1276,7 @@ func (a *QuotaAgent) recordHistory() {
 	}
 
 	fsType, _ := quota.DetectFSType(a.nfsBasePath)
-	usages, err := status.GetDirUsages(a.nfsBasePath, fsType)
+	usages, err := status.GetDirUsages(a.nfsBasePath, fsType, a.projectsFile, a.projidFile)
 	if err != nil {
 		slog.Error("Failed to get usages for history", "error", err)
 		return

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -127,6 +127,18 @@ type QuotaAgent struct {
 	reconcileTotal         atomic.Int64
 	reconcileErrors        atomic.Int64
 	reconcileDurationNanos atomic.Int64
+	// verificationFailures counts ensureQuota applies that succeeded (the
+	// quota binary exited 0) but whose read-back verification (see
+	// verifyQuotaOnDisk) then found the on-disk state didn't actually
+	// match what was requested -- a distinct failure class from an apply
+	// command itself failing, tracked separately so operators can tell
+	// "the tool refused" from "the tool lied" (#10). Also counted in
+	// reconcileErrors when the failing call went through the watch path's
+	// reconcile queue (recordReconcileResult) -- but NOT when it came from
+	// syncAllQuotas' periodic full sync, which calls ensureQuota directly
+	// and never touches recordReconcileResult. Don't assume this is always
+	// a subset of reconcileErrors; it can exceed it.
+	verificationFailures atomic.Int64
 
 	// Auto-cleanup configuration
 	enableAutoCleanup bool
@@ -935,6 +947,25 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, e
 
 	err = a.applyQuota(localPath, projectName, projectID, sizeBytes)
 
+	// Read-back verification (#10) runs before the CREATE/UPDATE audit
+	// entry, not after: the quota binary exiting 0 means the command
+	// succeeded, not that the kernel actually holds the limit we asked
+	// for. Auditing "success" here and a VERIFY_FAILED entry right behind
+	// it on a verification failure would leave two contradictory entries
+	// for the same apply -- anything reading the audit log for "was this
+	// quota applied" (the web UI's audit view) would trust the first one
+	// and be wrong. err is folded into a single final outcome instead, so
+	// exactly one CREATE/UPDATE entry reflects what actually happened.
+	if err == nil {
+		if verifyErr := a.verifyQuotaOnDisk(localPath, sizeBytes); verifyErr != nil {
+			a.verificationFailures.Add(1)
+			err = fmt.Errorf("quota apply succeeded but read-back verification failed for PV %s: %w", pv.Name, verifyErr)
+			if a.auditLogger != nil {
+				a.auditLogger.LogQuotaVerificationFailure(pv.Name, localPath, projectName, projectID, sizeBytes, a.fsType, verifyErr)
+			}
+		}
+	}
+
 	if a.auditLogger != nil {
 		if isUpdate {
 			a.auditLogger.LogQuotaUpdate(pv.Name, localPath, projectName, projectID, oldQuota, sizeBytes, a.fsType, err)
@@ -1112,6 +1143,63 @@ func (a *QuotaAgent) applyQuota(path, projectName string, projectID uint32, size
 	default:
 		return fmt.Errorf("unsupported filesystem type: %s", a.fsType)
 	}
+}
+
+// verifyQuotaOnDisk reads back the actual filesystem-enforced quota for
+// localPath and confirms it equals sizeBytes -- the "did the apply command
+// exiting 0 actually mean the kernel holds this limit" check #10 asks for.
+// Uses the agent's own configured a.projectsFile/a.projidFile (not the
+// hardcoded /etc/projects, /etc/projid the status/UI reporting path uses),
+// so this stays hermetically testable and correct under a non-default
+// --projects-file/--projid-file.
+//
+// Called from within ensureQuota, which already holds a.mu for its whole
+// body -- this only reads config fields set at startup (a.fsType,
+// a.nfsBasePath, a.projectsFile, a.projidFile), so no additional locking
+// is needed here.
+func (a *QuotaAgent) verifyQuotaOnDisk(localPath string, sizeBytes int64) error {
+	var quotaMap map[string]uint64
+	var err error
+
+	// a.quotaPath, matching what applyQuota itself targets (ApplyXFSQuota/
+	// ApplyExt4Quota's quotaPath, ApplyBtrfsQuota's own path argument) --
+	// not a.nfsBasePath, which happens to equal it by default but is a
+	// separate field once --quota-path diverges from the base export path.
+	switch a.fsType {
+	case quota.FSTypeXFS:
+		quotaMap, _, err = quota.GetXFSQuotaReport(a.quotaPath, a.projectsFile, a.projidFile)
+	case quota.FSTypeExt4:
+		quotaMap, _, err = quota.GetExt4QuotaReport(a.quotaPath, a.projectsFile)
+	case quota.FSTypeBtrfs:
+		quotaMap, _, err = quota.GetBtrfsQuotaReport(a.quotaPath)
+	default:
+		return fmt.Errorf("unsupported filesystem type: %s", a.fsType)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read back on-disk quota report: %w", err)
+	}
+
+	got, ok := quotaMap[localPath]
+	if !ok {
+		return fmt.Errorf("path %s not found in on-disk quota report after apply", localPath)
+	}
+	// Compare against what the backend was actually asked to enforce, not
+	// the raw request: XFS/ext4 both floor to whole KB (see
+	// ExpectedEnforcedBytes), so comparing against sizeBytes directly
+	// would reject a correct apply for any capacity that isn't already a
+	// 1024-byte multiple -- e.g. any decimal-SI `storage: 1G` PV.
+	want := uint64(quota.ExpectedEnforcedBytes(a.fsType, sizeBytes))
+	if got != want {
+		return fmt.Errorf("on-disk quota %d does not match expected enforced value %d (requested %d)", got, want, sizeBytes)
+	}
+	return nil
+}
+
+// VerificationFailures returns the cumulative count of ensureQuota applies
+// whose read-back verification (verifyQuotaOnDisk) failed after the apply
+// command itself succeeded, since process start.
+func (a *QuotaAgent) VerificationFailures() int64 {
+	return a.verificationFailures.Load()
 }
 
 // updateQuotaStatus updates the quota status annotation on the PV, and --

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -611,12 +612,31 @@ func TestEnsureQuotaSuccess(t *testing.T) {
 }
 
 func TestEnsureQuotaBtrfsSuccess(t *testing.T) {
+	// The runner tracks the `qgroup limit` call's (path -> byte limit) and
+	// answers a later `qgroup show` from that state, so ensureQuota's
+	// post-apply read-back verification (verifyQuotaOnDisk, #10) sees the
+	// limit it just applied instead of an unhandled-command error.
+	var mu sync.Mutex
+	limits := map[string]string{} // path -> byte limit string
 	withFakeRunner(t, &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
 		if name == "btrfs" && args[0] == "subvolume" && args[1] == "show" {
 			return []byte("Name: my-subvolume\nUUID: 1234"), nil
 		}
 		if name == "btrfs" && args[0] == "qgroup" && args[1] == "limit" {
+			mu.Lock()
+			limits[args[3]] = args[2]
+			mu.Unlock()
 			return []byte(""), nil
+		}
+		if name == "btrfs" && args[0] == "qgroup" && args[1] == "show" {
+			mu.Lock()
+			defer mu.Unlock()
+			var sb strings.Builder
+			sb.WriteString("qgroupid rfer excl max_rfer max_excl path\n-------- ---- ---- -------- -------- ----\n")
+			for path, bytes := range limits {
+				fmt.Fprintf(&sb, "0/256 %s %s %s none %s\n", bytes, bytes, bytes, path)
+			}
+			return []byte(sb.String()), nil
 		}
 		return nil, errors.New("unexpected command")
 	}})
@@ -724,6 +744,156 @@ func TestEnsureQuotaCommandFailure(t *testing.T) {
 	}
 	if updated.Annotations[AnnotationQuotaStatus] != QuotaStatusFailed {
 		t.Fatalf("expected quota status failed, got %q", updated.Annotations[AnnotationQuotaStatus])
+	}
+}
+
+// TestEnsureQuota_VerificationFailureNotReportedApplied covers #10's core
+// case: the apply command itself exits 0 (project init + limit both
+// "succeed"), but the read-back report doesn't show the project at all --
+// simulating the kernel not actually holding the state the tool claimed to
+// set. This must be treated the same as an apply command failure: no
+// caching, no QuotaStatusApplied, a distinct verification-failure count.
+func TestEnsureQuota_VerificationFailureNotReportedApplied(t *testing.T) {
+	r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+		if name == "xfs_quota" && len(args) >= 3 && strings.HasPrefix(args[2], "report") {
+			// The kernel's report doesn't show the project the preceding
+			// `limit -p` call just "applied" -- as if the mutation never
+			// actually took effect despite the command exiting 0.
+			return []byte("Project ID   Used   Soft   Hard   Warn/Grace\n"), nil
+		}
+		return xfsHappyRunner().fn(name, args...)
+	}}
+	withFakeRunner(t, r)
+
+	a, pv, client := ensureQuotaFixture(t, 1)
+	a.fsType = quota.FSTypeXFS
+
+	ctx := context.Background()
+	err := a.ensureQuota(ctx, pv, 0)
+	if err == nil {
+		t.Fatalf("expected verification-failure error")
+	}
+	if !strings.Contains(err.Error(), "read-back verification failed") {
+		t.Fatalf("expected error to mention read-back verification, got: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if _, ok := a.appliedQuotas[localPath]; ok {
+		t.Fatalf("appliedQuotas should not be set when read-back verification fails")
+	}
+
+	updated, err := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pv: %v", err)
+	}
+	if updated.Annotations[AnnotationQuotaStatus] != QuotaStatusFailed {
+		t.Fatalf("expected quota status failed, got %q", updated.Annotations[AnnotationQuotaStatus])
+	}
+	if updated.Annotations[AnnotationEnforcedLimitBytes] != "" {
+		t.Fatalf("enforced-limit-bytes should not be set for a verification failure, got %q", updated.Annotations[AnnotationEnforcedLimitBytes])
+	}
+
+	if got := a.VerificationFailures(); got != 1 {
+		t.Fatalf("VerificationFailures() = %d, want 1", got)
+	}
+}
+
+// TestEnsureQuota_VerificationMismatchedValueNotReportedApplied covers the
+// value-comparison branch specifically (as opposed to the "path missing
+// entirely" branch the test above covers) -- the report finds the project
+// at the right path, but with a different hard limit than what was
+// actually requested, simulating on-disk drift from the desired state.
+// Deleting the value comparison in verifyQuotaOnDisk entirely (leaving only
+// the "found" check) would make every other test in this file still pass,
+// since xfsHappyRunner's fake always reports back whatever value the
+// preceding `limit -p` call sent it -- this test is the one that would
+// catch that regression.
+func TestEnsureQuota_VerificationMismatchedValueNotReportedApplied(t *testing.T) {
+	r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+		if name == "xfs_quota" && len(args) >= 3 && strings.HasPrefix(args[2], "report") {
+			// Drift: the on-disk hard limit doesn't match what the
+			// preceding limit -p call for this project ID actually set.
+			return []byte("Project ID   Used   Soft   Hard   Warn/Grace\n#pv_pv_1     0      0      1    00 [------]\n"), nil
+		}
+		return xfsHappyRunner().fn(name, args...)
+	}}
+	withFakeRunner(t, r)
+
+	a, pv, client := ensureQuotaFixture(t, 1)
+	a.fsType = quota.FSTypeXFS
+
+	ctx := context.Background()
+	err := a.ensureQuota(ctx, pv, 0)
+	if err == nil {
+		t.Fatalf("expected verification-failure error for a mismatched on-disk value")
+	}
+	if !strings.Contains(err.Error(), "does not match expected enforced value") {
+		t.Fatalf("expected error to mention the value mismatch, got: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if _, ok := a.appliedQuotas[localPath]; ok {
+		t.Fatalf("appliedQuotas should not be set when the on-disk value doesn't match")
+	}
+
+	updated, err := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pv: %v", err)
+	}
+	if updated.Annotations[AnnotationQuotaStatus] != QuotaStatusFailed {
+		t.Fatalf("expected quota status failed, got %q", updated.Annotations[AnnotationQuotaStatus])
+	}
+}
+
+// TestEnsureQuota_NonGiCapacitySucceeds is the direct regression test for
+// the bug an independent review found in this same change: XFS/ext4 floor
+// the requested size to whole KB before enforcing it (ApplyXFSQuota's
+// bhard=%dk), so comparing read-back state against the raw requested byte
+// count -- instead of quota.ExpectedEnforcedBytes' floored value -- made
+// verifyQuotaOnDisk reject every correctly-applied PV whose capacity isn't
+// already a 1024-byte multiple. Every other ensureQuota test in this file
+// uses a Gi-multiple capacity via newBoundPV/ensureQuotaFixture, which is
+// exactly why this slipped through: 1Gi is already 1024-byte-aligned, so
+// the floor is a no-op and the bug is invisible.
+func TestEnsureQuota_NonGiCapacitySucceeds(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-nongi"},
+		Spec: v1.PersistentVolumeSpec{
+			// 1G decimal SI = 1,000,000,000 bytes -- not a multiple of 1024.
+			Capacity: v1.ResourceList{v1.ResourceStorage: *resource.NewQuantity(1000000000, resource.DecimalSI)},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				NFS: &v1.NFSVolumeSource{Server: "nfs.example.com", Path: "/exports/pvc-nongi"},
+			},
+			ClaimRef: &v1.ObjectReference{Namespace: "default", Name: "pv-nongi-claim"},
+		},
+		Status: v1.PersistentVolumeStatus{Phase: v1.VolumeBound},
+	}
+	client := fake.NewSimpleClientset(pv)
+	a := newTestAgent(t, client)
+	a.nfsServerPath = "/exports"
+	a.fsType = quota.FSTypeXFS
+	localPath := a.nfsPathToLocal("/exports/pvc-nongi")
+	if err := os.MkdirAll(localPath, 0755); err != nil {
+		t.Fatalf("mkdir localPath: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := a.ensureQuota(ctx, pv, 0); err != nil {
+		t.Fatalf("ensureQuota: %v", err)
+	}
+
+	if _, ok := a.appliedQuotas[localPath]; !ok {
+		t.Fatalf("expected appliedQuotas to be recorded for a non-Gi-multiple capacity")
+	}
+
+	updated, err := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pv: %v", err)
+	}
+	if updated.Annotations[AnnotationQuotaStatus] != QuotaStatusApplied {
+		t.Fatalf("expected quota status applied, got %q", updated.Annotations[AnnotationQuotaStatus])
 	}
 }
 

--- a/internal/agent/helpers_test.go
+++ b/internal/agent/helpers_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package agent
 
 import (
+	"fmt"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -64,9 +67,62 @@ func withFakeRunner(t *testing.T, r *fakeRunner) {
 	t.Cleanup(restore)
 }
 
+// xfsQuotaState is a minimal in-memory stand-in for the kernel's XFS
+// project quota table: it tracks each `limit -p bhard=...` call's project
+// ID -> byte limit and answers a later `report -p -b` query from that
+// state. Any fake xfs_quota runner that lets ensureQuota reach a successful
+// apply needs this -- without it, the post-apply read-back verification
+// (verifyQuotaOnDisk, #10) finds no matching project in the report and
+// fails, since the report command must actually reflect what was applied
+// rather than return a fixed string.
+type xfsQuotaState struct {
+	mu      sync.Mutex
+	applied map[string]int64 // projectID string -> hard limit bytes
+}
+
+// handle answers a "-x -c <cmd> [path]" xfs_quota invocation if cmd is a
+// `limit -p` or `report` call; ok is false for anything else (state/
+// version checks), leaving the caller to answer those itself.
+func (s *xfsQuotaState) handle(cmd string) (out []byte, ok bool) {
+	switch {
+	case strings.HasPrefix(cmd, "limit -p "):
+		fields := strings.Fields(cmd)
+		var projectID string
+		var bhardBytes int64
+		for _, f := range fields[2:] {
+			if strings.HasPrefix(f, "bhard=") {
+				if kb, err := strconv.ParseInt(strings.TrimSuffix(strings.TrimPrefix(f, "bhard="), "k"), 10, 64); err == nil {
+					bhardBytes = kb * 1024
+				}
+			} else {
+				projectID = f
+			}
+		}
+		s.mu.Lock()
+		if s.applied == nil {
+			s.applied = map[string]int64{}
+		}
+		s.applied[projectID] = bhardBytes
+		s.mu.Unlock()
+		return []byte(""), true
+	case strings.HasPrefix(cmd, "report"):
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		var sb strings.Builder
+		sb.WriteString("Project ID   Used   Soft   Hard   Warn/Grace\n")
+		for id, bytes := range s.applied {
+			fmt.Fprintf(&sb, "#%s     0      0      %d    00 [------]\n", id, bytes/1024)
+		}
+		return []byte(sb.String()), true
+	default:
+		return nil, false
+	}
+}
+
 // xfsHappyRunner returns a fakeRunner that answers every findmnt/xfs_quota
-// call needed for a successful xfs detect+check+apply flow.
+// call needed for a successful xfs detect+check+apply+verify flow.
 func xfsHappyRunner() *fakeRunner {
+	state := &xfsQuotaState{}
 	return &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
 		switch name {
 		case "findmnt":
@@ -74,6 +130,11 @@ func xfsHappyRunner() *fakeRunner {
 		case "xfs_quota":
 			if len(args) > 0 && args[0] == "-V" {
 				return []byte("xfs_quota version 1.0"), nil
+			}
+			if len(args) >= 3 && args[1] == "-c" {
+				if out, ok := state.handle(args[2]); ok {
+					return out, nil
+				}
 			}
 			return []byte("Project quota state: ON"), nil
 		default:

--- a/internal/agent/reconcile_queue_test.go
+++ b/internal/agent/reconcile_queue_test.go
@@ -55,6 +55,7 @@ func blockingXFSRunner(unblock <-chan struct{}) *fakeRunner {
 // AddRateLimited retry path.
 func failNTimesXFSRunner(n int) *fakeRunner {
 	var calls atomic.Int32
+	state := &xfsQuotaState{}
 	return &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
 		switch name {
 		case "findmnt":
@@ -65,6 +66,16 @@ func failNTimesXFSRunner(n int) *fakeRunner {
 			}
 			if calls.Add(1) <= int32(n) {
 				return nil, fmt.Errorf("simulated transient xfs_quota failure")
+			}
+			// Past the injected-failure count: behave like a working
+			// xfs_quota, including answering the post-apply read-back
+			// verification's `report` query (#10) from the same state
+			// the retry's `limit -p` call just wrote -- see xfsHappyRunner's
+			// doc comment for why a bare fixed-string reply isn't enough.
+			if len(args) >= 3 && args[1] == "-c" {
+				if out, ok := state.handle(args[2]); ok {
+					return out, nil
+				}
 			}
 			return []byte("Project quota state: ON"), nil
 		default:

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -151,6 +151,50 @@ func TestLogProjectIDAllocationFailure(t *testing.T) {
 	}
 }
 
+func TestLogQuotaVerificationFailure(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "audit-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logPath := filepath.Join(tmpDir, "audit.log")
+	logger, err := NewLogger(Config{Enabled: true, FilePath: logPath, MaxFileSize: 10 * 1024 * 1024})
+	if err != nil {
+		t.Fatalf("Failed to create audit logger: %v", err)
+	}
+
+	logger.LogQuotaVerificationFailure("pv-drift", "/data/drift", "project_drift", 42, 1073741824, "xfs", errors.New("on-disk quota 999999488 does not match expected enforced value 1000000000"))
+	logger.Close()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("Failed to read audit log: %v", err)
+	}
+
+	var entry Entry
+	lines := splitLines(data)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", len(lines))
+	}
+	if err := json.Unmarshal(lines[0], &entry); err != nil {
+		t.Fatalf("failed to parse audit entry: %v", err)
+	}
+
+	if entry.Action != ActionVerifyFailed {
+		t.Errorf("Action = %q, want %q", entry.Action, ActionVerifyFailed)
+	}
+	if entry.Success {
+		t.Error("Success = true, want false for a verification failure")
+	}
+	if entry.Error == "" {
+		t.Error("Error should be populated")
+	}
+	if entry.PVName != "pv-drift" || entry.Path != "/data/drift" || entry.ProjectName != "project_drift" || entry.ProjectID != 42 || entry.NewQuota != 1073741824 || entry.FSType != "xfs" {
+		t.Errorf("unexpected entry fields: %+v", entry)
+	}
+}
+
 func TestAuditLoggerDisabled(t *testing.T) {
 	config := Config{
 		Enabled: false,

--- a/internal/audit/entry.go
+++ b/internal/audit/entry.go
@@ -27,6 +27,11 @@ const (
 	ActionDelete   Action = "DELETE"
 	ActionCleanup  Action = "CLEANUP"
 	ActionAllocate Action = "ALLOCATE"
+	// ActionVerifyFailed marks a distinct failure class from
+	// ActionCreate/ActionUpdate's own Success=false: the quota apply
+	// command itself exited 0, but reading the value back off the
+	// filesystem afterward didn't match what was requested (#10).
+	ActionVerifyFailed Action = "VERIFY_FAILED"
 )
 
 // Entry represents a single audit log entry

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -175,6 +175,29 @@ func (l *Logger) LogProjectIDAllocationFailure(pvName, namespace, pvcName, path,
 	}
 }
 
+// LogQuotaVerificationFailure logs a read-back verification failure: the
+// quota apply command itself succeeded, but the on-disk state afterward
+// didn't match quotaBytes (#10). Distinct from LogQuotaCreate/LogQuotaUpdate
+// with a non-nil err, which cover the apply command itself failing -- this
+// is "the tool reported success but lied." Only ever called with a non-nil
+// err; Success is always false.
+func (l *Logger) LogQuotaVerificationFailure(pvName, path, projectName string, projectID uint32, quotaBytes int64, fsType string, err error) {
+	entry := Entry{
+		Action:      ActionVerifyFailed,
+		PVName:      pvName,
+		Path:        path,
+		ProjectID:   projectID,
+		ProjectName: projectName,
+		NewQuota:    quotaBytes,
+		FSType:      fsType,
+		Success:     false,
+		Error:       err.Error(),
+	}
+	if err := l.Log(entry); err != nil {
+		slog.Warn("Failed to write audit log entry", "action", entry.Action, "error", err)
+	}
+}
+
 // LogQuotaUpdate logs quota update
 func (l *Logger) LogQuotaUpdate(pvName, path, projectName string, projectID uint32, oldQuota, newQuota int64, fsType string, err error) {
 	entry := Entry{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -36,6 +36,13 @@ import (
 type AgentInfo interface {
 	BasePath() string
 	AppliedQuotaCount() int
+	// ProjectsFile/ProjidFile return the agent's configured
+	// /etc/projects, /etc/projid paths, so the per-directory usage/quota
+	// metrics resolve project name/ID to path the same way ensureQuota's
+	// own read-back verification does, rather than assume the standard
+	// locations under a non-default --projects-file/--projid-file.
+	ProjectsFile() string
+	ProjidFile() string
 	// LivenessOK reports whether the agent process is alive and making
 	// progress. It must be independent of the Kubernetes API and the NFS
 	// mount so /health never restart-loops on a transient outage a restart
@@ -148,7 +155,7 @@ func (c *Collector) updateMetrics() {
 	fsType, _ := quota.DetectFSType(basePath)
 
 	// Get directory quotas
-	dirUsages, err := status.GetDirUsages(basePath, fsType)
+	dirUsages, err := status.GetDirUsages(basePath, fsType, c.agent.ProjectsFile(), c.agent.ProjidFile())
 	if err == nil && len(dirUsages) > 0 {
 		sb.WriteString("# HELP nfs_quota_used_bytes Used space by directory in bytes\n")
 		sb.WriteString("# TYPE nfs_quota_used_bytes gauge\n")

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -58,6 +58,13 @@ type AgentInfo interface {
 	// processed, how many ended in error, and total wall-clock time spent
 	// in ensureQuota across all of them, in seconds.
 	ReconcileStats() (total, errors int64, durationSeconds float64)
+	// VerificationFailures returns the cumulative count of quota applies
+	// whose post-apply read-back verification found the on-disk state
+	// didn't match what was requested, since process start (#10) -- a
+	// narrower breakdown of ReconcileStats' errors, distinguishing "the
+	// apply command itself failed" from "it exited 0 but the filesystem
+	// disagreed."
+	VerificationFailures() int64
 	// LastSuccessfulFullSync returns when the periodic full reconciliation
 	// last completed without error, or the zero Time if it never has.
 	LastSuccessfulFullSync() time.Time
@@ -223,6 +230,10 @@ func (c *Collector) updateMetrics() {
 	sb.WriteString("# HELP nfs_quota_agent_reconcile_duration_seconds_sum Cumulative wall-clock time spent in ensureQuota by reconcile-queue workers since process start\n")
 	sb.WriteString("# TYPE nfs_quota_agent_reconcile_duration_seconds_sum counter\n")
 	fmt.Fprintf(&sb, "nfs_quota_agent_reconcile_duration_seconds_sum %f\n\n", reconcileDurationSeconds)
+
+	sb.WriteString("# HELP nfs_quota_agent_verification_failures_total Total applies where the quota command succeeded but a read-back of the quota tool's own reported project limit found a mismatch, since process start. Confirms the tool's bookkeeping, not that the target directory's inode is actually bound to that project.\n")
+	sb.WriteString("# TYPE nfs_quota_agent_verification_failures_total counter\n")
+	fmt.Fprintf(&sb, "nfs_quota_agent_verification_failures_total %d\n\n", c.agent.VerificationFailures())
 
 	sb.WriteString("# HELP nfs_quota_agent_last_full_sync_timestamp_seconds Unix timestamp of the last successful periodic full reconciliation (syncAllQuotas); 0 if none has succeeded yet\n")
 	sb.WriteString("# TYPE nfs_quota_agent_last_full_sync_timestamp_seconds gauge\n")

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -41,6 +41,7 @@ type fakeAgent struct {
 	reconcileTotal         int64
 	reconcileErrors        int64
 	reconcileDurationSecs  float64
+	verificationFailures   int64
 	lastSuccessfulFullSync time.Time
 
 	// haActive is a *bool (not bool) so its zero value ("unset") can mean
@@ -73,6 +74,8 @@ func (f *fakeAgent) ReconcileQueueDepth() int { return f.queueDepth }
 func (f *fakeAgent) ReconcileStats() (total, errors int64, durationSeconds float64) {
 	return f.reconcileTotal, f.reconcileErrors, f.reconcileDurationSecs
 }
+
+func (f *fakeAgent) VerificationFailures() int64 { return f.verificationFailures }
 
 func (f *fakeAgent) LastSuccessfulFullSync() time.Time { return f.lastSuccessfulFullSync }
 
@@ -116,6 +119,7 @@ func TestHandleMetrics_Basic(t *testing.T) {
 		"nfs_quota_agent_reconcile_total",
 		"nfs_quota_agent_reconcile_errors_total",
 		"nfs_quota_agent_reconcile_duration_seconds_sum",
+		"nfs_quota_agent_verification_failures_total",
 		"nfs_quota_agent_last_full_sync_timestamp_seconds",
 		"nfs_quota_agent_ha_active 1", // fakeAgent's haActive is unset -> defaults to active, same as HA gating disabled
 	} {
@@ -149,6 +153,7 @@ func TestHandleMetrics_ReconcileQueueStats(t *testing.T) {
 		reconcileTotal:         42,
 		reconcileErrors:        3,
 		reconcileDurationSecs:  12.5,
+		verificationFailures:   2,
 		lastSuccessfulFullSync: lastSync,
 	}}
 
@@ -162,6 +167,7 @@ func TestHandleMetrics_ReconcileQueueStats(t *testing.T) {
 		"nfs_quota_agent_reconcile_total 42",
 		"nfs_quota_agent_reconcile_errors_total 3",
 		"nfs_quota_agent_reconcile_duration_seconds_sum 12.5",
+		"nfs_quota_agent_verification_failures_total 2",
 		fmt.Sprintf("nfs_quota_agent_last_full_sync_timestamp_seconds %d", lastSync.Unix()),
 	} {
 		if !strings.Contains(body, want) {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -54,6 +54,8 @@ type fakeAgent struct {
 
 func (f *fakeAgent) BasePath() string       { return f.basePath }
 func (f *fakeAgent) AppliedQuotaCount() int { return f.appliedCount }
+func (f *fakeAgent) ProjectsFile() string   { return "/etc/projects" }
+func (f *fakeAgent) ProjidFile() string     { return "/etc/projid" }
 
 func (f *fakeAgent) LivenessOK() (bool, string) {
 	if f.liveReason == "" && f.liveOK {

--- a/internal/quota/ext4.go
+++ b/internal/quota/ext4.go
@@ -61,7 +61,18 @@ func ApplyExt4Quota(quotaPath, path, projectName string, projectID uint32, sizeB
 	}
 
 	// 2. Set the project attribute on the directory using chattr
-	// This associates the directory with the project ID
+	// This associates the directory with the project ID. rootProjected
+	// tracks whether path itself (not just some subdirectory) actually
+	// got +P set -- previously this whole block swallowed every failure
+	// unconditionally and always fell through to setquota, so setquota
+	// could succeed (a real limit exists for projectID) while zero bytes
+	// under path were actually accounted to it: usage would never count
+	// against the limit at all. Since #10's read-back verification only
+	// confirms the limit setquota reports, not the directory's actual
+	// project binding, that combination has to be a hard error here --
+	// otherwise "apply" can report success on a quota that structurally
+	// can never be enforced.
+	rootProjected := false
 	if output, err := defaultRunner.Run("chattr", "-R", "+P", "-p", fmt.Sprintf("%d", projectID), path); err != nil {
 		// Try alternative: use tune2fs project id setting
 		slog.Debug("chattr failed, trying alternative method", "error", err, "output", string(output))
@@ -74,12 +85,20 @@ func ApplyExt4Quota(quotaPath, path, projectName string, projectID uint32, sizeB
 			if d.IsDir() {
 				if _, chErr := defaultRunner.Run("chattr", "+P", "-p", fmt.Sprintf("%d", projectID), p); chErr != nil {
 					slog.Debug("chattr failed for entry", "path", p, "error", chErr)
+				} else if p == path {
+					rootProjected = true
 				}
 			}
 			return nil
 		}); walkErr != nil {
 			slog.Warn("Failed to walk directory for chattr", "path", path, "error", walkErr)
 		}
+	} else {
+		rootProjected = true
+	}
+
+	if !rootProjected {
+		return fmt.Errorf("failed to associate project %d with directory %s via chattr (both the recursive attempt and the per-directory walk fallback failed on the target directory itself)", projectID, path)
 	}
 
 	// 3. Set the quota limit using setquota

--- a/internal/quota/ext4_test.go
+++ b/internal/quota/ext4_test.go
@@ -150,6 +150,47 @@ func TestApplyExt4Quota(t *testing.T) {
 		}
 	})
 
+	t.Run("both chattr -R and the per-directory walk fail on the target directory itself", func(t *testing.T) {
+		// #10: previously ApplyExt4Quota swallowed every chattr failure
+		// unconditionally and fell through to setquota regardless, so a
+		// setquota success could report "applied" while zero bytes under
+		// path were actually accounted to the project (the walk continues
+		// past a failed entry rather than aborting). Now the root
+		// directory itself must actually get +P set via one of the two
+		// attempts, or ApplyExt4Quota must fail rather than claim success
+		// on a quota that can never be enforced.
+		dir := t.TempDir()
+		projPath := filepath.Join(dir, "projdir")
+		if err := makeDirWithSubdir(projPath); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+
+		r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+			if name == "chattr" {
+				return []byte("chattr failed"), errors.New("boom")
+			}
+			return []byte("ok"), nil
+		}}
+		withFakeRunner(t, r)
+
+		err := ApplyExt4Quota("/data", projPath, "proj-fail", 2099, 1024,
+			filepath.Join(dir, "projects"), filepath.Join(dir, "projid"))
+		if err == nil {
+			t.Fatal("expected error when chattr never succeeds for the target directory")
+		}
+		if !strings.Contains(err.Error(), "chattr") {
+			t.Errorf("expected error to mention chattr, got: %v", err)
+		}
+
+		// setquota must never be reached: a quota limit that can never
+		// bind to any inode under path shouldn't be set at all.
+		for _, c := range r.calls {
+			if c.name == "setquota" {
+				t.Errorf("setquota should not have been called when the directory was never projected, got call: %+v", c)
+			}
+		}
+	})
+
 	t.Run("setquota failure propagates", func(t *testing.T) {
 		dir := t.TempDir()
 		r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {

--- a/internal/quota/report.go
+++ b/internal/quota/report.go
@@ -18,13 +18,45 @@ package quota
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/dasomel/nfs-quota-agent/internal/util"
 )
 
-// GetXFSQuotaReport parses xfs_quota report
-func GetXFSQuotaReport(basePath string) (map[string]uint64, map[string]uint64, error) {
+// ExpectedEnforcedBytes returns the on-disk hard limit ApplyXFSQuota/
+// ApplyExt4Quota/ApplyBtrfsQuota actually asks the kernel to enforce for
+// sizeBytes, given fsType -- not necessarily sizeBytes itself. XFS and
+// ext4 quota tooling both operate in whole KB (`bhard=%dk` / setquota's KB
+// hard limit column), flooring sizeBytes to the nearest KB below it and
+// enforcing a 1KB floor for any nonzero request smaller than that; btrfs
+// qgroup limits are set in raw bytes with no such rounding. A caller
+// verifying on-disk state after an apply (agent.go's verifyQuotaOnDisk,
+// #10) must compare against this, not the raw requested sizeBytes -- doing
+// otherwise makes every PV whose capacity isn't already a 1024-byte
+// multiple (e.g. any decimal-SI `storage: 1G` = 1000000000 bytes) look
+// like a permanent verification failure despite being applied correctly.
+func ExpectedEnforcedBytes(fsType string, sizeBytes int64) int64 {
+	switch fsType {
+	case FSTypeXFS, FSTypeExt4:
+		sizeKB := sizeBytes / 1024
+		if sizeKB == 0 {
+			sizeKB = 1
+		}
+		return sizeKB * 1024
+	default:
+		return sizeBytes
+	}
+}
+
+// GetXFSQuotaReport parses xfs_quota report. projectsFile and projidFile
+// are read directly (not through defaultRunner) to resolve project
+// name/ID to filesystem path -- callers must pass the same paths the
+// agent applies quotas against (a.projectsFile/a.projidFile), not assume
+// the standard /etc/projects and /etc/projid; a caller with no
+// configurable paths of its own (e.g. the status/UI reporting path) can
+// pass those two literals directly.
+func GetXFSQuotaReport(basePath, projectsFile, projidFile string) (map[string]uint64, map[string]uint64, error) {
 	if err := validateQuotaArg("basePath", basePath); err != nil {
 		return nil, nil, err
 	}
@@ -39,7 +71,6 @@ func GetXFSQuotaReport(basePath string) (map[string]uint64, map[string]uint64, e
 
 	// Parse projid file to get projectName -> projectID mapping
 	projidMap := make(map[string]string) // projectName -> projectID
-	projidFile := "/etc/projid"
 	if data, err := os.ReadFile(projidFile); err == nil {
 		for _, line := range strings.Split(string(data), "\n") {
 			line = strings.TrimSpace(line)
@@ -55,7 +86,6 @@ func GetXFSQuotaReport(basePath string) (map[string]uint64, map[string]uint64, e
 
 	// Parse projects file to get projectID -> path mapping
 	projectPaths := make(map[string]string) // projectID -> path
-	projectsFile := "/etc/projects"
 	if data, err := os.ReadFile(projectsFile); err == nil {
 		for _, line := range strings.Split(string(data), "\n") {
 			line = strings.TrimSpace(line)
@@ -116,8 +146,11 @@ func GetXFSQuotaReport(basePath string) (map[string]uint64, map[string]uint64, e
 	return quotaMap, usageMap, nil
 }
 
-// GetExt4QuotaReport parses repquota output
-func GetExt4QuotaReport(basePath string) (map[string]uint64, map[string]uint64, error) {
+// GetExt4QuotaReport parses repquota output. projectsFile is read
+// directly (not basePath) to resolve project ID to filesystem path -- see
+// GetXFSQuotaReport's doc comment for why callers must pass the agent's
+// configured path rather than assume /etc/projects.
+func GetExt4QuotaReport(basePath, projectsFile string) (map[string]uint64, map[string]uint64, error) {
 	if err := validateQuotaArg("basePath", basePath); err != nil {
 		return nil, nil, err
 	}
@@ -130,9 +163,8 @@ func GetExt4QuotaReport(basePath string) (map[string]uint64, map[string]uint64, 
 		return quotaMap, usageMap, err
 	}
 
-	// Parse projects file (use /etc/projects, not basePath)
+	// Parse projects file (use projectsFile, not basePath)
 	projectPaths := make(map[string]string)
-	projectsFile := "/etc/projects"
 	if data, err := os.ReadFile(projectsFile); err == nil {
 		for _, line := range strings.Split(string(data), "\n") {
 			line = strings.TrimSpace(line)
@@ -154,15 +186,32 @@ func GetExt4QuotaReport(basePath string) (map[string]uint64, map[string]uint64, 
 			continue
 		}
 
-		// Skip header
-		if fields[0] == "Project" || strings.HasPrefix(line, "-") || strings.HasPrefix(line, "#") {
+		// Skip header/separator lines. Real repquota -P project rows
+		// themselves start with "#<id>" (e.g. "#100      --     100 ..."),
+		// so a bare HasPrefix(line, "#") here would drop every real data
+		// row along with the header -- checked and fixed as part of #10:
+		// this function had never actually resolved a real repquota row
+		// to a path, since every row was silently skipped before
+		// projectID was even computed.
+		if fields[0] == "Project" || strings.HasPrefix(line, "-") {
 			continue
 		}
 
-		projectID := strings.TrimSuffix(fields[0], "--")
+		projectID := strings.TrimPrefix(fields[0], "#")
+		projectID = strings.TrimSuffix(projectID, "--")
 		projectID = strings.TrimSuffix(projectID, "+-")
 		projectID = strings.TrimSuffix(projectID, "-+")
 		projectID = strings.TrimSuffix(projectID, "++")
+
+		// The removed HasPrefix(line, "#") check above no longer filters
+		// banner/comment lines out before they reach here -- make the
+		// "this column must be a numeric project ID" assumption explicit
+		// instead of relying entirely on an accidental map-lookup miss to
+		// reject anything that isn't (unverified against every real
+		// repquota banner variant; this guard is the cheap insurance).
+		if _, err := strconv.ParseUint(projectID, 10, 32); err != nil {
+			continue
+		}
 
 		if path, ok := projectPaths[projectID]; ok {
 			// Used is in KB

--- a/internal/quota/report_test.go
+++ b/internal/quota/report_test.go
@@ -18,19 +18,16 @@ package quota
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
-
-// Note: GetXFSQuotaReport/GetExt4QuotaReport read the fixed system paths
-// /etc/projid and /etc/projects directly, so full path-mapping behavior is
-// not hermetically testable here. These tests cover command construction
-// and error propagation through the CommandRunner seam (best-effort).
 
 func TestGetXFSQuotaReport_InvalidArgument(t *testing.T) {
 	r := &fakeRunner{}
 	withFakeRunner(t, r)
 
-	_, _, err := GetXFSQuotaReport("/data/proj ect")
+	_, _, err := GetXFSQuotaReport("/data/proj ect", "/etc/projects", "/etc/projid")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -43,7 +40,7 @@ func TestGetExt4QuotaReport_InvalidArgument(t *testing.T) {
 	r := &fakeRunner{}
 	withFakeRunner(t, r)
 
-	_, _, err := GetExt4QuotaReport("/data/proj ect")
+	_, _, err := GetExt4QuotaReport("/data/proj ect", "/etc/projects")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -58,7 +55,7 @@ func TestGetXFSQuotaReport_CommandError(t *testing.T) {
 	}}
 	withFakeRunner(t, r)
 
-	_, _, err := GetXFSQuotaReport("/data")
+	_, _, err := GetXFSQuotaReport("/data", "/etc/projects", "/etc/projid")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -73,14 +70,66 @@ func TestGetXFSQuotaReport_NoMatchingProjects(t *testing.T) {
 	}}
 	withFakeRunner(t, r)
 
-	quotaMap, usageMap, err := GetXFSQuotaReport("/data")
+	// Nonexistent projectsFile/projidFile: os.ReadFile fails, both maps
+	// stay pre-populated-empty rather than panicking.
+	quotaMap, usageMap, err := GetXFSQuotaReport("/data", "/does/not/exist/projects", "/does/not/exist/projid")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Without /etc/projid or /etc/projects entries for "proj1", no path can
-	// be resolved, so both maps should stay empty rather than panicking.
 	if len(quotaMap) != 0 || len(usageMap) != 0 {
 		t.Errorf("expected empty maps when no project mapping found, got quota=%v usage=%v", quotaMap, usageMap)
+	}
+}
+
+func TestGetXFSQuotaReport_ResolvesPathFromConfiguredFiles(t *testing.T) {
+	dir := t.TempDir()
+	projectsFile := filepath.Join(dir, "projects")
+	projidFile := filepath.Join(dir, "projid")
+	if err := os.WriteFile(projectsFile, []byte("100:/data/pvc-1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile projects: %v", err)
+	}
+	if err := os.WriteFile(projidFile, []byte("pvc-1:100\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile projid: %v", err)
+	}
+
+	r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+		return []byte("Project ID   Used   Soft   Hard   Warn/Grace\n#pvc-1     100    0      2097152    00 [------]\n"), nil
+	}}
+	withFakeRunner(t, r)
+
+	quotaMap, usageMap, err := GetXFSQuotaReport("/data", projectsFile, projidFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usageMap["/data/pvc-1"] != 100*1024 {
+		t.Errorf("usageMap[/data/pvc-1] = %d, want %d", usageMap["/data/pvc-1"], 100*1024)
+	}
+	if quotaMap["/data/pvc-1"] != 2097152*1024 {
+		t.Errorf("quotaMap[/data/pvc-1] = %d, want %d", quotaMap["/data/pvc-1"], 2097152*1024)
+	}
+
+	// A second projectsFile/projidFile pair pointing at different content
+	// must resolve independently -- this is the behavior the previous
+	// hardcoded /etc/projects and /etc/projid could never demonstrate.
+	dir2 := t.TempDir()
+	projectsFile2 := filepath.Join(dir2, "projects")
+	projidFile2 := filepath.Join(dir2, "projid")
+	if err := os.WriteFile(projectsFile2, []byte("100:/other/pvc-1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile projects2: %v", err)
+	}
+	if err := os.WriteFile(projidFile2, []byte("pvc-1:100\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile projid2: %v", err)
+	}
+
+	quotaMap2, _, err := GetXFSQuotaReport("/data", projectsFile2, projidFile2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := quotaMap2["/data/pvc-1"]; ok {
+		t.Errorf("quotaMap2 resolved /data/pvc-1 using the first pair's file content — projectsFile/projidFile parameters are not actually isolating reads")
+	}
+	if quotaMap2["/other/pvc-1"] != 2097152*1024 {
+		t.Errorf("quotaMap2[/other/pvc-1] = %d, want %d", quotaMap2["/other/pvc-1"], 2097152*1024)
 	}
 }
 
@@ -90,7 +139,7 @@ func TestGetExt4QuotaReport_CommandError(t *testing.T) {
 	}}
 	withFakeRunner(t, r)
 
-	_, _, err := GetExt4QuotaReport("/data")
+	_, _, err := GetExt4QuotaReport("/data", "/etc/projects")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -105,11 +154,59 @@ func TestGetExt4QuotaReport_NoMatchingProjects(t *testing.T) {
 	}}
 	withFakeRunner(t, r)
 
-	quotaMap, usageMap, err := GetExt4QuotaReport("/data")
+	quotaMap, usageMap, err := GetExt4QuotaReport("/data", "/does/not/exist/projects")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(quotaMap) != 0 || len(usageMap) != 0 {
 		t.Errorf("expected empty maps when no project mapping found, got quota=%v usage=%v", quotaMap, usageMap)
+	}
+}
+
+func TestGetExt4QuotaReport_ResolvesPathFromConfiguredFile(t *testing.T) {
+	dir := t.TempDir()
+	projectsFile := filepath.Join(dir, "projects")
+	if err := os.WriteFile(projectsFile, []byte("100:/data/pvc-1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile projects: %v", err)
+	}
+
+	r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+		return []byte("Project        used    soft    hard  grace   used  soft  hard  grace\n#100      --   100      0    2097152                5     0     0\n"), nil
+	}}
+	withFakeRunner(t, r)
+
+	quotaMap, usageMap, err := GetExt4QuotaReport("/data", projectsFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usageMap["/data/pvc-1"] != 100*1024 {
+		t.Errorf("usageMap[/data/pvc-1] = %d, want %d", usageMap["/data/pvc-1"], 100*1024)
+	}
+	if quotaMap["/data/pvc-1"] != 2097152*1024 {
+		t.Errorf("quotaMap[/data/pvc-1] = %d, want %d", quotaMap["/data/pvc-1"], 2097152*1024)
+	}
+}
+
+func TestExpectedEnforcedBytes(t *testing.T) {
+	tests := []struct {
+		name      string
+		fsType    string
+		sizeBytes int64
+		want      int64
+	}{
+		{"xfs floors to whole KB", FSTypeXFS, 1000000000, 999999488}, // 1G decimal SI, not a 1024 multiple
+		{"xfs exact KB multiple unchanged", FSTypeXFS, 1073741824, 1073741824},
+		{"xfs sub-1KB request floors to 1KB minimum", FSTypeXFS, 500, 1024},
+		{"ext4 floors to whole KB", FSTypeExt4, 1000000000, 999999488},
+		{"ext4 sub-1KB request floors to 1KB minimum", FSTypeExt4, 1, 1024},
+		{"btrfs uses raw bytes, no rounding", FSTypeBtrfs, 1000000000, 1000000000},
+		{"unknown fsType uses raw bytes", "zfs", 1000000000, 1000000000},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ExpectedEnforcedBytes(tc.fsType, tc.sizeBytes); got != tc.want {
+				t.Errorf("ExpectedEnforcedBytes(%q, %d) = %d, want %d", tc.fsType, tc.sizeBytes, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/status/dir.go
+++ b/internal/status/dir.go
@@ -24,8 +24,17 @@ import (
 	"github.com/dasomel/nfs-quota-agent/internal/quota"
 )
 
-// GetDirUsages returns usage information for all directories with quotas
-func GetDirUsages(basePath, fsType string) ([]DirUsage, error) {
+// GetDirUsages returns usage information for all directories with quotas.
+// projectsFile/projidFile must be the same paths the agent applying quotas
+// is actually configured with (a.ProjectsFile()/a.ProjidFile()) -- pass the
+// literal "/etc/projects"/"/etc/projid" only from a genuinely standalone
+// caller with no agent instance to read the real configured paths from
+// (the `nfs-quota-agent status` CLI path). Passing the standard-path
+// literals from a caller that does have an agent in scope silently shows
+// empty/wrong usage under a non-default --projects-file/--projid-file --
+// exactly the gap this parameterization exists to close; see the
+// CLAUDE.md gotcha on this.
+func GetDirUsages(basePath, fsType, projectsFile, projidFile string) ([]DirUsage, error) {
 	var usages []DirUsage
 
 	// Get quota report based on filesystem type
@@ -35,24 +44,9 @@ func GetDirUsages(basePath, fsType string) ([]DirUsage, error) {
 
 	switch fsType {
 	case "xfs":
-		// Literal /etc/projects, /etc/projid -- unchanged behavior from
-		// before GetXFSQuotaReport/GetExt4QuotaReport took these as
-		// explicit parameters (pre-existing, not introduced here): a
-		// deployment run with non-default --projects-file/--projid-file
-		// still sees this reporting path assume the standard locations,
-		// producing empty/wrong usage data. True for GetDirUsages' truly
-		// standalone callers (status/display.go, status/report.go, the
-		// `nfs-quota-agent status` CLI path, which have no agent instance
-		// to read configured paths from) -- but NOT for its other callers
-		// (internal/agent's recordHistory, internal/metrics, internal/ui),
-		// which do have a configured QuotaAgent in scope and inherit this
-		// same gap by calling through GetDirUsages rather than a path that
-		// threads the real paths in. See internal/agent's ensureQuota
-		// (verifyQuotaOnDisk) for the one caller in this codebase that
-		// does use the agent's configured files, for comparison.
-		quotaMap, usageMap, err = quota.GetXFSQuotaReport(basePath, "/etc/projects", "/etc/projid")
+		quotaMap, usageMap, err = quota.GetXFSQuotaReport(basePath, projectsFile, projidFile)
 	case "ext4":
-		quotaMap, usageMap, err = quota.GetExt4QuotaReport(basePath, "/etc/projects")
+		quotaMap, usageMap, err = quota.GetExt4QuotaReport(basePath, projectsFile)
 	case "btrfs":
 		quotaMap, usageMap, err = quota.GetBtrfsQuotaReport(basePath)
 	}

--- a/internal/status/dir.go
+++ b/internal/status/dir.go
@@ -35,9 +35,24 @@ func GetDirUsages(basePath, fsType string) ([]DirUsage, error) {
 
 	switch fsType {
 	case "xfs":
-		quotaMap, usageMap, err = quota.GetXFSQuotaReport(basePath)
+		// Literal /etc/projects, /etc/projid -- unchanged behavior from
+		// before GetXFSQuotaReport/GetExt4QuotaReport took these as
+		// explicit parameters (pre-existing, not introduced here): a
+		// deployment run with non-default --projects-file/--projid-file
+		// still sees this reporting path assume the standard locations,
+		// producing empty/wrong usage data. True for GetDirUsages' truly
+		// standalone callers (status/display.go, status/report.go, the
+		// `nfs-quota-agent status` CLI path, which have no agent instance
+		// to read configured paths from) -- but NOT for its other callers
+		// (internal/agent's recordHistory, internal/metrics, internal/ui),
+		// which do have a configured QuotaAgent in scope and inherit this
+		// same gap by calling through GetDirUsages rather than a path that
+		// threads the real paths in. See internal/agent's ensureQuota
+		// (verifyQuotaOnDisk) for the one caller in this codebase that
+		// does use the agent's configured files, for comparison.
+		quotaMap, usageMap, err = quota.GetXFSQuotaReport(basePath, "/etc/projects", "/etc/projid")
 	case "ext4":
-		quotaMap, usageMap, err = quota.GetExt4QuotaReport(basePath)
+		quotaMap, usageMap, err = quota.GetExt4QuotaReport(basePath, "/etc/projects")
 	case "btrfs":
 		quotaMap, usageMap, err = quota.GetBtrfsQuotaReport(basePath)
 	}

--- a/internal/status/dir_test.go
+++ b/internal/status/dir_test.go
@@ -59,7 +59,7 @@ func TestGetDirUsages_FlatDirectories(t *testing.T) {
 	writeSized(t, filepath.Join(base, "pvc-a", "f"), 100)
 	writeSized(t, filepath.Join(base, "pvc-b", "f"), 50)
 
-	usages, err := GetDirUsages(base, "")
+	usages, err := GetDirUsages(base, "", "/etc/projects", "/etc/projid")
 	if err != nil {
 		t.Fatalf("GetDirUsages: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestGetDirUsages_NestedNamespaceDirectories(t *testing.T) {
 	writeSized(t, filepath.Join(base, "team-a", "pvc-1", "f"), 200)
 	writeSized(t, filepath.Join(base, "team-a", "pvc-2", "f"), 300)
 
-	usages, err := GetDirUsages(base, "")
+	usages, err := GetDirUsages(base, "", "/etc/projects", "/etc/projid")
 	if err != nil {
 		t.Fatalf("GetDirUsages: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestGetDirUsages_SkipsHiddenAndProjectFiles(t *testing.T) {
 	}
 	writeSized(t, filepath.Join(base, "pvc-a", "f"), 5)
 
-	usages, err := GetDirUsages(base, "")
+	usages, err := GetDirUsages(base, "", "/etc/projects", "/etc/projid")
 	if err != nil {
 		t.Fatalf("GetDirUsages: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestGetDirUsages_SkipsHiddenAndProjectFiles(t *testing.T) {
 }
 
 func TestGetDirUsages_NonexistentBasePath(t *testing.T) {
-	_, err := GetDirUsages(filepath.Join(t.TempDir(), "missing"), "")
+	_, err := GetDirUsages(filepath.Join(t.TempDir(), "missing"), "", "/etc/projects", "/etc/projid")
 	if err == nil {
 		t.Fatal("expected error for nonexistent base path")
 	}

--- a/internal/status/display.go
+++ b/internal/status/display.go
@@ -52,8 +52,10 @@ func ShowStatus(basePath string, showAll bool) error {
 	fmt.Printf("Used:       %s (%.1f%%)\n", util.FormatBytes(int64(diskUsage.Used)), diskUsage.UsedPct)
 	fmt.Printf("Available:  %s\n\n", util.FormatBytes(int64(diskUsage.Available)))
 
-	// Get directory quotas
-	dirUsages, err := GetDirUsages(basePath, fsType)
+	// Get directory quotas. Literal /etc/projects, /etc/projid: this is the
+	// standalone `status` CLI path, with no agent instance to read a
+	// configured --projects-file/--projid-file from.
+	dirUsages, err := GetDirUsages(basePath, fsType, "/etc/projects", "/etc/projid")
 	if err != nil {
 		return fmt.Errorf("failed to get directory usages: %w", err)
 	}
@@ -152,7 +154,7 @@ func ShowTop(basePath string, count int, watch bool) error {
 			return err
 		}
 
-		dirUsages, err := GetDirUsages(basePath, fsType)
+		dirUsages, err := GetDirUsages(basePath, fsType, "/etc/projects", "/etc/projid")
 		if err != nil {
 			return err
 		}

--- a/internal/status/report.go
+++ b/internal/status/report.go
@@ -76,7 +76,7 @@ func GenerateReport(basePath, format, outputFile string) (err error) {
 		return err
 	}
 
-	dirUsages, err := GetDirUsages(basePath, fsType)
+	dirUsages, err := GetDirUsages(basePath, fsType, "/etc/projects", "/etc/projid")
 	if err != nil {
 		return err
 	}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -59,6 +59,10 @@ type AgentInterface interface {
 	GetOrphans(ctx context.Context) []OrphanInfo
 	RemoveOrphan(orphan OrphanInfo) error
 	AuditLogger() *audit.Logger
+	// ProjectsFile/ProjidFile return the agent's configured
+	// /etc/projects, /etc/projid paths -- see projectFiles below.
+	ProjectsFile() string
+	ProjidFile() string
 	// HAActive reports whether this instance currently owns quota
 	// enforcement (see agent.QuotaAgent.HAActive, #11). Always true when
 	// HA gating is disabled. Checked before a destructive orphan-delete
@@ -183,6 +187,18 @@ func (ui *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, dashboardHTML)
 }
 
+// projectFiles returns the projects/projid paths GetDirUsages should read
+// project name/ID -> path mappings from. Prefers the agent's configured
+// paths (present whenever the UI is embedded in the main daemon); falls
+// back to the standard locations for the standalone `nfs-quota-agent ui`
+// subcommand, which has no agent (and no Kubernetes client of any kind).
+func (ui *Server) projectFiles() (projectsFile, projidFile string) {
+	if ui.agent != nil {
+		return ui.agent.ProjectsFile(), ui.agent.ProjidFile()
+	}
+	return "/etc/projects", "/etc/projid"
+}
+
 func (ui *Server) handleAPIStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -194,7 +210,8 @@ func (ui *Server) handleAPIStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dirUsages, _ := status.GetDirUsages(ui.basePath, fsType)
+	projectsFile, projidFile := ui.projectFiles()
+	dirUsages, _ := status.GetDirUsages(ui.basePath, fsType, projectsFile, projidFile)
 
 	var totalUsed, totalQuota uint64
 	var warningCount, exceededCount, okCount int
@@ -300,7 +317,8 @@ func (ui *Server) handleAPIQuotas(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	fsType, _ := quota.DetectFSType(ui.basePath)
-	dirUsages, err := status.GetDirUsages(ui.basePath, fsType)
+	projectsFile, projidFile := ui.projectFiles()
+	dirUsages, err := status.GetDirUsages(ui.basePath, fsType, projectsFile, projidFile)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -86,6 +86,8 @@ func (f *fakeAgent) RemoveOrphan(o OrphanInfo) error {
 	return nil
 }
 func (f *fakeAgent) AuditLogger() *audit.Logger { return f.logger }
+func (f *fakeAgent) ProjectsFile() string       { return "/etc/projects" }
+func (f *fakeAgent) ProjidFile() string         { return "/etc/projid" }
 func (f *fakeAgent) HAActive() bool {
 	if f.haActive == nil {
 		return true


### PR DESCRIPTION
## Summary
Addresses #10's core gap: `ensureQuota` trusted the quota binary's exit code as proof the kernel actually holds the requested limit and never checked. Now, after a successful apply, it reads back the real on-disk state (same `GetXFSQuotaReport`/`GetExt4QuotaReport`/`GetBtrfsQuotaReport` machinery the status/UI path already uses) and compares it against what was requested. A mismatch is treated the same as an apply failure — not cached, not marked `applied`, retried on the next reconcile — with a new `nfs_quota_agent_verification_failures_total` metric and a dedicated `LogQuotaVerificationFailure` audit entry distinguishing "the tool refused" from "the tool lied."

**Two real, separate bugs found and fixed along the way:**
- `GetExt4QuotaReport` had never actually resolved a single real `repquota` row to a path — a stray header-skip check dropped every real data row (which itself starts with `#<id>`), and even when a row survived, the `#` prefix was never trimmed before the map lookup.
- `ApplyExt4Quota` silently swallowed every `chattr` failure and always fell through to `setquota` regardless — so `setquota` could succeed on a project ID with zero bytes actually bound to it under the target directory. Now requires the target directory itself to actually get `+P` set via one of the two attempts, or fails.

`GetXFSQuotaReport`/`GetExt4QuotaReport` now take `projectsFile`/`projidFile` as explicit parameters instead of hardcoding `/etc/projects`/`/etc/projid` — the one external call site (`internal/status/dir.go`) preserves its exact prior behavior with literal defaults.

## An independent review caught a CRITICAL bug before this shipped
Dispatched an opus-tier independent code review (separate context) before committing, per this repo's convention for `internal/quota`-adjacent changes. It found: **XFS/ext4 floor the requested size to whole KB (`bhard=%dk`) before enforcing it, but the read-back comparison was against the raw requested byte count** — so any PV capacity not already a 1024-byte multiple (any decimal-SI `storage: 1G` = 1,000,000,000 bytes) would fail verification *forever* despite being applied correctly, permanently reporting `QuotaStatusFailed` and re-walking the full directory tree (`xfs_quota project -s -p`) on every retry.

Fixed via `quota.ExpectedEnforcedBytes(fsType, sizeBytes)`, which mirrors each backend's own rounding. Also fixed: a `basePath` mismatch between apply (`a.quotaPath`) and verify (was `a.nfsBasePath`); an audit-log ordering bug where a verification failure left a contradictory "success" CREATE/UPDATE entry ahead of the failure entry; and an inaccurate doc comment about the new metric vs. `reconcileErrors`.

## Test plan
- [x] `TestEnsureQuota_NonGiCapacitySucceeds` — the direct regression test for the CRITICAL finding (1G decimal-SI capacity applies and verifies correctly)
- [x] `TestEnsureQuota_VerificationMismatchedValueNotReportedApplied` — a genuine on-disk value mismatch (not just "path not found") is caught
- [x] `TestEnsureQuota_VerificationFailureNotReportedApplied` — path missing from report entirely
- [x] `TestApplyExt4Quota/both_chattr_-R_and_the_per-directory_walk_fail...` — new ext4 hard-failure path
- [x] `TestExpectedEnforcedBytes` — direct unit coverage of the rounding fix, all three backends
- [x] `TestGetXFSQuotaReport_ResolvesPathFromConfiguredFiles`, `TestGetExt4QuotaReport_ResolvesPathFromConfiguredFile` — hermetic path-resolution tests (previously marked "not hermetically testable" in a code comment)
- [x] `TestLogQuotaVerificationFailure`, metrics rendering assertions for `nfs_quota_agent_verification_failures_total`
- [x] Every fix mutation-verified individually (reverted → confirmed the right test fails for the right reason → restored → confirmed clean) — see commit message for the full list
- [x] `go build ./...`, `go vet ./...`, `go test -race ./...`, `gofmt -l .` all clean

## Update: the GetDirUsages gap is now fixed too
A later commit on this branch closes the `internal/status/dir.go` gap this PR originally deferred: `GetDirUsages` now takes `projectsFile`/`projidFile` explicitly, threaded from `internal/agent`'s `recordHistory`, `internal/metrics`, and `internal/ui` (new `ProjectsFile()`/`ProjidFile()` on `AgentInfo`/`AgentInterface`, backed by new `QuotaAgent` getters), while the genuinely standalone `status` CLI path keeps the `/etc/projects`/`/etc/projid` literals with a comment explaining why. `internal/ui`'s two call sites go through a `projectFiles()` helper that falls back to the standard paths when `ui.agent` is nil (the standalone `ui` subcommand) — `TestHandleAPIStatus` already constructs a `Server` with a nil agent, so it already regression-guards the fallback; mutation-verified by removing the nil check and confirming that exact test panics. Independently reviewed via `codex exec review --uncommitted` (no issues found) in addition to the usual build/test/race verification.

## Deliberately not addressed (documented in code, not fixed here)
- `verifyQuotaOnDisk` does one full report scan per apply (O(total projects on the node)), not a targeted per-project read — expensive at startup when every existing PV re-verifies at once. Noted in `agent.go`'s doc comments; a real fix needs a per-cycle cache or a targeted read, out of scope here.

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT
