### PR TITLE
feat(quotapolicy): implement Drifted condition via independent read-back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ Layout, commands, testing conventions, and contribution flow are already documen
 
 **Filesystem backends deliberately don't share a signature.** XFS and ext4 take the full project tuple because they use `/etc/projects`; btrfs takes `(path, sizeBytes)` because it uses subvolume qgroups. A new backend should match the model its filesystem actually uses, and needs the three switch sites in `agent.go` plus the `Dockerfile` package list updated with it.
 
+**Inferring "did this mutate anything" from a before/after cache read is ABA-vulnerable here.** `syncAllQuotas` (the periodic full sync) and the watch path's reconcile queue are separate goroutines that can both call `ensureQuota` for the same PV; a concurrent watch-triggered write can leave a before/after snapshot of `appliedQuotas[localPath]` looking unchanged even though a real mutation happened in between. `ensureQuotaMutated` exists so callers that need to know can get the actual signal from the call itself instead of inferring it — an independent review caught the inferred version as the root cause of a real false-positive in #13's `Drifted` condition.
+
 ## High-risk paths
 
 Changes to argv construction, `validateQuotaArg`, `/etc/projects` · `/etc/projid` writes, or `privileged` / RBAC in the chart fail as host-level or command-injection problems rather than as failing tests. Give them the strongest reasoning available and a review pass from a context that didn't author them. Widening an RBAC verb widens cluster privilege — same tier.

--- a/charts/nfs-quota-agent/crds/quota.nfs.io_quotapolicies.yaml
+++ b/charts/nfs-quota-agent/crds/quota.nfs.io_quotapolicies.yaml
@@ -276,6 +276,57 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              driftedClaims:
+                description: |-
+                  driftedClaims is a bounded sample (capped at 20 entries) of won
+                  claims whose on-disk quota no longer matches this policy, checked
+                  independently of the enforcement attempt itself -- a claim only
+                  appears here when its most recent enforcement attempt reported no
+                  error (see FailingClaims for that case instead). Reuses the
+                  FailingClaim shape rather than a parallel type: same
+                  namespace/name/reason/message/lastTransitionTime fields apply.
+                items:
+                  description: |-
+                    FailingClaim names a PersistentVolumeClaim this policy won precedence for
+                    but failed to enforce on, and why. This is a bounded, most-recent-first
+                    sample for triage — not an audit log or a substitute for time series. For
+                    quota-application history over time, consult the agent's Prometheus
+                    metrics or, if history.enabled in the Helm chart, internal/history.Store's
+                    persisted snapshots; this field only ever reflects current failures.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is when this claim was last
+                        observed to fail.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human-readable detail, e.g. the underlying command
+                        error surfaced from internal/quota.CommandRunner.
+                      type: string
+                    name:
+                      description: name of the failing PersistentVolumeClaim.
+                      type: string
+                    namespace:
+                      description: |-
+                        namespace of the failing PersistentVolumeClaim. Always equal to the
+                        QuotaPolicy's own namespace, since QuotaPolicy is namespace-scoped;
+                        carried explicitly so this struct is self-describing at the call
+                        site and stays shaped like MatchedClaim below.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is a short machine-readable cause, drawn from the same
+                        vocabulary as Conditions[].Reason where applicable (e.g.
+                        EnforcementFailed, FilesystemUnavailable, ProjectIDExhausted).
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - reason
+                  type: object
+                maxItems: 20
+                type: array
               failingClaims:
                 description: |-
                   failingClaims is a bounded, most-recent-first sample (capped at 20

--- a/charts/nfs-quota-agent/templates/pdb.yaml
+++ b/charts/nfs-quota-agent/templates/pdb.yaml
@@ -1,4 +1,17 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+# Known limitation (observed on k3s v1.36.3, #4): the disruption controller
+# cannot compute expectedPods/currentHealthy/disruptionsAllowed for a
+# DaemonSet-backed PDB ("daemonsets.apps does not implement the scale
+# subresource" -- see `kubectl describe pdb` events), so
+# disruptionsAllowed stays permanently 0 and every direct Eviction API
+# call against this pod returns 429 DisruptionBudget, regardless of
+# maxUnavailable's value. `kubectl drain` is unaffected (it skips
+# DaemonSet pods entirely, PDB or not), and so is `helm upgrade`'s
+# rolling replacement (DaemonSet-controller-driven delete+create, not the
+# Eviction API). Only a caller that evicts directly -- cluster-autoscaler,
+# descheduler, a custom controller -- is blocked, and fails safe (retries
+# forever rather than force-removing the pod). Root cause is in
+# Kubernetes core, not this chart; see #4 for the reproduction.
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/docs/quotapolicy-design.md
+++ b/docs/quotapolicy-design.md
@@ -13,8 +13,10 @@ staleness in CI. The controller itself is
 bounding logic, plus dynamic-client listing and status write-back), wired
 into the agent's existing sync cadence from
 [`internal/agent/policy.go`](../internal/agent/policy.go) — no separate
-watch loop or work queue; see §11 below for what that means and what it
-deliberately still doesn't cover (e.g. `Drifted`).
+watch loop or work queue; see §11 below for what that means. `Drifted`
+(#13) is implemented via an independent filesystem read-back, not the
+enforcement cache — see "`Drifted`: independent read-back, not the
+enforcement cache" below.
 
 ## 1. Problem
 
@@ -471,17 +473,50 @@ still lose a race against whoever manages the CR's spec even with a single
 `QuotaPolicy` writer, and that's a benign, common race that shouldn't fail
 the whole sync cycle.
 
-### What's deliberately not implemented: `Drifted`
+### `Drifted`: independent read-back, not the enforcement cache
 
-The `Drifted` condition is never set by this PR. §5 already requires "if
-you cannot determine it cheaply and honestly, omit the condition entirely
-rather than reporting a check you didn't do" — a real drift check would
-mean reading back the filesystem's actual project quota (`xfs_quota
-report` / `repquota` / btrfs qgroup show) per matched claim and comparing it
-against spec, which this PR does not do. The agent's own
-`appliedQuotas` cache reflects what the agent *thinks* it last applied, not
-an independent read of on-disk state, so it can't honestly back this
-condition either. Left for a follow-up that adds that read-back.
+`Drifted` is now set (#13), once #10 added the read-back mechanism §5's
+"if you cannot determine it cheaply and honestly, omit the condition
+entirely" rule was blocking on: `syncAllQuotas` independently reads back
+the filesystem's actual project quota (`xfs_quota report` / `repquota` /
+`btrfs qgroup show`, fetched once per sync cycle and reused across every
+matched claim, not once per claim) and compares it against what the
+policy currently specifies — deliberately *not* the agent's own
+`appliedQuotas` cache, which only reflects what the agent last believes it
+applied, not an independent observation of on-disk state.
+
+A claim `ensureQuota` actually mutated this same cycle is excluded from
+the check: its own apply-time read-back (#10's `verifyQuotaOnDisk`)
+already confirmed it moments ago, and comparing it against a
+report snapshot that may predate that exact mutation would misreport a
+brand-new, correctly-applied value as drift (an independent review caught
+this as the first version's most serious bug before it shipped). Only
+claims that were untouched this cycle — genuine cache hits, where nothing
+about their on-disk state could have changed as a side effect of this same
+sync — are compared against the shared snapshot.
+
+`Drifted` has three states, not two: `True` (confirmed mismatch — see
+`status.driftedClaims`), `False` (checked, and every won claim matched),
+and `Unknown` (the report itself couldn't be read this cycle — a
+transient `xfs_quota`/`repquota`/`btrfs` failure). `Unknown` exists
+specifically so a report outage can't masquerade as a healthy `False`;
+an operator relying on this condition needs to be able to tell "checked,
+fine" apart from "couldn't check."
+
+**Known, accepted gap**: the shared report snapshot can still be stale
+relative to a mutation the *watch path's* reconcile queue makes
+concurrently, in a separate goroutine, to a claim this same cycle also
+drift-checks against it. The exclusion above only covers mutations this
+same `syncAllQuotas` call itself makes (via `ensureQuotaMutated`'s own
+return value — not an inferred before/after cache comparison, which an
+earlier version used and which turned out to be vulnerable to the same
+kind of race). Fully closing the concurrent-watch-path case would mean
+either re-fetching the report per claim (defeating the fetch-once
+optimization) or locking a claim's check against concurrent
+reconciliation of that same claim, which the reconcile queue doesn't
+currently expose a hook for. The failure mode is a spurious `Drifted=True`
+for one claim, self-correcting on the next cycle — not a missed real
+problem or an enforcement error.
 
 ### RBAC: two new grants beyond the CRD-only ClusterRole, both gated on `quotaPolicy.enabled`
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -720,6 +720,32 @@ func (a *QuotaAgent) syncAllQuotas(ctx context.Context) error {
 	// there is no concurrency for a queue to protect.
 	cycle := a.beginQuotaPolicyCycle(ctx)
 
+	// Lazily fetched at most once for this whole cycle, on the first PV
+	// that actually needs a drift check (#13) -- the report is identical
+	// for every PV on this node within one cycle (same
+	// fsType/quotaPath/projectsFile/projidFile, none of which vary per
+	// PV), so fetching it per-PV would repeat the same filesystem-wide
+	// scan once per matched claim. See fetchQuotaReport's doc comment.
+	//
+	// Known, accepted residual gap: this snapshot can still be stale
+	// relative to a mutation the *watch path's* reconcile queue makes
+	// concurrently, in a separate goroutine, to a claim this same cycle
+	// also drift-checks against it -- the mutatedThisCycle-equivalent
+	// guard below (using ensureQuotaMutated's own return value) only
+	// covers mutations *this syncAllQuotas call itself* makes, not ones
+	// made by a concurrent caller. Fully closing that would mean either
+	// re-fetching per claim (defeating the fetch-once optimization this
+	// exists for) or locking a claim's whole check against concurrent
+	// watch-path reconciliation of the same claim, which reconcile_queue.go
+	// doesn't currently expose a hook for. The failure mode is a spurious
+	// Drifted=True for one claim, self-correcting on the next cycle once
+	// the concurrent write has landed -- not a missed real problem or an
+	// enforcement error, which is why this is documented rather than
+	// solved outright.
+	var driftReport map[string]uint64
+	var driftReportErr error
+	var driftReportFetched bool
+
 	syncedCount := 0
 	haSkippedCount := 0
 	live := make(map[string]struct{}, len(pvList.Items))
@@ -776,16 +802,74 @@ func (a *QuotaAgent) syncAllQuotas(ctx context.Context) error {
 			// which is exactly why status write-back stays gated off here.
 		}
 
-		err := a.ensureQuota(ctx, &pv, effectiveBytes)
+		mutated, err := a.ensureQuotaMutated(ctx, &pv, effectiveBytes)
 		switch {
 		case hasLocalDir:
-			cycle.recordEnforcement(winner, &pv, err)
+			// Independent drift check (#13's Drifted condition), only
+			// when enforcement itself reported no error: ensureQuota's
+			// own cache short-circuit (appliedQuotas[localPath] ==
+			// sizeBytes) skips re-verifying an already-cached value even
+			// if the real on-disk state has since changed out of band --
+			// this is what catches that case on every full sync cycle
+			// regardless. A standby instance's err is ErrHAStandby
+			// (non-nil), so this never runs there either, same as the
+			// enforcement path it piggybacks on.
+			//
+			// Restricted to claims THIS call to ensureQuotaMutated did
+			// NOT itself just mutate: the shared driftReport snapshot
+			// below is fetched once, lazily, on the first claim that
+			// needs it -- so for a PV that gets a fresh apply/update
+			// *after* that snapshot was taken (a different PV earlier in
+			// this same loop triggered the fetch), the snapshot predates
+			// this PV's own mutation and comparing against it would
+			// misreport a brand new, correctly-applied value as drift. A
+			// freshly mutated claim doesn't need this check anyway:
+			// ensureQuota's own apply-time read-back (#10's
+			// verifyQuotaOnDisk) already confirmed it moments ago.
+			//
+			// mutated comes directly from ensureQuotaMutated's own return
+			// value, not inferred from a before/after read of
+			// appliedQuotas: an independent review pointed out that
+			// inference is vulnerable to an ABA race against the watch
+			// path's reconcile queue, which can concurrently call
+			// ensureQuota for the same PV in a separate goroutine and
+			// leave the net cache value looking unchanged even though a
+			// mutation genuinely happened during this window.
+			var drift driftCheck
+			if err == nil && winner != nil && !mutated {
+				if !driftReportFetched {
+					driftReportFetched = true
+					driftReport, driftReportErr = a.fetchQuotaReport()
+					if driftReportErr != nil {
+						// A transient report-command failure isn't
+						// evidence of drift, only that this cycle
+						// couldn't check -- see errQuotaReportUnavailable's
+						// doc comment. Logged once per cycle, not once per
+						// PV: every PV shares this same fetch attempt.
+						slog.Warn("Could not check quota drift this cycle: on-disk quota report unavailable", "error", driftReportErr)
+					}
+				}
+				if driftReportErr != nil {
+					drift.unknown = true
+				} else if sizeBytes, sizeErr := resolveSizeBytes(&pv, effectiveBytes); sizeErr == nil {
+					drift.err = compareToReport(a.fsType, driftReport, localPath, sizeBytes)
+					// sizeErr itself is deliberately not surfaced as
+					// drift: a PV with no storage capacity is an
+					// enforcement problem ensureQuota's own error path
+					// above would already have caught (ensureQuota calls
+					// the identical resolveSizeBytes first), not a "the
+					// filesystem disagrees" one -- and err is nil here
+					// precisely because ensureQuota already resolved this
+					// pv without error this same cycle.
+				}
+			}
+			cycle.recordEnforcement(winner, &pv, err, drift)
 		case a.quotaPolicySingleWriter:
 			// ensureQuota returned nil here too (it skips silently on a
 			// missing directory), so without substituting a real error the
 			// claim would still look like a clean success. Record the
 			// actual, honest outcome: matched, but not enforced.
-			cycle.recordEnforcement(winner, &pv, errLocalDirectoryMissing)
+			cycle.recordEnforcement(winner, &pv, errLocalDirectoryMissing, driftCheck{})
 		}
 		switch {
 		case errors.Is(err, ErrHAStandby):
@@ -879,6 +963,26 @@ func (a *QuotaAgent) getNFSPath(pv *v1.PersistentVolume) string {
 	return pvpath.NFSPath(pv)
 }
 
+// resolveSizeBytes computes the actual byte count that should be enforced
+// for pv, given effectiveBytes (a QuotaPolicy-resolved bound, or 0/negative
+// to mean "use the PV's own capacity unchanged" -- see ensureQuota's doc
+// comment on effectiveBytes for the full contract). Pulled out of
+// ensureQuota so the independent drift check in syncAllQuotas (#13's
+// Drifted condition) resolves the exact same expected value ensureQuota
+// itself would -- duplicating this arithmetic inline at both call sites
+// would let them silently diverge if either one changed later, which is
+// exactly the class of bug #10's CRITICAL finding was.
+func resolveSizeBytes(pv *v1.PersistentVolume, effectiveBytes int64) (int64, error) {
+	capacity, ok := pv.Spec.Capacity[v1.ResourceStorage]
+	if !ok {
+		return 0, fmt.Errorf("PV %s has no storage capacity", pv.Name)
+	}
+	if effectiveBytes > 0 {
+		return effectiveBytes, nil
+	}
+	return capacity.Value(), nil
+}
+
 // ensureQuota ensures the quota is applied for a PV.
 //
 // effectiveBytes, when positive, overrides the PV's own capacity — this is
@@ -892,7 +996,27 @@ func (a *QuotaAgent) getNFSPath(pv *v1.PersistentVolume) string {
 // Added/Modified event doesn't ignore QuotaPolicy (or, worse, undo a clamp
 // the last sync just applied — see beginQuotaPolicyCycle's doc comment for
 // why that would otherwise oscillate forever).
+// ensureQuota's public signature is unchanged for its existing callers
+// (reconcile_queue.go, every existing test): it just discards the mutated
+// signal ensureQuotaMutated now also returns. syncAllQuotas' drift check
+// (#13) uses ensureQuotaMutated directly instead of inferring "did this
+// call actually change anything" from a before/after cache-value
+// comparison -- an independent review caught that inference as
+// ABA-vulnerable against a concurrent watch-path reconcile for the same
+// claim (a genuinely reachable race: the periodic full sync and the watch
+// reconcile queue are separate goroutines that can both call ensureQuota
+// for the same PV).
 func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, effectiveBytes int64) error {
+	_, err := a.ensureQuotaMutated(ctx, pv, effectiveBytes)
+	return err
+}
+
+// ensureQuotaMutated is ensureQuota's real implementation. mutated is true
+// only when this specific call actually wrote a new value into
+// a.appliedQuotas (the fresh-apply success path) -- false for every other
+// return, including the cache-hit no-op (already correct, nothing to do)
+// and every error path (nothing was durably changed).
+func (a *QuotaAgent) ensureQuotaMutated(ctx context.Context, pv *v1.PersistentVolume, effectiveBytes int64) (mutated bool, err error) {
 	// Checked before taking a.mu: HAActive() is just a stat call, and a
 	// standby instance should never even contend for the lock over work
 	// it's about to skip. See haActiveFile's doc comment (#11) -- this is
@@ -905,36 +1029,30 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, e
 	// this specific error as "correctly skipped," not a failure.
 	if !a.HAActive() {
 		slog.Debug("Skipping quota mutation: this instance is HA standby", "pv", pv.Name)
-		return ErrHAStandby
+		return false, ErrHAStandby
 	}
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	capacity, ok := pv.Spec.Capacity[v1.ResourceStorage]
-	if !ok {
-		return fmt.Errorf("PV %s has no storage capacity", pv.Name)
+	sizeBytes, err := resolveSizeBytes(pv, effectiveBytes)
+	if err != nil {
+		return false, err
 	}
-	capacityBytes := capacity.Value()
 
 	nfsPath := a.getNFSPath(pv)
 	if nfsPath == "" {
-		return fmt.Errorf("PV %s has no NFS path", pv.Name)
+		return false, fmt.Errorf("PV %s has no NFS path", pv.Name)
 	}
 	localPath := a.nfsPathToLocal(nfsPath)
 
-	sizeBytes := capacityBytes
-	if effectiveBytes > 0 {
-		sizeBytes = effectiveBytes
-	}
-
-	if _, err := os.Stat(localPath); os.IsNotExist(err) {
+	if _, statErr := os.Stat(localPath); os.IsNotExist(statErr) {
 		slog.Warn("Directory does not exist, skipping quota", "path", localPath, "pv", pv.Name)
-		return nil
+		return false, nil
 	}
 
 	if existingQuota, exists := a.appliedQuotas[localPath]; exists && existingQuota == sizeBytes {
-		return nil
+		return false, nil
 	}
 
 	var namespace, pvcName string
@@ -950,7 +1068,7 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, e
 			a.auditLogger.LogProjectIDAllocationFailure(pv.Name, namespace, pvcName, localPath, projectName, err)
 		}
 		a.updateQuotaStatus(ctx, pv, QuotaStatusFailed, 0)
-		return fmt.Errorf("failed to allocate project ID for PV %s: %w", pv.Name, err)
+		return false, fmt.Errorf("failed to allocate project ID for PV %s: %w", pv.Name, err)
 	}
 
 	oldQuota := a.appliedQuotas[localPath]
@@ -987,7 +1105,7 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, e
 
 	if err != nil {
 		a.updateQuotaStatus(ctx, pv, QuotaStatusFailed, 0)
-		return err
+		return false, err
 	}
 
 	a.appliedQuotas[localPath] = sizeBytes
@@ -999,7 +1117,7 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, e
 		"capacity", util.FormatBytes(sizeBytes),
 	)
 
-	return nil
+	return true, nil
 }
 
 // nfsPathToLocal converts NFS server path to local mount path. Delegates to
@@ -1169,6 +1287,34 @@ func (a *QuotaAgent) applyQuota(path, projectName string, projectID uint32, size
 // a.nfsBasePath, a.projectsFile, a.projidFile), so no additional locking
 // is needed here.
 func (a *QuotaAgent) verifyQuotaOnDisk(localPath string, sizeBytes int64) error {
+	quotaMap, err := a.fetchQuotaReport()
+	if err != nil {
+		return err
+	}
+	return compareToReport(a.fsType, quotaMap, localPath, sizeBytes)
+}
+
+// errQuotaReportUnavailable wraps a failure to read the on-disk quota
+// report itself (the xfs_quota/repquota/btrfs command failing) -- distinct
+// from a report that was read successfully but disagrees with what's
+// expected. A caller deciding whether to treat a failure as confirmed
+// drift (#13's Drifted condition) must check for this and exclude it: an
+// independent review pointed out that a transient report-command failure
+// isn't evidence the filesystem's actual state disagrees with anything,
+// only that this attempt to observe it failed -- reporting it as
+// Drifted=True would be a false positive indistinguishable from a real
+// mismatch to anything reading the condition.
+var errQuotaReportUnavailable = errors.New("failed to read back on-disk quota report")
+
+// fetchQuotaReport is the read half of verifyQuotaOnDisk, pulled out so a
+// caller checking many PVs in one cycle (syncAllQuotas' drift check, #13)
+// can fetch the filesystem-wide report once and reuse it, rather than
+// repeating a full scan once per PV -- an independent review flagged the
+// naive per-PV cost as unnecessarily expensive for installations with many
+// QuotaPolicy-matched claims, since the report is identical for every PV
+// on this node within one cycle (same fsType/quotaPath/projectsFile/
+// projidFile, none of which vary per PV).
+func (a *QuotaAgent) fetchQuotaReport() (map[string]uint64, error) {
 	var quotaMap map[string]uint64
 	var err error
 
@@ -1184,12 +1330,19 @@ func (a *QuotaAgent) verifyQuotaOnDisk(localPath string, sizeBytes int64) error 
 	case quota.FSTypeBtrfs:
 		quotaMap, _, err = quota.GetBtrfsQuotaReport(a.quotaPath)
 	default:
-		return fmt.Errorf("unsupported filesystem type: %s", a.fsType)
+		return nil, fmt.Errorf("unsupported filesystem type: %s", a.fsType)
 	}
 	if err != nil {
-		return fmt.Errorf("failed to read back on-disk quota report: %w", err)
+		return nil, fmt.Errorf("%w: %v", errQuotaReportUnavailable, err)
 	}
+	return quotaMap, nil
+}
 
+// compareToReport checks localPath's expected sizeBytes against a
+// previously fetched quotaMap (see fetchQuotaReport) -- pure comparison,
+// no I/O, so it's free to call once per PV even when the report itself
+// was fetched once for the whole cycle.
+func compareToReport(fsType string, quotaMap map[string]uint64, localPath string, sizeBytes int64) error {
 	got, ok := quotaMap[localPath]
 	if !ok {
 		return fmt.Errorf("path %s not found in on-disk quota report after apply", localPath)
@@ -1199,7 +1352,7 @@ func (a *QuotaAgent) verifyQuotaOnDisk(localPath string, sizeBytes int64) error 
 	// ExpectedEnforcedBytes), so comparing against sizeBytes directly
 	// would reject a correct apply for any capacity that isn't already a
 	// 1024-byte multiple -- e.g. any decimal-SI `storage: 1G` PV.
-	want := uint64(quota.ExpectedEnforcedBytes(a.fsType, sizeBytes))
+	want := uint64(quota.ExpectedEnforcedBytes(fsType, sizeBytes))
 	if got != want {
 		return fmt.Errorf("on-disk quota %d does not match expected enforced value %d (requested %d)", got, want, sizeBytes)
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -245,6 +245,17 @@ func (a *QuotaAgent) SetProjectsFile(v string) { a.projectsFile = v }
 // SetProjidFile sets the projid file path.
 func (a *QuotaAgent) SetProjidFile(v string) { a.projidFile = v }
 
+// ProjectsFile returns the configured projects file path, for callers
+// (internal/metrics, internal/ui) that need to read the same real
+// on-disk quota state ensureQuota's own verification does, rather than
+// assume the standard /etc/projects -- see the CLAUDE.md gotcha on
+// GetDirUsages' hardcoded defaults for why this matters under a
+// non-default --projects-file.
+func (a *QuotaAgent) ProjectsFile() string { return a.projectsFile }
+
+// ProjidFile returns the configured projid file path. See ProjectsFile.
+func (a *QuotaAgent) ProjidFile() string { return a.projidFile }
+
 // SetStateDir sets the host-backed directory used for crash-recovery backup
 // sidecars of projectsFile/projidFile. An empty value disables the sidecar
 // (see quota.RemoveLineFromFile/RecoverProjectFile), degrading gracefully
@@ -1265,7 +1276,7 @@ func (a *QuotaAgent) recordHistory() {
 	}
 
 	fsType, _ := quota.DetectFSType(a.nfsBasePath)
-	usages, err := status.GetDirUsages(a.nfsBasePath, fsType)
+	usages, err := status.GetDirUsages(a.nfsBasePath, fsType, a.projectsFile, a.projidFile)
 	if err != nil {
 		slog.Error("Failed to get usages for history", "error", err)
 		return

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -127,6 +127,18 @@ type QuotaAgent struct {
 	reconcileTotal         atomic.Int64
 	reconcileErrors        atomic.Int64
 	reconcileDurationNanos atomic.Int64
+	// verificationFailures counts ensureQuota applies that succeeded (the
+	// quota binary exited 0) but whose read-back verification (see
+	// verifyQuotaOnDisk) then found the on-disk state didn't actually
+	// match what was requested -- a distinct failure class from an apply
+	// command itself failing, tracked separately so operators can tell
+	// "the tool refused" from "the tool lied" (#10). Also counted in
+	// reconcileErrors when the failing call went through the watch path's
+	// reconcile queue (recordReconcileResult) -- but NOT when it came from
+	// syncAllQuotas' periodic full sync, which calls ensureQuota directly
+	// and never touches recordReconcileResult. Don't assume this is always
+	// a subset of reconcileErrors; it can exceed it.
+	verificationFailures atomic.Int64
 
 	// Auto-cleanup configuration
 	enableAutoCleanup bool
@@ -935,6 +947,25 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, e
 
 	err = a.applyQuota(localPath, projectName, projectID, sizeBytes)
 
+	// Read-back verification (#10) runs before the CREATE/UPDATE audit
+	// entry, not after: the quota binary exiting 0 means the command
+	// succeeded, not that the kernel actually holds the limit we asked
+	// for. Auditing "success" here and a VERIFY_FAILED entry right behind
+	// it on a verification failure would leave two contradictory entries
+	// for the same apply -- anything reading the audit log for "was this
+	// quota applied" (the web UI's audit view) would trust the first one
+	// and be wrong. err is folded into a single final outcome instead, so
+	// exactly one CREATE/UPDATE entry reflects what actually happened.
+	if err == nil {
+		if verifyErr := a.verifyQuotaOnDisk(localPath, sizeBytes); verifyErr != nil {
+			a.verificationFailures.Add(1)
+			err = fmt.Errorf("quota apply succeeded but read-back verification failed for PV %s: %w", pv.Name, verifyErr)
+			if a.auditLogger != nil {
+				a.auditLogger.LogQuotaVerificationFailure(pv.Name, localPath, projectName, projectID, sizeBytes, a.fsType, verifyErr)
+			}
+		}
+	}
+
 	if a.auditLogger != nil {
 		if isUpdate {
 			a.auditLogger.LogQuotaUpdate(pv.Name, localPath, projectName, projectID, oldQuota, sizeBytes, a.fsType, err)
@@ -1112,6 +1143,63 @@ func (a *QuotaAgent) applyQuota(path, projectName string, projectID uint32, size
 	default:
 		return fmt.Errorf("unsupported filesystem type: %s", a.fsType)
 	}
+}
+
+// verifyQuotaOnDisk reads back the actual filesystem-enforced quota for
+// localPath and confirms it equals sizeBytes -- the "did the apply command
+// exiting 0 actually mean the kernel holds this limit" check #10 asks for.
+// Uses the agent's own configured a.projectsFile/a.projidFile (not the
+// hardcoded /etc/projects, /etc/projid the status/UI reporting path uses),
+// so this stays hermetically testable and correct under a non-default
+// --projects-file/--projid-file.
+//
+// Called from within ensureQuota, which already holds a.mu for its whole
+// body -- this only reads config fields set at startup (a.fsType,
+// a.nfsBasePath, a.projectsFile, a.projidFile), so no additional locking
+// is needed here.
+func (a *QuotaAgent) verifyQuotaOnDisk(localPath string, sizeBytes int64) error {
+	var quotaMap map[string]uint64
+	var err error
+
+	// a.quotaPath, matching what applyQuota itself targets (ApplyXFSQuota/
+	// ApplyExt4Quota's quotaPath, ApplyBtrfsQuota's own path argument) --
+	// not a.nfsBasePath, which happens to equal it by default but is a
+	// separate field once --quota-path diverges from the base export path.
+	switch a.fsType {
+	case quota.FSTypeXFS:
+		quotaMap, _, err = quota.GetXFSQuotaReport(a.quotaPath, a.projectsFile, a.projidFile)
+	case quota.FSTypeExt4:
+		quotaMap, _, err = quota.GetExt4QuotaReport(a.quotaPath, a.projectsFile)
+	case quota.FSTypeBtrfs:
+		quotaMap, _, err = quota.GetBtrfsQuotaReport(a.quotaPath)
+	default:
+		return fmt.Errorf("unsupported filesystem type: %s", a.fsType)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read back on-disk quota report: %w", err)
+	}
+
+	got, ok := quotaMap[localPath]
+	if !ok {
+		return fmt.Errorf("path %s not found in on-disk quota report after apply", localPath)
+	}
+	// Compare against what the backend was actually asked to enforce, not
+	// the raw request: XFS/ext4 both floor to whole KB (see
+	// ExpectedEnforcedBytes), so comparing against sizeBytes directly
+	// would reject a correct apply for any capacity that isn't already a
+	// 1024-byte multiple -- e.g. any decimal-SI `storage: 1G` PV.
+	want := uint64(quota.ExpectedEnforcedBytes(a.fsType, sizeBytes))
+	if got != want {
+		return fmt.Errorf("on-disk quota %d does not match expected enforced value %d (requested %d)", got, want, sizeBytes)
+	}
+	return nil
+}
+
+// VerificationFailures returns the cumulative count of ensureQuota applies
+// whose read-back verification (verifyQuotaOnDisk) failed after the apply
+// command itself succeeded, since process start.
+func (a *QuotaAgent) VerificationFailures() int64 {
+	return a.verificationFailures.Load()
 }
 
 // updateQuotaStatus updates the quota status annotation on the PV, and --

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -611,12 +612,31 @@ func TestEnsureQuotaSuccess(t *testing.T) {
 }
 
 func TestEnsureQuotaBtrfsSuccess(t *testing.T) {
+	// The runner tracks the `qgroup limit` call's (path -> byte limit) and
+	// answers a later `qgroup show` from that state, so ensureQuota's
+	// post-apply read-back verification (verifyQuotaOnDisk, #10) sees the
+	// limit it just applied instead of an unhandled-command error.
+	var mu sync.Mutex
+	limits := map[string]string{} // path -> byte limit string
 	withFakeRunner(t, &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
 		if name == "btrfs" && args[0] == "subvolume" && args[1] == "show" {
 			return []byte("Name: my-subvolume\nUUID: 1234"), nil
 		}
 		if name == "btrfs" && args[0] == "qgroup" && args[1] == "limit" {
+			mu.Lock()
+			limits[args[3]] = args[2]
+			mu.Unlock()
 			return []byte(""), nil
+		}
+		if name == "btrfs" && args[0] == "qgroup" && args[1] == "show" {
+			mu.Lock()
+			defer mu.Unlock()
+			var sb strings.Builder
+			sb.WriteString("qgroupid rfer excl max_rfer max_excl path\n-------- ---- ---- -------- -------- ----\n")
+			for path, bytes := range limits {
+				fmt.Fprintf(&sb, "0/256 %s %s %s none %s\n", bytes, bytes, bytes, path)
+			}
+			return []byte(sb.String()), nil
 		}
 		return nil, errors.New("unexpected command")
 	}})
@@ -724,6 +744,156 @@ func TestEnsureQuotaCommandFailure(t *testing.T) {
 	}
 	if updated.Annotations[AnnotationQuotaStatus] != QuotaStatusFailed {
 		t.Fatalf("expected quota status failed, got %q", updated.Annotations[AnnotationQuotaStatus])
+	}
+}
+
+// TestEnsureQuota_VerificationFailureNotReportedApplied covers #10's core
+// case: the apply command itself exits 0 (project init + limit both
+// "succeed"), but the read-back report doesn't show the project at all --
+// simulating the kernel not actually holding the state the tool claimed to
+// set. This must be treated the same as an apply command failure: no
+// caching, no QuotaStatusApplied, a distinct verification-failure count.
+func TestEnsureQuota_VerificationFailureNotReportedApplied(t *testing.T) {
+	r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+		if name == "xfs_quota" && len(args) >= 3 && strings.HasPrefix(args[2], "report") {
+			// The kernel's report doesn't show the project the preceding
+			// `limit -p` call just "applied" -- as if the mutation never
+			// actually took effect despite the command exiting 0.
+			return []byte("Project ID   Used   Soft   Hard   Warn/Grace\n"), nil
+		}
+		return xfsHappyRunner().fn(name, args...)
+	}}
+	withFakeRunner(t, r)
+
+	a, pv, client := ensureQuotaFixture(t, 1)
+	a.fsType = quota.FSTypeXFS
+
+	ctx := context.Background()
+	err := a.ensureQuota(ctx, pv, 0)
+	if err == nil {
+		t.Fatalf("expected verification-failure error")
+	}
+	if !strings.Contains(err.Error(), "read-back verification failed") {
+		t.Fatalf("expected error to mention read-back verification, got: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if _, ok := a.appliedQuotas[localPath]; ok {
+		t.Fatalf("appliedQuotas should not be set when read-back verification fails")
+	}
+
+	updated, err := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pv: %v", err)
+	}
+	if updated.Annotations[AnnotationQuotaStatus] != QuotaStatusFailed {
+		t.Fatalf("expected quota status failed, got %q", updated.Annotations[AnnotationQuotaStatus])
+	}
+	if updated.Annotations[AnnotationEnforcedLimitBytes] != "" {
+		t.Fatalf("enforced-limit-bytes should not be set for a verification failure, got %q", updated.Annotations[AnnotationEnforcedLimitBytes])
+	}
+
+	if got := a.VerificationFailures(); got != 1 {
+		t.Fatalf("VerificationFailures() = %d, want 1", got)
+	}
+}
+
+// TestEnsureQuota_VerificationMismatchedValueNotReportedApplied covers the
+// value-comparison branch specifically (as opposed to the "path missing
+// entirely" branch the test above covers) -- the report finds the project
+// at the right path, but with a different hard limit than what was
+// actually requested, simulating on-disk drift from the desired state.
+// Deleting the value comparison in verifyQuotaOnDisk entirely (leaving only
+// the "found" check) would make every other test in this file still pass,
+// since xfsHappyRunner's fake always reports back whatever value the
+// preceding `limit -p` call sent it -- this test is the one that would
+// catch that regression.
+func TestEnsureQuota_VerificationMismatchedValueNotReportedApplied(t *testing.T) {
+	r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+		if name == "xfs_quota" && len(args) >= 3 && strings.HasPrefix(args[2], "report") {
+			// Drift: the on-disk hard limit doesn't match what the
+			// preceding limit -p call for this project ID actually set.
+			return []byte("Project ID   Used   Soft   Hard   Warn/Grace\n#pv_pv_1     0      0      1    00 [------]\n"), nil
+		}
+		return xfsHappyRunner().fn(name, args...)
+	}}
+	withFakeRunner(t, r)
+
+	a, pv, client := ensureQuotaFixture(t, 1)
+	a.fsType = quota.FSTypeXFS
+
+	ctx := context.Background()
+	err := a.ensureQuota(ctx, pv, 0)
+	if err == nil {
+		t.Fatalf("expected verification-failure error for a mismatched on-disk value")
+	}
+	if !strings.Contains(err.Error(), "does not match expected enforced value") {
+		t.Fatalf("expected error to mention the value mismatch, got: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if _, ok := a.appliedQuotas[localPath]; ok {
+		t.Fatalf("appliedQuotas should not be set when the on-disk value doesn't match")
+	}
+
+	updated, err := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pv: %v", err)
+	}
+	if updated.Annotations[AnnotationQuotaStatus] != QuotaStatusFailed {
+		t.Fatalf("expected quota status failed, got %q", updated.Annotations[AnnotationQuotaStatus])
+	}
+}
+
+// TestEnsureQuota_NonGiCapacitySucceeds is the direct regression test for
+// the bug an independent review found in this same change: XFS/ext4 floor
+// the requested size to whole KB before enforcing it (ApplyXFSQuota's
+// bhard=%dk), so comparing read-back state against the raw requested byte
+// count -- instead of quota.ExpectedEnforcedBytes' floored value -- made
+// verifyQuotaOnDisk reject every correctly-applied PV whose capacity isn't
+// already a 1024-byte multiple. Every other ensureQuota test in this file
+// uses a Gi-multiple capacity via newBoundPV/ensureQuotaFixture, which is
+// exactly why this slipped through: 1Gi is already 1024-byte-aligned, so
+// the floor is a no-op and the bug is invisible.
+func TestEnsureQuota_NonGiCapacitySucceeds(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-nongi"},
+		Spec: v1.PersistentVolumeSpec{
+			// 1G decimal SI = 1,000,000,000 bytes -- not a multiple of 1024.
+			Capacity: v1.ResourceList{v1.ResourceStorage: *resource.NewQuantity(1000000000, resource.DecimalSI)},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				NFS: &v1.NFSVolumeSource{Server: "nfs.example.com", Path: "/exports/pvc-nongi"},
+			},
+			ClaimRef: &v1.ObjectReference{Namespace: "default", Name: "pv-nongi-claim"},
+		},
+		Status: v1.PersistentVolumeStatus{Phase: v1.VolumeBound},
+	}
+	client := fake.NewSimpleClientset(pv)
+	a := newTestAgent(t, client)
+	a.nfsServerPath = "/exports"
+	a.fsType = quota.FSTypeXFS
+	localPath := a.nfsPathToLocal("/exports/pvc-nongi")
+	if err := os.MkdirAll(localPath, 0755); err != nil {
+		t.Fatalf("mkdir localPath: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := a.ensureQuota(ctx, pv, 0); err != nil {
+		t.Fatalf("ensureQuota: %v", err)
+	}
+
+	if _, ok := a.appliedQuotas[localPath]; !ok {
+		t.Fatalf("expected appliedQuotas to be recorded for a non-Gi-multiple capacity")
+	}
+
+	updated, err := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pv: %v", err)
+	}
+	if updated.Annotations[AnnotationQuotaStatus] != QuotaStatusApplied {
+		t.Fatalf("expected quota status applied, got %q", updated.Annotations[AnnotationQuotaStatus])
 	}
 }
 

--- a/internal/agent/helpers_test.go
+++ b/internal/agent/helpers_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package agent
 
 import (
+	"fmt"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -64,9 +67,62 @@ func withFakeRunner(t *testing.T, r *fakeRunner) {
 	t.Cleanup(restore)
 }
 
+// xfsQuotaState is a minimal in-memory stand-in for the kernel's XFS
+// project quota table: it tracks each `limit -p bhard=...` call's project
+// ID -> byte limit and answers a later `report -p -b` query from that
+// state. Any fake xfs_quota runner that lets ensureQuota reach a successful
+// apply needs this -- without it, the post-apply read-back verification
+// (verifyQuotaOnDisk, #10) finds no matching project in the report and
+// fails, since the report command must actually reflect what was applied
+// rather than return a fixed string.
+type xfsQuotaState struct {
+	mu      sync.Mutex
+	applied map[string]int64 // projectID string -> hard limit bytes
+}
+
+// handle answers a "-x -c <cmd> [path]" xfs_quota invocation if cmd is a
+// `limit -p` or `report` call; ok is false for anything else (state/
+// version checks), leaving the caller to answer those itself.
+func (s *xfsQuotaState) handle(cmd string) (out []byte, ok bool) {
+	switch {
+	case strings.HasPrefix(cmd, "limit -p "):
+		fields := strings.Fields(cmd)
+		var projectID string
+		var bhardBytes int64
+		for _, f := range fields[2:] {
+			if strings.HasPrefix(f, "bhard=") {
+				if kb, err := strconv.ParseInt(strings.TrimSuffix(strings.TrimPrefix(f, "bhard="), "k"), 10, 64); err == nil {
+					bhardBytes = kb * 1024
+				}
+			} else {
+				projectID = f
+			}
+		}
+		s.mu.Lock()
+		if s.applied == nil {
+			s.applied = map[string]int64{}
+		}
+		s.applied[projectID] = bhardBytes
+		s.mu.Unlock()
+		return []byte(""), true
+	case strings.HasPrefix(cmd, "report"):
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		var sb strings.Builder
+		sb.WriteString("Project ID   Used   Soft   Hard   Warn/Grace\n")
+		for id, bytes := range s.applied {
+			fmt.Fprintf(&sb, "#%s     0      0      %d    00 [------]\n", id, bytes/1024)
+		}
+		return []byte(sb.String()), true
+	default:
+		return nil, false
+	}
+}
+
 // xfsHappyRunner returns a fakeRunner that answers every findmnt/xfs_quota
-// call needed for a successful xfs detect+check+apply flow.
+// call needed for a successful xfs detect+check+apply+verify flow.
 func xfsHappyRunner() *fakeRunner {
+	state := &xfsQuotaState{}
 	return &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
 		switch name {
 		case "findmnt":
@@ -74,6 +130,11 @@ func xfsHappyRunner() *fakeRunner {
 		case "xfs_quota":
 			if len(args) > 0 && args[0] == "-V" {
 				return []byte("xfs_quota version 1.0"), nil
+			}
+			if len(args) >= 3 && args[1] == "-c" {
+				if out, ok := state.handle(args[2]); ok {
+					return out, nil
+				}
 			}
 			return []byte("Project quota state: ON"), nil
 		default:

--- a/internal/agent/policy.go
+++ b/internal/agent/policy.go
@@ -259,7 +259,15 @@ func (c *quotaPolicyCycle) resolve(pv *v1.PersistentVolume) (effectiveBytes int6
 // what resolve returned for this same pv earlier in the same loop
 // iteration; nil means resolve found no matching policy, in which case
 // there is nothing to record and this is a no-op, same as a nil cycle.
-func (c *quotaPolicyCycle) recordEnforcement(winner *v1alpha1.QuotaPolicy, pv *v1.PersistentVolume, err error) {
+//
+// driftErr, when non-nil, is an independent read-back mismatch (#10's
+// verifyQuotaOnDisk, checked by the caller regardless of whether
+// ensureQuota actually mutated anything this cycle -- see agent.go's
+// syncAllQuotas). Only meaningful when err is nil: an enforcement failure
+// already explains why the filesystem might disagree, so driftErr is
+// ignored (not recorded) whenever err is non-nil, keeping Degraded and
+// Drifted from both firing off the same underlying cause.
+func (c *quotaPolicyCycle) recordEnforcement(winner *v1alpha1.QuotaPolicy, pv *v1.PersistentVolume, err error, drift driftCheck) {
 	if c == nil || winner == nil || pv.Spec.ClaimRef == nil {
 		return
 	}
@@ -271,11 +279,31 @@ func (c *quotaPolicyCycle) recordEnforcement(winner *v1alpha1.QuotaPolicy, pv *v
 		MatchKind: c.matchKindFor[claimKey],
 		Won:       true,
 	}
-	if err != nil {
+	switch {
+	case err != nil:
 		outcome.EnforcementErr = err
 		outcome.EnforcementReason = classifyEnforcementError(err)
+	case drift.unknown:
+		outcome.DriftUnknown = true
+	case drift.err != nil:
+		outcome.DriftErr = drift.err
 	}
 	c.record(winner.Namespace, winner.Name, outcome)
+}
+
+// driftCheck carries the independent read-back drift check's outcome for
+// one claim (#13's Drifted condition) into recordEnforcement. The zero
+// value means "not checked this cycle" -- enforcement itself failed, there
+// was no local directory, or the claim was mutated by ensureQuota this
+// same cycle (see syncAllQuotas' doc comment on why a freshly mutated
+// claim isn't re-checked against a report snapshot that may predate its
+// own mutation). err and unknown are mutually exclusive: unknown means the
+// on-disk quota report itself couldn't be read this cycle, which is a
+// different, weaker signal than err (the report was read successfully and
+// disagreed) -- see setDrifted's Unknown-vs-False handling.
+type driftCheck struct {
+	err     error
+	unknown bool
 }
 
 // record appends outcome to the running list for the policy identified by

--- a/internal/agent/policy_test.go
+++ b/internal/agent/policy_test.go
@@ -18,8 +18,12 @@ package agent
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -270,5 +274,511 @@ func TestFinishQuotaPolicyCycle_SkipsStatusByDefault(t *testing.T) {
 	}
 	if _, found, _ := unstructured.NestedSlice(got.Object, "status", "conditions"); found {
 		t.Fatalf("expected status.conditions to be unset without quotaPolicySingleWriter, got %+v", got.Object["status"])
+	}
+}
+
+// TestSyncAllQuotas_DriftIndependentOfEnforcementCache is the end-to-end
+// regression test for #13's Drifted condition: it proves the drift check
+// actually catches what it exists to catch -- a claim ensureQuota's own
+// cache short-circuit (appliedQuotas[localPath] == sizeBytes) would
+// otherwise skip re-verifying, because nothing about the *enforcement
+// path* changed between cycles. Cycle 1 applies and caches the policy's
+// 1Gi max. Between cycles, the fake xfs_quota's on-disk state is mutated
+// directly (simulating an out-of-band change -- someone running xfs_quota
+// by hand, or a kernel-level anomaly) without touching the agent's cache
+// or re-running any apply. Cycle 2 must still detect the mismatch via the
+// independent read-back check and report Drifted=True, even though
+// ensureQuota itself does no work that cycle (same cached value, same
+// effectiveBytes -- its fast path returns nil without ever calling
+// verifyQuotaOnDisk).
+func TestSyncAllQuotas_DriftIndependentOfEnforcementCache(t *testing.T) {
+	state := &xfsQuotaState{}
+	var enforcementCalls atomic.Int32 // project -s / limit -p, i.e. actual mutation attempts
+	runner := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+		switch name {
+		case "findmnt":
+			return []byte("xfs\n"), nil
+		case "xfs_quota":
+			if len(args) > 0 && args[0] == "-V" {
+				return []byte("xfs_quota version 1.0"), nil
+			}
+			if len(args) >= 3 && args[1] == "-c" {
+				if strings.HasPrefix(args[2], "project -s") || strings.HasPrefix(args[2], "limit -p") {
+					enforcementCalls.Add(1)
+				}
+				if out, ok := state.handle(args[2]); ok {
+					return out, nil
+				}
+			}
+			return []byte("Project quota state: ON"), nil
+		default:
+			return []byte(""), nil
+		}
+	}}
+	withFakeRunner(t, runner)
+
+	a, _ := quotaPolicyTestFixture(t)
+	a.SetQuotaPolicyEnabled(true)
+	a.SetQuotaPolicySingleWriter(true)
+	p := gi1MaxPolicy("default", "cap-at-1gi")
+	dyn := newFakeQuotaPolicyClient(t, p)
+	a.SetDynamicClient(dyn)
+
+	// Cycle 1: normal apply. Confirms the baseline (Applied=True,
+	// Drifted=False) before introducing drift.
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas (cycle 1): %v", err)
+	}
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if got := a.appliedQuotas[localPath]; got != oneGiBytes {
+		t.Fatalf("applied quota after cycle 1 = %d, want %d", got, oneGiBytes)
+	}
+
+	got1, err := dyn.Resource(quotapolicy.GroupVersionResource).Namespace(p.Namespace).Get(context.Background(), p.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get policy after cycle 1: %v", err)
+	}
+	assertConditionStatus(t, got1, "Drifted", "False")
+
+	// Introduce drift: directly overwrite the fake's on-disk state for
+	// this project's ID to a different value, bypassing the agent
+	// entirely -- exactly what an out-of-band xfs_quota invocation would
+	// do. The agent's own appliedQuotas cache and QuotaPolicy resolution
+	// are completely untouched.
+	state.mu.Lock()
+	for id := range state.applied {
+		state.applied[id] = oneGiBytes / 2
+	}
+	state.mu.Unlock()
+
+	// Cycle 2: same policy, same PV, same cache -- ensureQuota's fast path
+	// (appliedQuotas[localPath] == sizeBytes) means it does no work at all
+	// this cycle. Only the independent drift check can catch this.
+	enforcementCalls.Store(0)
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas (cycle 2): %v", err)
+	}
+	if got := a.appliedQuotas[localPath]; got != oneGiBytes {
+		t.Fatalf("appliedQuotas cache changed after cycle 2 = %d, want unchanged %d (drift detection must not itself mutate the cache)", got, oneGiBytes)
+	}
+	// Directly proves "independent of the enforcement cache": Drifted is
+	// detected below without ensureQuota ever re-running project -s/limit
+	// -p this cycle. Without this, a future refactor that re-verifies
+	// (and incidentally re-applies) during enforcement whenever it
+	// detects drift could make this test still pass for the wrong reason.
+	if got := enforcementCalls.Load(); got != 0 {
+		t.Fatalf("enforcement calls (project -s/limit -p) in cycle 2 = %d, want 0 -- drift must be detected without re-running the apply path", got)
+	}
+
+	got2, err := dyn.Resource(quotapolicy.GroupVersionResource).Namespace(p.Namespace).Get(context.Background(), p.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get policy after cycle 2: %v", err)
+	}
+	assertConditionStatus(t, got2, "Drifted", "True")
+	assertConditionStatus(t, got2, "Applied", "True") // enforcement itself still reported no error this cycle
+	driftedClaims, found, err := unstructured.NestedSlice(got2.Object, "status", "driftedClaims")
+	if err != nil || !found || len(driftedClaims) != 1 {
+		t.Fatalf("expected exactly one driftedClaims entry, found=%v err=%v got=%+v", found, err, driftedClaims)
+	}
+}
+
+// assertConditionStatus fails the test unless got's status.conditions
+// contains one entry of the given type with the given status.
+func assertConditionStatus(t *testing.T, got *unstructured.Unstructured, condType, wantStatus string) {
+	t.Helper()
+	conditions, found, err := unstructured.NestedSlice(got.Object, "status", "conditions")
+	if err != nil || !found {
+		t.Fatalf("status.conditions: found=%v err=%v", found, err)
+	}
+	for _, c := range conditions {
+		m, ok := c.(map[string]interface{})
+		if !ok || m["type"] != condType {
+			continue
+		}
+		if m["status"] != wantStatus {
+			t.Fatalf("condition %s status = %v, want %v (full: %+v)", condType, m["status"], wantStatus, m)
+		}
+		return
+	}
+	t.Fatalf("condition %s not found in %+v", condType, conditions)
+}
+
+// assertMatchedAndApplied fails the test unless got's status.matchedClaims
+// and status.appliedClaims equal the given values exactly.
+func assertMatchedAndApplied(t *testing.T, got *unstructured.Unstructured, wantMatched, wantApplied int64) {
+	t.Helper()
+	matched, found, err := unstructured.NestedInt64(got.Object, "status", "matchedClaims")
+	if err != nil || !found || matched != wantMatched {
+		t.Fatalf("status.matchedClaims: found=%v err=%v value=%d, want %d", found, err, matched, wantMatched)
+	}
+	applied, found, err := unstructured.NestedInt64(got.Object, "status", "appliedClaims")
+	if err != nil || !found || applied != wantApplied {
+		t.Fatalf("status.appliedClaims: found=%v err=%v value=%d, want %d", found, err, applied, wantApplied)
+	}
+}
+
+// TestSyncAllQuotas_DriftReportUnavailableReportsUnknown guards against
+// exactly what an independent review caught before this shipped, in two
+// rounds: first, that a transient failure to read the on-disk quota
+// report itself (the xfs_quota command failing) must not be reported as
+// Drifted=True -- that would be a false positive indistinguishable from a
+// real, confirmed mismatch. Second (the review's follow-up round), that it
+// must not be reported as Drifted=False either -- a report outage isn't
+// evidence of a healthy "no drift" state any more than it's evidence of
+// drift; it's Unknown, and the condition needs to say so or an operator
+// reading a falsely-healthy status would miss exactly the outage they most
+// need to know about.
+func TestSyncAllQuotas_DriftReportUnavailableReportsUnknown(t *testing.T) {
+	// failReports flips on only after cycle 1: cycle 1 needs its report
+	// call to succeed (ensureQuota's own apply-time verification, #10 --
+	// unrelated to this test) so the PV is genuinely cached as applied
+	// before cycle 2's report failure is introduced. Otherwise a failure
+	// on the very first report call would fail the apply itself, not
+	// exercise the drift-check's handling of a report failure at all.
+	var failReports atomic.Bool
+	state := &xfsQuotaState{}
+	runner := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+		if name == "xfs_quota" && len(args) >= 3 && args[1] == "-c" && strings.HasPrefix(args[2], "report") && failReports.Load() {
+			return nil, errors.New("simulated transient xfs_quota report failure")
+		}
+		switch name {
+		case "findmnt":
+			return []byte("xfs\n"), nil
+		case "xfs_quota":
+			if len(args) > 0 && args[0] == "-V" {
+				return []byte("xfs_quota version 1.0"), nil
+			}
+			if len(args) >= 3 && args[1] == "-c" {
+				if out, ok := state.handle(args[2]); ok {
+					return out, nil
+				}
+			}
+			return []byte("Project quota state: ON"), nil
+		default:
+			return []byte(""), nil
+		}
+	}}
+	withFakeRunner(t, runner)
+
+	a, _ := quotaPolicyTestFixture(t)
+	a.SetQuotaPolicyEnabled(true)
+	a.SetQuotaPolicySingleWriter(true)
+	p := gi1MaxPolicy("default", "cap-at-1gi")
+	dyn := newFakeQuotaPolicyClient(t, p)
+	a.SetDynamicClient(dyn)
+
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas (cycle 1): %v", err)
+	}
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if got := a.appliedQuotas[localPath]; got != oneGiBytes {
+		t.Fatalf("applied quota after cycle 1 = %d, want %d", got, oneGiBytes)
+	}
+
+	// Cycle 2: the PV is already cached correctly (no fresh apply needed,
+	// ensureQuota's fast path returns nil without calling report at all),
+	// so the only report call this cycle comes from the drift check --
+	// and it fails.
+	failReports.Store(true)
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas (cycle 2): %v", err)
+	}
+
+	got, err := dyn.Resource(quotapolicy.GroupVersionResource).Namespace(p.Namespace).Get(context.Background(), p.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get policy after cycle 2: %v", err)
+	}
+	assertConditionStatus(t, got, "Applied", "True")
+	assertConditionStatus(t, got, "Drifted", "Unknown")
+	drifted, err := getConditionReason(got, "Drifted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if drifted != v1alpha1.ReasonDriftCheckUnavailable {
+		t.Fatalf("Drifted condition reason = %q, want %q", drifted, v1alpha1.ReasonDriftCheckUnavailable)
+	}
+	if claims, found, err := unstructured.NestedSlice(got.Object, "status", "driftedClaims"); err != nil || (found && len(claims) != 0) {
+		t.Fatalf("expected no driftedClaims when the report itself was unreadable (that's Unknown, not confirmed drift), found=%v err=%v got=%+v", found, err, claims)
+	}
+}
+
+// getConditionReason returns the Reason of got's status.conditions entry
+// of the given type.
+func getConditionReason(got *unstructured.Unstructured, condType string) (string, error) {
+	conditions, found, err := unstructured.NestedSlice(got.Object, "status", "conditions")
+	if err != nil || !found {
+		return "", fmt.Errorf("status.conditions: found=%v err=%w", found, err)
+	}
+	for _, c := range conditions {
+		m, ok := c.(map[string]interface{})
+		if !ok || m["type"] != condType {
+			continue
+		}
+		reason, _ := m["reason"].(string)
+		return reason, nil
+	}
+	return "", fmt.Errorf("condition %s not found", condType)
+}
+
+// TestSyncAllQuotas_DriftReportFetchedOnceForMultiplePVs is the direct
+// regression test for the other half of the same review finding: with
+// several PVs matched by the same policy, the on-disk quota report must
+// be fetched once for the whole cycle and reused, not once per PV -- a
+// naive per-PV fetch would turn one sync into N filesystem-wide report
+// scans.
+func TestSyncAllQuotas_DriftReportFetchedOnceForMultiplePVs(t *testing.T) {
+	state := &xfsQuotaState{}
+	var reportCalls atomic.Int32
+	// corruptReport, once armed, makes the report response lie about every
+	// project's limit -- proving the batch fetch is actually compared
+	// per-PV (not just fetched once and blindly trusted): if only the
+	// first matched PV were compared, or the comparison loop silently
+	// skipped some claims, driftedClaims below would show fewer than
+	// nPVs entries despite every one of them genuinely mismatching.
+	var corruptReport atomic.Bool
+	runner := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+		switch name {
+		case "findmnt":
+			return []byte("xfs\n"), nil
+		case "xfs_quota":
+			if len(args) > 0 && args[0] == "-V" {
+				return []byte("xfs_quota version 1.0"), nil
+			}
+			if len(args) >= 3 && args[1] == "-c" {
+				if strings.HasPrefix(args[2], "report") {
+					reportCalls.Add(1)
+					if corruptReport.Load() {
+						return []byte("Project ID   Used   Soft   Hard   Warn/Grace\n"), nil
+					}
+				}
+				if out, ok := state.handle(args[2]); ok {
+					return out, nil
+				}
+			}
+			return []byte("Project quota state: ON"), nil
+		default:
+			return []byte(""), nil
+		}
+	}}
+	withFakeRunner(t, runner)
+
+	const nPVs = 3
+	var pvs []*v1.PersistentVolume
+	var objs []runtime.Object
+	for i := 0; i < nPVs; i++ {
+		name := "pv-" + string(rune('a'+i))
+		nfsPath := "/exports/pvc-" + string(rune('a'+i))
+		pv := newBoundPV(name, nfsPath, 10)
+		pv.Annotations = map[string]string{"pv.kubernetes.io/provisioned-by": "example.com/nfs"}
+		pvs = append(pvs, pv)
+		objs = append(objs, pv, &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Namespace: pv.Spec.ClaimRef.Namespace, Name: pv.Spec.ClaimRef.Name},
+		})
+	}
+	client := fake.NewSimpleClientset(objs...)
+
+	a := newTestAgent(t, client)
+	a.nfsServerPath = "/exports"
+	a.fsType = quota.FSTypeXFS
+	a.provisionerName = "example.com/nfs"
+	for i := range pvs {
+		if err := os.MkdirAll(filepath.Join(a.nfsBasePath, "pvc-"+string(rune('a'+i))), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+
+	a.SetQuotaPolicyEnabled(true)
+	a.SetQuotaPolicySingleWriter(true)
+	p := gi1MaxPolicy("default", "cap-at-1gi")
+	dyn := newFakeQuotaPolicyClient(t, p)
+	a.SetDynamicClient(dyn)
+
+	// Cycle 1 legitimately calls report once per freshly-applied PV (each
+	// one goes through ensureQuota's own apply-time verification, #10 --
+	// unrelated to this test's concern), so reportCalls isn't asserted
+	// here.
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas (cycle 1): %v", err)
+	}
+	for i := range pvs {
+		localPath := a.nfsPathToLocal("/exports/pvc-" + string(rune('a'+i)))
+		if got := a.appliedQuotas[localPath]; got != oneGiBytes {
+			t.Fatalf("pv %d: applied quota = %d, want %d", i, got, oneGiBytes)
+		}
+	}
+
+	// Cycle 2: every PV is already cached correctly, so ensureQuota's fast
+	// path skips all of them without ever calling report -- the only
+	// report call this cycle can come from the shared drift-check fetch.
+	// The report is also corrupted to show no matching entries at all, so
+	// every one of the nPVs claims should independently come back as
+	// drifted -- proving the single shared fetch is actually compared
+	// per-claim, not just fetched and trusted for one PV.
+	reportCalls.Store(0)
+	corruptReport.Store(true)
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas (cycle 2): %v", err)
+	}
+	if got := reportCalls.Load(); got != 1 {
+		t.Fatalf("report command called %d times in cycle 2 for %d matched PVs, want exactly 1 (fetched once for the cycle, not once per PV)", got, nPVs)
+	}
+
+	got, err := dyn.Resource(quotapolicy.GroupVersionResource).Namespace("default").Get(context.Background(), "cap-at-1gi", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get policy after cycle 2: %v", err)
+	}
+	assertConditionStatus(t, got, "Drifted", "True")
+	matched, found, err := unstructured.NestedInt64(got.Object, "status", "matchedClaims")
+	if err != nil || !found || matched != nPVs {
+		t.Fatalf("matchedClaims after cycle 2: found=%v err=%v value=%d, want %d", found, err, matched, nPVs)
+	}
+	drifted, found, err := unstructured.NestedSlice(got.Object, "status", "driftedClaims")
+	if err != nil || !found || len(drifted) != nPVs {
+		t.Fatalf("driftedClaims after cycle 2: found=%v err=%v len=%d, want %d (every matched PV must be individually checked against the shared report, not just the first one)", found, err, len(drifted), nPVs)
+	}
+}
+
+// TestSyncAllQuotas_FreshlyMutatedClaimNotFalselyDrifted is the direct
+// regression test for the P1 finding an independent review raised against
+// the first version of the drift check: the shared driftReport snapshot
+// (fetched once, lazily, on the first claim that needs it) is fetched
+// during THIS cycle, so a different claim that gets a fresh apply/update
+// later in this same cycle -- after the snapshot was taken -- would be
+// missing or stale in it. Comparing that freshly mutated claim against the
+// stale snapshot would misreport a brand new, correctly-applied value as
+// drift. The fix excludes any claim ensureQuota actually mutated this
+// cycle from the drift check entirely (its own apply-time verification,
+// #10, already confirmed it).
+//
+// Two separate pvcName-scoped policies target two separate PVs so their
+// mutation timing can be controlled independently: pv-a's policy is
+// unchanged between cycles (pv-a becomes a cache-hit in cycle 2, eligible
+// for drift-check); pv-b's policy's maxQuota changes between cycles,
+// forcing pv-b to be freshly re-applied in cycle 2.
+func TestSyncAllQuotas_FreshlyMutatedClaimNotFalselyDrifted(t *testing.T) {
+	state := &xfsQuotaState{}
+	runner := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+		switch name {
+		case "findmnt":
+			return []byte("xfs\n"), nil
+		case "xfs_quota":
+			if len(args) > 0 && args[0] == "-V" {
+				return []byte("xfs_quota version 1.0"), nil
+			}
+			if len(args) >= 3 && args[1] == "-c" {
+				if out, ok := state.handle(args[2]); ok {
+					return out, nil
+				}
+			}
+			return []byte("Project quota state: ON"), nil
+		default:
+			return []byte(""), nil
+		}
+	}}
+	withFakeRunner(t, runner)
+
+	pvA := newBoundPV("pv-a", "/exports/pvc-a", 10)
+	pvA.Annotations = map[string]string{"pv.kubernetes.io/provisioned-by": "example.com/nfs"}
+	pvB := newBoundPV("pv-b", "/exports/pvc-b", 10)
+	pvB.Annotations = map[string]string{"pv.kubernetes.io/provisioned-by": "example.com/nfs"}
+	client := fake.NewSimpleClientset(
+		pvA, &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Namespace: pvA.Spec.ClaimRef.Namespace, Name: pvA.Spec.ClaimRef.Name}},
+		pvB, &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Namespace: pvB.Spec.ClaimRef.Namespace, Name: pvB.Spec.ClaimRef.Name}},
+	)
+
+	a := newTestAgent(t, client)
+	a.nfsServerPath = "/exports"
+	a.fsType = quota.FSTypeXFS
+	a.provisionerName = "example.com/nfs"
+	for _, dir := range []string{"pvc-a", "pvc-b"} {
+		if err := os.MkdirAll(filepath.Join(a.nfsBasePath, dir), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+
+	pvcAName := pvA.Spec.ClaimRef.Name
+	pvcBName := pvB.Spec.ClaimRef.Name
+	pA := &v1alpha1.QuotaPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "policy-a"},
+		Spec: v1alpha1.QuotaPolicySpec{
+			Selector:   v1alpha1.QuotaPolicySelector{PVCName: &pvcAName},
+			MaxQuota:   resource.NewQuantity(oneGiBytes, resource.BinarySI),
+			EnforceMax: true,
+		},
+	}
+	pB := &v1alpha1.QuotaPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "policy-b"},
+		Spec: v1alpha1.QuotaPolicySpec{
+			Selector:   v1alpha1.QuotaPolicySelector{PVCName: &pvcBName},
+			MaxQuota:   resource.NewQuantity(oneGiBytes, resource.BinarySI),
+			EnforceMax: true,
+		},
+	}
+	dyn := newFakeQuotaPolicyClient(t, pA, pB)
+
+	a.SetQuotaPolicyEnabled(true)
+	a.SetQuotaPolicySingleWriter(true)
+	a.SetDynamicClient(dyn)
+
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas (cycle 1): %v", err)
+	}
+	localPathA := a.nfsPathToLocal("/exports/pvc-a")
+	localPathB := a.nfsPathToLocal("/exports/pvc-b")
+	if got := a.appliedQuotas[localPathA]; got != oneGiBytes {
+		t.Fatalf("pv-a applied quota after cycle 1 = %d, want %d", got, oneGiBytes)
+	}
+	if got := a.appliedQuotas[localPathB]; got != oneGiBytes {
+		t.Fatalf("pv-b applied quota after cycle 1 = %d, want %d", got, oneGiBytes)
+	}
+
+	// Bump only policy-b's maxQuota: only pv-b needs a fresh apply in
+	// cycle 2. pv-a's policy is untouched, so pv-a is a pure cache-hit,
+	// eligible for (and expected to pass) the drift check.
+	unstructuredB, err := dyn.Resource(quotapolicy.GroupVersionResource).Namespace("default").Get(context.Background(), "policy-b", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get policy-b: %v", err)
+	}
+	if err := unstructured.SetNestedField(unstructuredB.Object, "2Gi", "spec", "maxQuota"); err != nil {
+		t.Fatalf("set maxQuota: %v", err)
+	}
+	if _, err := dyn.Resource(quotapolicy.GroupVersionResource).Namespace("default").Update(context.Background(), unstructuredB, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update policy-b: %v", err)
+	}
+
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas (cycle 2): %v", err)
+	}
+
+	if got := a.appliedQuotas[localPathB]; got != 2*oneGiBytes {
+		t.Fatalf("pv-b applied quota after cycle 2 = %d, want %d (should have been freshly re-applied to the new maxQuota)", got, 2*oneGiBytes)
+	}
+
+	gotA, err := dyn.Resource(quotapolicy.GroupVersionResource).Namespace("default").Get(context.Background(), "policy-a", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get policy-a after cycle 2: %v", err)
+	}
+	// matchedClaims/appliedClaims asserted explicitly, not just the
+	// conditions: Applied=True and Drifted=False are both also true
+	// vacuously for zero recorded outcomes, so without this a claim that
+	// was silently skipped from status recording entirely (a different
+	// bug than the one this test targets) could still pass.
+	assertConditionStatus(t, gotA, "Applied", "True")
+	assertConditionStatus(t, gotA, "Drifted", "False")
+	assertMatchedAndApplied(t, gotA, 1, 1)
+
+	gotB, err := dyn.Resource(quotapolicy.GroupVersionResource).Namespace("default").Get(context.Background(), "policy-b", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get policy-b after cycle 2: %v", err)
+	}
+	// The regression this test exists for: without the mutatedThisCycle
+	// exclusion, pv-b's freshly-applied 2Gi could be compared against a
+	// report snapshot taken before that mutation and misreported as
+	// drift.
+	assertConditionStatus(t, gotB, "Applied", "True")
+	assertConditionStatus(t, gotB, "Drifted", "False")
+	assertMatchedAndApplied(t, gotB, 1, 1)
+	if claims, found, err := unstructured.NestedSlice(gotB.Object, "status", "driftedClaims"); err != nil || (found && len(claims) != 0) {
+		t.Fatalf("policy-b: expected no driftedClaims for a claim freshly applied this same cycle, found=%v err=%v got=%+v", found, err, claims)
 	}
 }

--- a/internal/agent/reconcile_queue_test.go
+++ b/internal/agent/reconcile_queue_test.go
@@ -55,6 +55,7 @@ func blockingXFSRunner(unblock <-chan struct{}) *fakeRunner {
 // AddRateLimited retry path.
 func failNTimesXFSRunner(n int) *fakeRunner {
 	var calls atomic.Int32
+	state := &xfsQuotaState{}
 	return &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
 		switch name {
 		case "findmnt":
@@ -65,6 +66,16 @@ func failNTimesXFSRunner(n int) *fakeRunner {
 			}
 			if calls.Add(1) <= int32(n) {
 				return nil, fmt.Errorf("simulated transient xfs_quota failure")
+			}
+			// Past the injected-failure count: behave like a working
+			// xfs_quota, including answering the post-apply read-back
+			// verification's `report` query (#10) from the same state
+			// the retry's `limit -p` call just wrote -- see xfsHappyRunner's
+			// doc comment for why a bare fixed-string reply isn't enough.
+			if len(args) >= 3 && args[1] == "-c" {
+				if out, ok := state.handle(args[2]); ok {
+					return out, nil
+				}
 			}
 			return []byte("Project quota state: ON"), nil
 		default:

--- a/internal/apis/quota/v1alpha1/types.go
+++ b/internal/apis/quota/v1alpha1/types.go
@@ -120,6 +120,14 @@ const (
 
 	ReasonQuotaDriftDetected = "QuotaDriftDetected"
 	ReasonNoDrift            = "NoDrift"
+	// ReasonDriftCheckUnavailable pairs with Drifted=Unknown: the on-disk
+	// quota report itself couldn't be read this cycle (a transient
+	// xfs_quota/repquota/btrfs failure), so no won claim was actually
+	// checked -- distinct from ReasonNoDrift, which means claims were
+	// checked and matched. Reporting False/NoDrift here would be a false
+	// "healthy" signal during exactly the outage an operator most needs
+	// to know about.
+	ReasonDriftCheckUnavailable = "DriftCheckUnavailable"
 
 	ReasonExceedsLimitRangeMax = "ExceedsLimitRangeMax"
 	ReasonWithinLimitRange     = "WithinLimitRange"
@@ -339,6 +347,17 @@ type QuotaPolicyStatus struct {
 	// +kubebuilder:validation:MaxItems=20
 	// +optional
 	FailingClaims []FailingClaim `json:"failingClaims,omitempty"`
+
+	// driftedClaims is a bounded sample (capped at 20 entries) of won
+	// claims whose on-disk quota no longer matches this policy, checked
+	// independently of the enforcement attempt itself -- a claim only
+	// appears here when its most recent enforcement attempt reported no
+	// error (see FailingClaims for that case instead). Reuses the
+	// FailingClaim shape rather than a parallel type: same
+	// namespace/name/reason/message/lastTransitionTime fields apply.
+	// +kubebuilder:validation:MaxItems=20
+	// +optional
+	DriftedClaims []FailingClaim `json:"driftedClaims,omitempty"`
 
 	// matchedClaimSample is a bounded sample (capped at 20 entries) of
 	// MatchedClaim covering this policy's matched claims, used to audit

--- a/internal/apis/quota/v1alpha1/zz_generated.deepcopy.go
+++ b/internal/apis/quota/v1alpha1/zz_generated.deepcopy.go
@@ -191,6 +191,13 @@ func (in *QuotaPolicyStatus) DeepCopyInto(out *QuotaPolicyStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.DriftedClaims != nil {
+		in, out := &in.DriftedClaims, &out.DriftedClaims
+		*out = make([]FailingClaim, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.MatchedClaimSample != nil {
 		in, out := &in.MatchedClaimSample, &out.MatchedClaimSample
 		*out = make([]MatchedClaim, len(*in))

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -151,6 +151,50 @@ func TestLogProjectIDAllocationFailure(t *testing.T) {
 	}
 }
 
+func TestLogQuotaVerificationFailure(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "audit-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logPath := filepath.Join(tmpDir, "audit.log")
+	logger, err := NewLogger(Config{Enabled: true, FilePath: logPath, MaxFileSize: 10 * 1024 * 1024})
+	if err != nil {
+		t.Fatalf("Failed to create audit logger: %v", err)
+	}
+
+	logger.LogQuotaVerificationFailure("pv-drift", "/data/drift", "project_drift", 42, 1073741824, "xfs", errors.New("on-disk quota 999999488 does not match expected enforced value 1000000000"))
+	logger.Close()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("Failed to read audit log: %v", err)
+	}
+
+	var entry Entry
+	lines := splitLines(data)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", len(lines))
+	}
+	if err := json.Unmarshal(lines[0], &entry); err != nil {
+		t.Fatalf("failed to parse audit entry: %v", err)
+	}
+
+	if entry.Action != ActionVerifyFailed {
+		t.Errorf("Action = %q, want %q", entry.Action, ActionVerifyFailed)
+	}
+	if entry.Success {
+		t.Error("Success = true, want false for a verification failure")
+	}
+	if entry.Error == "" {
+		t.Error("Error should be populated")
+	}
+	if entry.PVName != "pv-drift" || entry.Path != "/data/drift" || entry.ProjectName != "project_drift" || entry.ProjectID != 42 || entry.NewQuota != 1073741824 || entry.FSType != "xfs" {
+		t.Errorf("unexpected entry fields: %+v", entry)
+	}
+}
+
 func TestAuditLoggerDisabled(t *testing.T) {
 	config := Config{
 		Enabled: false,

--- a/internal/audit/entry.go
+++ b/internal/audit/entry.go
@@ -27,6 +27,11 @@ const (
 	ActionDelete   Action = "DELETE"
 	ActionCleanup  Action = "CLEANUP"
 	ActionAllocate Action = "ALLOCATE"
+	// ActionVerifyFailed marks a distinct failure class from
+	// ActionCreate/ActionUpdate's own Success=false: the quota apply
+	// command itself exited 0, but reading the value back off the
+	// filesystem afterward didn't match what was requested (#10).
+	ActionVerifyFailed Action = "VERIFY_FAILED"
 )
 
 // Entry represents a single audit log entry

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -175,6 +175,29 @@ func (l *Logger) LogProjectIDAllocationFailure(pvName, namespace, pvcName, path,
 	}
 }
 
+// LogQuotaVerificationFailure logs a read-back verification failure: the
+// quota apply command itself succeeded, but the on-disk state afterward
+// didn't match quotaBytes (#10). Distinct from LogQuotaCreate/LogQuotaUpdate
+// with a non-nil err, which cover the apply command itself failing -- this
+// is "the tool reported success but lied." Only ever called with a non-nil
+// err; Success is always false.
+func (l *Logger) LogQuotaVerificationFailure(pvName, path, projectName string, projectID uint32, quotaBytes int64, fsType string, err error) {
+	entry := Entry{
+		Action:      ActionVerifyFailed,
+		PVName:      pvName,
+		Path:        path,
+		ProjectID:   projectID,
+		ProjectName: projectName,
+		NewQuota:    quotaBytes,
+		FSType:      fsType,
+		Success:     false,
+		Error:       err.Error(),
+	}
+	if err := l.Log(entry); err != nil {
+		slog.Warn("Failed to write audit log entry", "action", entry.Action, "error", err)
+	}
+}
+
 // LogQuotaUpdate logs quota update
 func (l *Logger) LogQuotaUpdate(pvName, path, projectName string, projectID uint32, oldQuota, newQuota int64, fsType string, err error) {
 	entry := Entry{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -36,6 +36,13 @@ import (
 type AgentInfo interface {
 	BasePath() string
 	AppliedQuotaCount() int
+	// ProjectsFile/ProjidFile return the agent's configured
+	// /etc/projects, /etc/projid paths, so the per-directory usage/quota
+	// metrics resolve project name/ID to path the same way ensureQuota's
+	// own read-back verification does, rather than assume the standard
+	// locations under a non-default --projects-file/--projid-file.
+	ProjectsFile() string
+	ProjidFile() string
 	// LivenessOK reports whether the agent process is alive and making
 	// progress. It must be independent of the Kubernetes API and the NFS
 	// mount so /health never restart-loops on a transient outage a restart
@@ -148,7 +155,7 @@ func (c *Collector) updateMetrics() {
 	fsType, _ := quota.DetectFSType(basePath)
 
 	// Get directory quotas
-	dirUsages, err := status.GetDirUsages(basePath, fsType)
+	dirUsages, err := status.GetDirUsages(basePath, fsType, c.agent.ProjectsFile(), c.agent.ProjidFile())
 	if err == nil && len(dirUsages) > 0 {
 		sb.WriteString("# HELP nfs_quota_used_bytes Used space by directory in bytes\n")
 		sb.WriteString("# TYPE nfs_quota_used_bytes gauge\n")

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -58,6 +58,13 @@ type AgentInfo interface {
 	// processed, how many ended in error, and total wall-clock time spent
 	// in ensureQuota across all of them, in seconds.
 	ReconcileStats() (total, errors int64, durationSeconds float64)
+	// VerificationFailures returns the cumulative count of quota applies
+	// whose post-apply read-back verification found the on-disk state
+	// didn't match what was requested, since process start (#10) -- a
+	// narrower breakdown of ReconcileStats' errors, distinguishing "the
+	// apply command itself failed" from "it exited 0 but the filesystem
+	// disagreed."
+	VerificationFailures() int64
 	// LastSuccessfulFullSync returns when the periodic full reconciliation
 	// last completed without error, or the zero Time if it never has.
 	LastSuccessfulFullSync() time.Time
@@ -223,6 +230,10 @@ func (c *Collector) updateMetrics() {
 	sb.WriteString("# HELP nfs_quota_agent_reconcile_duration_seconds_sum Cumulative wall-clock time spent in ensureQuota by reconcile-queue workers since process start\n")
 	sb.WriteString("# TYPE nfs_quota_agent_reconcile_duration_seconds_sum counter\n")
 	fmt.Fprintf(&sb, "nfs_quota_agent_reconcile_duration_seconds_sum %f\n\n", reconcileDurationSeconds)
+
+	sb.WriteString("# HELP nfs_quota_agent_verification_failures_total Total applies where the quota command succeeded but a read-back of the quota tool's own reported project limit found a mismatch, since process start. Confirms the tool's bookkeeping, not that the target directory's inode is actually bound to that project.\n")
+	sb.WriteString("# TYPE nfs_quota_agent_verification_failures_total counter\n")
+	fmt.Fprintf(&sb, "nfs_quota_agent_verification_failures_total %d\n\n", c.agent.VerificationFailures())
 
 	sb.WriteString("# HELP nfs_quota_agent_last_full_sync_timestamp_seconds Unix timestamp of the last successful periodic full reconciliation (syncAllQuotas); 0 if none has succeeded yet\n")
 	sb.WriteString("# TYPE nfs_quota_agent_last_full_sync_timestamp_seconds gauge\n")

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -41,6 +41,7 @@ type fakeAgent struct {
 	reconcileTotal         int64
 	reconcileErrors        int64
 	reconcileDurationSecs  float64
+	verificationFailures   int64
 	lastSuccessfulFullSync time.Time
 
 	// haActive is a *bool (not bool) so its zero value ("unset") can mean
@@ -73,6 +74,8 @@ func (f *fakeAgent) ReconcileQueueDepth() int { return f.queueDepth }
 func (f *fakeAgent) ReconcileStats() (total, errors int64, durationSeconds float64) {
 	return f.reconcileTotal, f.reconcileErrors, f.reconcileDurationSecs
 }
+
+func (f *fakeAgent) VerificationFailures() int64 { return f.verificationFailures }
 
 func (f *fakeAgent) LastSuccessfulFullSync() time.Time { return f.lastSuccessfulFullSync }
 
@@ -116,6 +119,7 @@ func TestHandleMetrics_Basic(t *testing.T) {
 		"nfs_quota_agent_reconcile_total",
 		"nfs_quota_agent_reconcile_errors_total",
 		"nfs_quota_agent_reconcile_duration_seconds_sum",
+		"nfs_quota_agent_verification_failures_total",
 		"nfs_quota_agent_last_full_sync_timestamp_seconds",
 		"nfs_quota_agent_ha_active 1", // fakeAgent's haActive is unset -> defaults to active, same as HA gating disabled
 	} {
@@ -149,6 +153,7 @@ func TestHandleMetrics_ReconcileQueueStats(t *testing.T) {
 		reconcileTotal:         42,
 		reconcileErrors:        3,
 		reconcileDurationSecs:  12.5,
+		verificationFailures:   2,
 		lastSuccessfulFullSync: lastSync,
 	}}
 
@@ -162,6 +167,7 @@ func TestHandleMetrics_ReconcileQueueStats(t *testing.T) {
 		"nfs_quota_agent_reconcile_total 42",
 		"nfs_quota_agent_reconcile_errors_total 3",
 		"nfs_quota_agent_reconcile_duration_seconds_sum 12.5",
+		"nfs_quota_agent_verification_failures_total 2",
 		fmt.Sprintf("nfs_quota_agent_last_full_sync_timestamp_seconds %d", lastSync.Unix()),
 	} {
 		if !strings.Contains(body, want) {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -54,6 +54,8 @@ type fakeAgent struct {
 
 func (f *fakeAgent) BasePath() string       { return f.basePath }
 func (f *fakeAgent) AppliedQuotaCount() int { return f.appliedCount }
+func (f *fakeAgent) ProjectsFile() string   { return "/etc/projects" }
+func (f *fakeAgent) ProjidFile() string     { return "/etc/projid" }
 
 func (f *fakeAgent) LivenessOK() (bool, string) {
 	if f.liveReason == "" && f.liveOK {

--- a/internal/quota/ext4.go
+++ b/internal/quota/ext4.go
@@ -61,7 +61,18 @@ func ApplyExt4Quota(quotaPath, path, projectName string, projectID uint32, sizeB
 	}
 
 	// 2. Set the project attribute on the directory using chattr
-	// This associates the directory with the project ID
+	// This associates the directory with the project ID. rootProjected
+	// tracks whether path itself (not just some subdirectory) actually
+	// got +P set -- previously this whole block swallowed every failure
+	// unconditionally and always fell through to setquota, so setquota
+	// could succeed (a real limit exists for projectID) while zero bytes
+	// under path were actually accounted to it: usage would never count
+	// against the limit at all. Since #10's read-back verification only
+	// confirms the limit setquota reports, not the directory's actual
+	// project binding, that combination has to be a hard error here --
+	// otherwise "apply" can report success on a quota that structurally
+	// can never be enforced.
+	rootProjected := false
 	if output, err := defaultRunner.Run("chattr", "-R", "+P", "-p", fmt.Sprintf("%d", projectID), path); err != nil {
 		// Try alternative: use tune2fs project id setting
 		slog.Debug("chattr failed, trying alternative method", "error", err, "output", string(output))
@@ -74,12 +85,20 @@ func ApplyExt4Quota(quotaPath, path, projectName string, projectID uint32, sizeB
 			if d.IsDir() {
 				if _, chErr := defaultRunner.Run("chattr", "+P", "-p", fmt.Sprintf("%d", projectID), p); chErr != nil {
 					slog.Debug("chattr failed for entry", "path", p, "error", chErr)
+				} else if p == path {
+					rootProjected = true
 				}
 			}
 			return nil
 		}); walkErr != nil {
 			slog.Warn("Failed to walk directory for chattr", "path", path, "error", walkErr)
 		}
+	} else {
+		rootProjected = true
+	}
+
+	if !rootProjected {
+		return fmt.Errorf("failed to associate project %d with directory %s via chattr (both the recursive attempt and the per-directory walk fallback failed on the target directory itself)", projectID, path)
 	}
 
 	// 3. Set the quota limit using setquota

--- a/internal/quota/ext4_test.go
+++ b/internal/quota/ext4_test.go
@@ -150,6 +150,47 @@ func TestApplyExt4Quota(t *testing.T) {
 		}
 	})
 
+	t.Run("both chattr -R and the per-directory walk fail on the target directory itself", func(t *testing.T) {
+		// #10: previously ApplyExt4Quota swallowed every chattr failure
+		// unconditionally and fell through to setquota regardless, so a
+		// setquota success could report "applied" while zero bytes under
+		// path were actually accounted to the project (the walk continues
+		// past a failed entry rather than aborting). Now the root
+		// directory itself must actually get +P set via one of the two
+		// attempts, or ApplyExt4Quota must fail rather than claim success
+		// on a quota that can never be enforced.
+		dir := t.TempDir()
+		projPath := filepath.Join(dir, "projdir")
+		if err := makeDirWithSubdir(projPath); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+
+		r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+			if name == "chattr" {
+				return []byte("chattr failed"), errors.New("boom")
+			}
+			return []byte("ok"), nil
+		}}
+		withFakeRunner(t, r)
+
+		err := ApplyExt4Quota("/data", projPath, "proj-fail", 2099, 1024,
+			filepath.Join(dir, "projects"), filepath.Join(dir, "projid"))
+		if err == nil {
+			t.Fatal("expected error when chattr never succeeds for the target directory")
+		}
+		if !strings.Contains(err.Error(), "chattr") {
+			t.Errorf("expected error to mention chattr, got: %v", err)
+		}
+
+		// setquota must never be reached: a quota limit that can never
+		// bind to any inode under path shouldn't be set at all.
+		for _, c := range r.calls {
+			if c.name == "setquota" {
+				t.Errorf("setquota should not have been called when the directory was never projected, got call: %+v", c)
+			}
+		}
+	})
+
 	t.Run("setquota failure propagates", func(t *testing.T) {
 		dir := t.TempDir()
 		r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {

--- a/internal/quota/report.go
+++ b/internal/quota/report.go
@@ -18,13 +18,45 @@ package quota
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/dasomel/nfs-quota-agent/internal/util"
 )
 
-// GetXFSQuotaReport parses xfs_quota report
-func GetXFSQuotaReport(basePath string) (map[string]uint64, map[string]uint64, error) {
+// ExpectedEnforcedBytes returns the on-disk hard limit ApplyXFSQuota/
+// ApplyExt4Quota/ApplyBtrfsQuota actually asks the kernel to enforce for
+// sizeBytes, given fsType -- not necessarily sizeBytes itself. XFS and
+// ext4 quota tooling both operate in whole KB (`bhard=%dk` / setquota's KB
+// hard limit column), flooring sizeBytes to the nearest KB below it and
+// enforcing a 1KB floor for any nonzero request smaller than that; btrfs
+// qgroup limits are set in raw bytes with no such rounding. A caller
+// verifying on-disk state after an apply (agent.go's verifyQuotaOnDisk,
+// #10) must compare against this, not the raw requested sizeBytes -- doing
+// otherwise makes every PV whose capacity isn't already a 1024-byte
+// multiple (e.g. any decimal-SI `storage: 1G` = 1000000000 bytes) look
+// like a permanent verification failure despite being applied correctly.
+func ExpectedEnforcedBytes(fsType string, sizeBytes int64) int64 {
+	switch fsType {
+	case FSTypeXFS, FSTypeExt4:
+		sizeKB := sizeBytes / 1024
+		if sizeKB == 0 {
+			sizeKB = 1
+		}
+		return sizeKB * 1024
+	default:
+		return sizeBytes
+	}
+}
+
+// GetXFSQuotaReport parses xfs_quota report. projectsFile and projidFile
+// are read directly (not through defaultRunner) to resolve project
+// name/ID to filesystem path -- callers must pass the same paths the
+// agent applies quotas against (a.projectsFile/a.projidFile), not assume
+// the standard /etc/projects and /etc/projid; a caller with no
+// configurable paths of its own (e.g. the status/UI reporting path) can
+// pass those two literals directly.
+func GetXFSQuotaReport(basePath, projectsFile, projidFile string) (map[string]uint64, map[string]uint64, error) {
 	if err := validateQuotaArg("basePath", basePath); err != nil {
 		return nil, nil, err
 	}
@@ -39,7 +71,6 @@ func GetXFSQuotaReport(basePath string) (map[string]uint64, map[string]uint64, e
 
 	// Parse projid file to get projectName -> projectID mapping
 	projidMap := make(map[string]string) // projectName -> projectID
-	projidFile := "/etc/projid"
 	if data, err := os.ReadFile(projidFile); err == nil {
 		for _, line := range strings.Split(string(data), "\n") {
 			line = strings.TrimSpace(line)
@@ -55,7 +86,6 @@ func GetXFSQuotaReport(basePath string) (map[string]uint64, map[string]uint64, e
 
 	// Parse projects file to get projectID -> path mapping
 	projectPaths := make(map[string]string) // projectID -> path
-	projectsFile := "/etc/projects"
 	if data, err := os.ReadFile(projectsFile); err == nil {
 		for _, line := range strings.Split(string(data), "\n") {
 			line = strings.TrimSpace(line)
@@ -116,8 +146,11 @@ func GetXFSQuotaReport(basePath string) (map[string]uint64, map[string]uint64, e
 	return quotaMap, usageMap, nil
 }
 
-// GetExt4QuotaReport parses repquota output
-func GetExt4QuotaReport(basePath string) (map[string]uint64, map[string]uint64, error) {
+// GetExt4QuotaReport parses repquota output. projectsFile is read
+// directly (not basePath) to resolve project ID to filesystem path -- see
+// GetXFSQuotaReport's doc comment for why callers must pass the agent's
+// configured path rather than assume /etc/projects.
+func GetExt4QuotaReport(basePath, projectsFile string) (map[string]uint64, map[string]uint64, error) {
 	if err := validateQuotaArg("basePath", basePath); err != nil {
 		return nil, nil, err
 	}
@@ -130,9 +163,8 @@ func GetExt4QuotaReport(basePath string) (map[string]uint64, map[string]uint64, 
 		return quotaMap, usageMap, err
 	}
 
-	// Parse projects file (use /etc/projects, not basePath)
+	// Parse projects file (use projectsFile, not basePath)
 	projectPaths := make(map[string]string)
-	projectsFile := "/etc/projects"
 	if data, err := os.ReadFile(projectsFile); err == nil {
 		for _, line := range strings.Split(string(data), "\n") {
 			line = strings.TrimSpace(line)
@@ -154,15 +186,32 @@ func GetExt4QuotaReport(basePath string) (map[string]uint64, map[string]uint64, 
 			continue
 		}
 
-		// Skip header
-		if fields[0] == "Project" || strings.HasPrefix(line, "-") || strings.HasPrefix(line, "#") {
+		// Skip header/separator lines. Real repquota -P project rows
+		// themselves start with "#<id>" (e.g. "#100      --     100 ..."),
+		// so a bare HasPrefix(line, "#") here would drop every real data
+		// row along with the header -- checked and fixed as part of #10:
+		// this function had never actually resolved a real repquota row
+		// to a path, since every row was silently skipped before
+		// projectID was even computed.
+		if fields[0] == "Project" || strings.HasPrefix(line, "-") {
 			continue
 		}
 
-		projectID := strings.TrimSuffix(fields[0], "--")
+		projectID := strings.TrimPrefix(fields[0], "#")
+		projectID = strings.TrimSuffix(projectID, "--")
 		projectID = strings.TrimSuffix(projectID, "+-")
 		projectID = strings.TrimSuffix(projectID, "-+")
 		projectID = strings.TrimSuffix(projectID, "++")
+
+		// The removed HasPrefix(line, "#") check above no longer filters
+		// banner/comment lines out before they reach here -- make the
+		// "this column must be a numeric project ID" assumption explicit
+		// instead of relying entirely on an accidental map-lookup miss to
+		// reject anything that isn't (unverified against every real
+		// repquota banner variant; this guard is the cheap insurance).
+		if _, err := strconv.ParseUint(projectID, 10, 32); err != nil {
+			continue
+		}
 
 		if path, ok := projectPaths[projectID]; ok {
 			// Used is in KB

--- a/internal/quota/report_test.go
+++ b/internal/quota/report_test.go
@@ -18,19 +18,16 @@ package quota
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
-
-// Note: GetXFSQuotaReport/GetExt4QuotaReport read the fixed system paths
-// /etc/projid and /etc/projects directly, so full path-mapping behavior is
-// not hermetically testable here. These tests cover command construction
-// and error propagation through the CommandRunner seam (best-effort).
 
 func TestGetXFSQuotaReport_InvalidArgument(t *testing.T) {
 	r := &fakeRunner{}
 	withFakeRunner(t, r)
 
-	_, _, err := GetXFSQuotaReport("/data/proj ect")
+	_, _, err := GetXFSQuotaReport("/data/proj ect", "/etc/projects", "/etc/projid")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -43,7 +40,7 @@ func TestGetExt4QuotaReport_InvalidArgument(t *testing.T) {
 	r := &fakeRunner{}
 	withFakeRunner(t, r)
 
-	_, _, err := GetExt4QuotaReport("/data/proj ect")
+	_, _, err := GetExt4QuotaReport("/data/proj ect", "/etc/projects")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -58,7 +55,7 @@ func TestGetXFSQuotaReport_CommandError(t *testing.T) {
 	}}
 	withFakeRunner(t, r)
 
-	_, _, err := GetXFSQuotaReport("/data")
+	_, _, err := GetXFSQuotaReport("/data", "/etc/projects", "/etc/projid")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -73,14 +70,66 @@ func TestGetXFSQuotaReport_NoMatchingProjects(t *testing.T) {
 	}}
 	withFakeRunner(t, r)
 
-	quotaMap, usageMap, err := GetXFSQuotaReport("/data")
+	// Nonexistent projectsFile/projidFile: os.ReadFile fails, both maps
+	// stay pre-populated-empty rather than panicking.
+	quotaMap, usageMap, err := GetXFSQuotaReport("/data", "/does/not/exist/projects", "/does/not/exist/projid")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Without /etc/projid or /etc/projects entries for "proj1", no path can
-	// be resolved, so both maps should stay empty rather than panicking.
 	if len(quotaMap) != 0 || len(usageMap) != 0 {
 		t.Errorf("expected empty maps when no project mapping found, got quota=%v usage=%v", quotaMap, usageMap)
+	}
+}
+
+func TestGetXFSQuotaReport_ResolvesPathFromConfiguredFiles(t *testing.T) {
+	dir := t.TempDir()
+	projectsFile := filepath.Join(dir, "projects")
+	projidFile := filepath.Join(dir, "projid")
+	if err := os.WriteFile(projectsFile, []byte("100:/data/pvc-1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile projects: %v", err)
+	}
+	if err := os.WriteFile(projidFile, []byte("pvc-1:100\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile projid: %v", err)
+	}
+
+	r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+		return []byte("Project ID   Used   Soft   Hard   Warn/Grace\n#pvc-1     100    0      2097152    00 [------]\n"), nil
+	}}
+	withFakeRunner(t, r)
+
+	quotaMap, usageMap, err := GetXFSQuotaReport("/data", projectsFile, projidFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usageMap["/data/pvc-1"] != 100*1024 {
+		t.Errorf("usageMap[/data/pvc-1] = %d, want %d", usageMap["/data/pvc-1"], 100*1024)
+	}
+	if quotaMap["/data/pvc-1"] != 2097152*1024 {
+		t.Errorf("quotaMap[/data/pvc-1] = %d, want %d", quotaMap["/data/pvc-1"], 2097152*1024)
+	}
+
+	// A second projectsFile/projidFile pair pointing at different content
+	// must resolve independently -- this is the behavior the previous
+	// hardcoded /etc/projects and /etc/projid could never demonstrate.
+	dir2 := t.TempDir()
+	projectsFile2 := filepath.Join(dir2, "projects")
+	projidFile2 := filepath.Join(dir2, "projid")
+	if err := os.WriteFile(projectsFile2, []byte("100:/other/pvc-1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile projects2: %v", err)
+	}
+	if err := os.WriteFile(projidFile2, []byte("pvc-1:100\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile projid2: %v", err)
+	}
+
+	quotaMap2, _, err := GetXFSQuotaReport("/data", projectsFile2, projidFile2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := quotaMap2["/data/pvc-1"]; ok {
+		t.Errorf("quotaMap2 resolved /data/pvc-1 using the first pair's file content — projectsFile/projidFile parameters are not actually isolating reads")
+	}
+	if quotaMap2["/other/pvc-1"] != 2097152*1024 {
+		t.Errorf("quotaMap2[/other/pvc-1] = %d, want %d", quotaMap2["/other/pvc-1"], 2097152*1024)
 	}
 }
 
@@ -90,7 +139,7 @@ func TestGetExt4QuotaReport_CommandError(t *testing.T) {
 	}}
 	withFakeRunner(t, r)
 
-	_, _, err := GetExt4QuotaReport("/data")
+	_, _, err := GetExt4QuotaReport("/data", "/etc/projects")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -105,11 +154,59 @@ func TestGetExt4QuotaReport_NoMatchingProjects(t *testing.T) {
 	}}
 	withFakeRunner(t, r)
 
-	quotaMap, usageMap, err := GetExt4QuotaReport("/data")
+	quotaMap, usageMap, err := GetExt4QuotaReport("/data", "/does/not/exist/projects")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(quotaMap) != 0 || len(usageMap) != 0 {
 		t.Errorf("expected empty maps when no project mapping found, got quota=%v usage=%v", quotaMap, usageMap)
+	}
+}
+
+func TestGetExt4QuotaReport_ResolvesPathFromConfiguredFile(t *testing.T) {
+	dir := t.TempDir()
+	projectsFile := filepath.Join(dir, "projects")
+	if err := os.WriteFile(projectsFile, []byte("100:/data/pvc-1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile projects: %v", err)
+	}
+
+	r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+		return []byte("Project        used    soft    hard  grace   used  soft  hard  grace\n#100      --   100      0    2097152                5     0     0\n"), nil
+	}}
+	withFakeRunner(t, r)
+
+	quotaMap, usageMap, err := GetExt4QuotaReport("/data", projectsFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usageMap["/data/pvc-1"] != 100*1024 {
+		t.Errorf("usageMap[/data/pvc-1] = %d, want %d", usageMap["/data/pvc-1"], 100*1024)
+	}
+	if quotaMap["/data/pvc-1"] != 2097152*1024 {
+		t.Errorf("quotaMap[/data/pvc-1] = %d, want %d", quotaMap["/data/pvc-1"], 2097152*1024)
+	}
+}
+
+func TestExpectedEnforcedBytes(t *testing.T) {
+	tests := []struct {
+		name      string
+		fsType    string
+		sizeBytes int64
+		want      int64
+	}{
+		{"xfs floors to whole KB", FSTypeXFS, 1000000000, 999999488}, // 1G decimal SI, not a 1024 multiple
+		{"xfs exact KB multiple unchanged", FSTypeXFS, 1073741824, 1073741824},
+		{"xfs sub-1KB request floors to 1KB minimum", FSTypeXFS, 500, 1024},
+		{"ext4 floors to whole KB", FSTypeExt4, 1000000000, 999999488},
+		{"ext4 sub-1KB request floors to 1KB minimum", FSTypeExt4, 1, 1024},
+		{"btrfs uses raw bytes, no rounding", FSTypeBtrfs, 1000000000, 1000000000},
+		{"unknown fsType uses raw bytes", "zfs", 1000000000, 1000000000},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ExpectedEnforcedBytes(tc.fsType, tc.sizeBytes); got != tc.want {
+				t.Errorf("ExpectedEnforcedBytes(%q, %d) = %d, want %d", tc.fsType, tc.sizeBytes, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/quotapolicy/status.go
+++ b/internal/quotapolicy/status.go
@@ -22,6 +22,7 @@ package quotapolicy
 // what actually persists the result.
 
 import (
+	"fmt"
 	"sort"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -55,6 +56,24 @@ type ClaimOutcome struct {
 	// (e.g. ReasonEnforcementFailed, ReasonFilesystemUnavailable,
 	// ReasonProjectIDExhausted). Ignored when EnforcementErr is nil.
 	EnforcementReason string
+
+	// DriftErr, when non-nil, means Won was true, the enforcement attempt
+	// itself reported no error, but an independent read-back check found
+	// the on-disk quota no longer matches what this policy currently
+	// specifies (#13's Drifted condition, #10's read-back mechanism). The
+	// caller only ever sets this when EnforcementErr is nil -- Degraded
+	// already covers the case where enforcement itself failed, and
+	// BuildStatus's setDrifted defensively ignores DriftErr on an outcome
+	// that also has EnforcementErr set, regardless. Mutually exclusive
+	// with DriftUnknown below (the caller sets at most one).
+	DriftErr error
+	// DriftUnknown is true when this claim's drift status genuinely
+	// couldn't be determined this cycle -- the on-disk quota report
+	// itself was unreadable (a transient xfs_quota/repquota/btrfs
+	// failure), not that it was read and found to match. setDrifted
+	// reports Drifted=Unknown rather than False when this fires, so a
+	// report outage doesn't masquerade as a confirmed "no drift" signal.
+	DriftUnknown bool
 }
 
 // LimitRangeInfo carries just what BuildStatus needs from
@@ -87,12 +106,14 @@ func BuildStatus(policy *v1alpha1.QuotaPolicy, outcomes []ClaimOutcome, lr Limit
 	setReady(&conditions, policy, now)
 	appliedCount, wonCount, failing := setAppliedAndDegraded(&conditions, policy, outcomes, now)
 	setLimitRangeConflict(&conditions, policy, lr, now)
+	drifted := setDrifted(&conditions, policy, outcomes, now)
 
 	status.Conditions = conditions
 	status.MatchedClaims = int32(len(outcomes))
 	status.AppliedClaims = int32(appliedCount)
 	status.ShadowedClaims = int32(len(outcomes) - wonCount)
 	status.FailingClaims = capFailingClaims(failing)
+	status.DriftedClaims = capDriftedClaims(drifted)
 	status.MatchedClaimSample = capMatchedClaims(outcomes)
 
 	return status
@@ -202,6 +223,65 @@ func failingReason(failing []ClaimOutcome) string {
 	return reason
 }
 
+// setDrifted evaluates the Drifted condition (#13): whether the on-disk
+// quota for any won claim no longer matches what this policy currently
+// specifies, independent of whether the enforcement attempt itself
+// reported an error. Applied/Degraded (setAppliedAndDegraded) already
+// cover "did the last enforcement attempt succeed"; Drifted covers "does
+// reality agree with that right now" -- these can and do diverge, since
+// ensureQuota's own cache short-circuit skips re-verifying an
+// already-cached value even if the filesystem state has since changed out
+// of band (see #10's verifyQuotaOnDisk and internal/agent's independent
+// per-cycle drift check that calls it here). Vacuously false when this
+// policy wins for no claims, same convention as Applied/Degraded. Returns
+// the drifted outcomes for the caller to build status.driftedClaims from.
+func setDrifted(conditions *[]metav1.Condition, policy *v1alpha1.QuotaPolicy, outcomes []ClaimOutcome, now metav1.Time) []ClaimOutcome {
+	var drifted []ClaimOutcome
+	var unknownCount int
+	for _, o := range outcomes {
+		if !o.Won || o.EnforcementErr != nil {
+			continue
+		}
+		// DriftErr checked first: the caller (recordEnforcement) only
+		// ever sets one of these, never both, but a confirmed mismatch
+		// must win over "unknown" if that invariant is ever violated --
+		// hiding a known drift behind Unknown would be strictly worse
+		// than the reverse.
+		switch {
+		case o.DriftErr != nil:
+			drifted = append(drifted, o)
+		case o.DriftUnknown:
+			unknownCount++
+		}
+	}
+
+	cond := metav1.Condition{
+		Type:               v1alpha1.ConditionDrifted,
+		ObservedGeneration: policy.Generation,
+		LastTransitionTime: now,
+	}
+	switch {
+	case len(drifted) > 0:
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = v1alpha1.ReasonQuotaDriftDetected
+		cond.Message = "one or more won claims' on-disk quota no longer matches this policy; see status.driftedClaims"
+	case unknownCount > 0:
+		// Not False/NoDrift: the report itself was unreadable for these
+		// claims, so nothing was actually checked -- reporting a healthy
+		// "no drift" during exactly the outage an operator most needs to
+		// know about would defeat the point of this condition.
+		cond.Status = metav1.ConditionUnknown
+		cond.Reason = v1alpha1.ReasonDriftCheckUnavailable
+		cond.Message = fmt.Sprintf("could not check %d won claim(s) for drift this cycle; the on-disk quota report was unavailable", unknownCount)
+	default:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = v1alpha1.ReasonNoDrift
+		cond.Message = "on-disk quota matches this policy for every won claim checked this cycle"
+	}
+	meta.SetStatusCondition(conditions, cond)
+	return drifted
+}
+
 // setLimitRangeConflict evaluates the LimitRangeConflict condition per
 // docs/quotapolicy-design.md §3: the policy still wins and is still
 // enforced even when it conflicts, so this only ever reports the
@@ -259,6 +339,37 @@ func capFailingClaims(failing []ClaimOutcome) []v1alpha1.FailingClaim {
 			Namespace:          o.Claim.Namespace,
 			Name:               o.Claim.Name,
 			Reason:             reason,
+			Message:            message,
+			LastTransitionTime: &now,
+		})
+	}
+	return out
+}
+
+// capDriftedClaims converts up to maxStatusSampleEntries drifted outcomes
+// into the bounded DriftedClaims sample. Mirrors capFailingClaims, reusing
+// the same v1alpha1.FailingClaim shape (see DriftedClaims' doc comment for
+// why) with DriftErr in place of EnforcementErr and a fixed Reason, since
+// every entry here is drift by construction.
+func capDriftedClaims(drifted []ClaimOutcome) []v1alpha1.FailingClaim {
+	if len(drifted) == 0 {
+		return nil
+	}
+	n := len(drifted)
+	if n > maxStatusSampleEntries {
+		n = maxStatusSampleEntries
+	}
+	now := metav1.Now()
+	out := make([]v1alpha1.FailingClaim, 0, n)
+	for _, o := range drifted[:n] {
+		message := ""
+		if o.DriftErr != nil {
+			message = o.DriftErr.Error()
+		}
+		out = append(out, v1alpha1.FailingClaim{
+			Namespace:          o.Claim.Namespace,
+			Name:               o.Claim.Name,
+			Reason:             v1alpha1.ReasonQuotaDriftDetected,
 			Message:            message,
 			LastTransitionTime: &now,
 		})

--- a/internal/quotapolicy/status_test.go
+++ b/internal/quotapolicy/status_test.go
@@ -120,6 +120,126 @@ func TestBuildStatus_FailingClaimsMarkDegraded(t *testing.T) {
 	}
 }
 
+func TestBuildStatus_DriftedClaimsMarkDrifted(t *testing.T) {
+	p := namedPolicy("ns", "p", 100, v1alpha1.QuotaPolicySelector{})
+	outcomes := []ClaimOutcome{
+		{Claim: Claim{Namespace: "ns", Name: "a"}, Won: true},
+		{Claim: Claim{Namespace: "ns", Name: "b"}, Won: true, DriftErr: errors.New("on-disk quota 500 does not match expected enforced value 1000")},
+	}
+
+	status := BuildStatus(&p, outcomes, LimitRangeInfo{}, nil, metav1.Now())
+
+	// Applied must stay True: enforcement itself reported no error for
+	// either claim -- Drifted is a separate axis, not a replacement for
+	// Applied (see ConditionDrifted's doc comment: "Applied=True and
+	// Drifted=True describes a policy that is enforced but has since
+	// drifted out of band").
+	applied := findCondition(status.Conditions, v1alpha1.ConditionApplied)
+	if applied == nil || applied.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Applied=True (enforcement itself succeeded for both claims), got %+v", applied)
+	}
+	degraded := findCondition(status.Conditions, v1alpha1.ConditionDegraded)
+	if degraded == nil || degraded.Status != metav1.ConditionFalse {
+		t.Fatalf("expected Degraded=False (no EnforcementErr on either claim), got %+v", degraded)
+	}
+
+	drifted := findCondition(status.Conditions, v1alpha1.ConditionDrifted)
+	if drifted == nil || drifted.Status != metav1.ConditionTrue || drifted.Reason != v1alpha1.ReasonQuotaDriftDetected {
+		t.Fatalf("expected Drifted=True/QuotaDriftDetected, got %+v", drifted)
+	}
+	if len(status.DriftedClaims) != 1 || status.DriftedClaims[0].Name != "b" {
+		t.Fatalf("expected exactly one drifted claim 'b', got %+v", status.DriftedClaims)
+	}
+	if status.DriftedClaims[0].Reason != v1alpha1.ReasonQuotaDriftDetected {
+		t.Fatalf("expected drifted claim reason QuotaDriftDetected, got %q", status.DriftedClaims[0].Reason)
+	}
+}
+
+func TestBuildStatus_DriftedFalseWhenNoDrift(t *testing.T) {
+	p := namedPolicy("ns", "p", 100, v1alpha1.QuotaPolicySelector{})
+	outcomes := []ClaimOutcome{
+		{Claim: Claim{Namespace: "ns", Name: "a"}, Won: true},
+	}
+
+	status := BuildStatus(&p, outcomes, LimitRangeInfo{}, nil, metav1.Now())
+
+	drifted := findCondition(status.Conditions, v1alpha1.ConditionDrifted)
+	if drifted == nil || drifted.Status != metav1.ConditionFalse || drifted.Reason != v1alpha1.ReasonNoDrift {
+		t.Fatalf("expected Drifted=False/NoDrift, got %+v", drifted)
+	}
+	if len(status.DriftedClaims) != 0 {
+		t.Fatalf("expected no drifted claims, got %+v", status.DriftedClaims)
+	}
+}
+
+// TestBuildStatus_EnforcementErrTakesPrecedenceOverDrift guards the
+// invariant recordEnforcement (internal/agent/policy.go) is supposed to
+// maintain -- DriftErr is only ever meaningful when EnforcementErr is nil
+// -- defensively at the BuildStatus layer too, so a caller bug that sets
+// both on the same outcome can't double-report the same underlying
+// failure as both Degraded and Drifted.
+func TestBuildStatus_EnforcementErrTakesPrecedenceOverDrift(t *testing.T) {
+	p := namedPolicy("ns", "p", 100, v1alpha1.QuotaPolicySelector{})
+	outcomes := []ClaimOutcome{
+		{
+			Claim:             Claim{Namespace: "ns", Name: "a"},
+			Won:               true,
+			EnforcementErr:    errors.New("disk full"),
+			EnforcementReason: v1alpha1.ReasonEnforcementFailed,
+			DriftErr:          errors.New("should be ignored"),
+		},
+	}
+
+	status := BuildStatus(&p, outcomes, LimitRangeInfo{}, nil, metav1.Now())
+
+	degraded := findCondition(status.Conditions, v1alpha1.ConditionDegraded)
+	if degraded == nil || degraded.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Degraded=True, got %+v", degraded)
+	}
+	drifted := findCondition(status.Conditions, v1alpha1.ConditionDrifted)
+	if drifted == nil || drifted.Status != metav1.ConditionFalse {
+		t.Fatalf("expected Drifted=False when the same outcome already has an EnforcementErr, got %+v", drifted)
+	}
+	if len(status.DriftedClaims) != 0 {
+		t.Fatalf("expected no drifted claims when EnforcementErr is set, got %+v", status.DriftedClaims)
+	}
+}
+
+// TestBuildStatus_DriftedClaimsSampleCappedAt20 mirrors
+// TestBuildStatus_FailingClaimsSampleCappedAt20's live-round-trip
+// verification (see that test's doc comment for why: a real Kubernetes API
+// server rejects the whole status write, not just the extra entry, if any
+// bounded sample exceeds 20) for the new DriftedClaims sample.
+func TestBuildStatus_DriftedClaimsSampleCappedAt20(t *testing.T) {
+	p := namedPolicy("ns-b", "p", 100, v1alpha1.QuotaPolicySelector{})
+	var outcomes []ClaimOutcome
+	for i := 0; i < 25; i++ {
+		outcomes = append(outcomes, ClaimOutcome{
+			Claim:    Claim{Namespace: "ns-b", Name: "pvc"},
+			Won:      true,
+			DriftErr: errors.New("drift"),
+		})
+	}
+
+	status := BuildStatus(&p, outcomes, LimitRangeInfo{}, nil, metav1.Now())
+	if len(status.DriftedClaims) != maxStatusSampleEntries {
+		t.Fatalf("DriftedClaims len = %d, want %d", len(status.DriftedClaims), maxStatusSampleEntries)
+	}
+
+	client := newFakeDynamicClient(t, &p)
+	if err := WriteStatus(context.Background(), client, &p, status); err != nil {
+		t.Fatalf("WriteStatus with a 20-entry-capped drifted sample must succeed, got: %v", err)
+	}
+	got, err := client.Resource(GroupVersionResource).Namespace("ns-b").Get(context.Background(), "p", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get after WriteStatus: %v", err)
+	}
+	drifted, found, _ := unstructured.NestedSlice(got.Object, "status", "driftedClaims")
+	if !found || len(drifted) != maxStatusSampleEntries {
+		t.Fatalf("driftedClaims after write: found=%v len=%d, want %d", found, len(drifted), maxStatusSampleEntries)
+	}
+}
+
 func TestBuildStatus_LimitRangeConflict(t *testing.T) {
 	p := namedPolicy("ns", "p", 100, v1alpha1.QuotaPolicySelector{})
 	p.Spec.MaxQuota = gi(20)

--- a/internal/status/dir.go
+++ b/internal/status/dir.go
@@ -24,8 +24,17 @@ import (
 	"github.com/dasomel/nfs-quota-agent/internal/quota"
 )
 
-// GetDirUsages returns usage information for all directories with quotas
-func GetDirUsages(basePath, fsType string) ([]DirUsage, error) {
+// GetDirUsages returns usage information for all directories with quotas.
+// projectsFile/projidFile must be the same paths the agent applying quotas
+// is actually configured with (a.ProjectsFile()/a.ProjidFile()) -- pass the
+// literal "/etc/projects"/"/etc/projid" only from a genuinely standalone
+// caller with no agent instance to read the real configured paths from
+// (the `nfs-quota-agent status` CLI path). Passing the standard-path
+// literals from a caller that does have an agent in scope silently shows
+// empty/wrong usage under a non-default --projects-file/--projid-file --
+// exactly the gap this parameterization exists to close; see the
+// CLAUDE.md gotcha on this.
+func GetDirUsages(basePath, fsType, projectsFile, projidFile string) ([]DirUsage, error) {
 	var usages []DirUsage
 
 	// Get quota report based on filesystem type
@@ -35,24 +44,9 @@ func GetDirUsages(basePath, fsType string) ([]DirUsage, error) {
 
 	switch fsType {
 	case "xfs":
-		// Literal /etc/projects, /etc/projid -- unchanged behavior from
-		// before GetXFSQuotaReport/GetExt4QuotaReport took these as
-		// explicit parameters (pre-existing, not introduced here): a
-		// deployment run with non-default --projects-file/--projid-file
-		// still sees this reporting path assume the standard locations,
-		// producing empty/wrong usage data. True for GetDirUsages' truly
-		// standalone callers (status/display.go, status/report.go, the
-		// `nfs-quota-agent status` CLI path, which have no agent instance
-		// to read configured paths from) -- but NOT for its other callers
-		// (internal/agent's recordHistory, internal/metrics, internal/ui),
-		// which do have a configured QuotaAgent in scope and inherit this
-		// same gap by calling through GetDirUsages rather than a path that
-		// threads the real paths in. See internal/agent's ensureQuota
-		// (verifyQuotaOnDisk) for the one caller in this codebase that
-		// does use the agent's configured files, for comparison.
-		quotaMap, usageMap, err = quota.GetXFSQuotaReport(basePath, "/etc/projects", "/etc/projid")
+		quotaMap, usageMap, err = quota.GetXFSQuotaReport(basePath, projectsFile, projidFile)
 	case "ext4":
-		quotaMap, usageMap, err = quota.GetExt4QuotaReport(basePath, "/etc/projects")
+		quotaMap, usageMap, err = quota.GetExt4QuotaReport(basePath, projectsFile)
 	case "btrfs":
 		quotaMap, usageMap, err = quota.GetBtrfsQuotaReport(basePath)
 	}

--- a/internal/status/dir.go
+++ b/internal/status/dir.go
@@ -35,9 +35,24 @@ func GetDirUsages(basePath, fsType string) ([]DirUsage, error) {
 
 	switch fsType {
 	case "xfs":
-		quotaMap, usageMap, err = quota.GetXFSQuotaReport(basePath)
+		// Literal /etc/projects, /etc/projid -- unchanged behavior from
+		// before GetXFSQuotaReport/GetExt4QuotaReport took these as
+		// explicit parameters (pre-existing, not introduced here): a
+		// deployment run with non-default --projects-file/--projid-file
+		// still sees this reporting path assume the standard locations,
+		// producing empty/wrong usage data. True for GetDirUsages' truly
+		// standalone callers (status/display.go, status/report.go, the
+		// `nfs-quota-agent status` CLI path, which have no agent instance
+		// to read configured paths from) -- but NOT for its other callers
+		// (internal/agent's recordHistory, internal/metrics, internal/ui),
+		// which do have a configured QuotaAgent in scope and inherit this
+		// same gap by calling through GetDirUsages rather than a path that
+		// threads the real paths in. See internal/agent's ensureQuota
+		// (verifyQuotaOnDisk) for the one caller in this codebase that
+		// does use the agent's configured files, for comparison.
+		quotaMap, usageMap, err = quota.GetXFSQuotaReport(basePath, "/etc/projects", "/etc/projid")
 	case "ext4":
-		quotaMap, usageMap, err = quota.GetExt4QuotaReport(basePath)
+		quotaMap, usageMap, err = quota.GetExt4QuotaReport(basePath, "/etc/projects")
 	case "btrfs":
 		quotaMap, usageMap, err = quota.GetBtrfsQuotaReport(basePath)
 	}

--- a/internal/status/dir_test.go
+++ b/internal/status/dir_test.go
@@ -59,7 +59,7 @@ func TestGetDirUsages_FlatDirectories(t *testing.T) {
 	writeSized(t, filepath.Join(base, "pvc-a", "f"), 100)
 	writeSized(t, filepath.Join(base, "pvc-b", "f"), 50)
 
-	usages, err := GetDirUsages(base, "")
+	usages, err := GetDirUsages(base, "", "/etc/projects", "/etc/projid")
 	if err != nil {
 		t.Fatalf("GetDirUsages: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestGetDirUsages_NestedNamespaceDirectories(t *testing.T) {
 	writeSized(t, filepath.Join(base, "team-a", "pvc-1", "f"), 200)
 	writeSized(t, filepath.Join(base, "team-a", "pvc-2", "f"), 300)
 
-	usages, err := GetDirUsages(base, "")
+	usages, err := GetDirUsages(base, "", "/etc/projects", "/etc/projid")
 	if err != nil {
 		t.Fatalf("GetDirUsages: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestGetDirUsages_SkipsHiddenAndProjectFiles(t *testing.T) {
 	}
 	writeSized(t, filepath.Join(base, "pvc-a", "f"), 5)
 
-	usages, err := GetDirUsages(base, "")
+	usages, err := GetDirUsages(base, "", "/etc/projects", "/etc/projid")
 	if err != nil {
 		t.Fatalf("GetDirUsages: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestGetDirUsages_SkipsHiddenAndProjectFiles(t *testing.T) {
 }
 
 func TestGetDirUsages_NonexistentBasePath(t *testing.T) {
-	_, err := GetDirUsages(filepath.Join(t.TempDir(), "missing"), "")
+	_, err := GetDirUsages(filepath.Join(t.TempDir(), "missing"), "", "/etc/projects", "/etc/projid")
 	if err == nil {
 		t.Fatal("expected error for nonexistent base path")
 	}

--- a/internal/status/display.go
+++ b/internal/status/display.go
@@ -52,8 +52,10 @@ func ShowStatus(basePath string, showAll bool) error {
 	fmt.Printf("Used:       %s (%.1f%%)\n", util.FormatBytes(int64(diskUsage.Used)), diskUsage.UsedPct)
 	fmt.Printf("Available:  %s\n\n", util.FormatBytes(int64(diskUsage.Available)))
 
-	// Get directory quotas
-	dirUsages, err := GetDirUsages(basePath, fsType)
+	// Get directory quotas. Literal /etc/projects, /etc/projid: this is the
+	// standalone `status` CLI path, with no agent instance to read a
+	// configured --projects-file/--projid-file from.
+	dirUsages, err := GetDirUsages(basePath, fsType, "/etc/projects", "/etc/projid")
 	if err != nil {
 		return fmt.Errorf("failed to get directory usages: %w", err)
 	}
@@ -152,7 +154,7 @@ func ShowTop(basePath string, count int, watch bool) error {
 			return err
 		}
 
-		dirUsages, err := GetDirUsages(basePath, fsType)
+		dirUsages, err := GetDirUsages(basePath, fsType, "/etc/projects", "/etc/projid")
 		if err != nil {
 			return err
 		}

--- a/internal/status/report.go
+++ b/internal/status/report.go
@@ -76,7 +76,7 @@ func GenerateReport(basePath, format, outputFile string) (err error) {
 		return err
 	}
 
-	dirUsages, err := GetDirUsages(basePath, fsType)
+	dirUsages, err := GetDirUsages(basePath, fsType, "/etc/projects", "/etc/projid")
 	if err != nil {
 		return err
 	}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -59,6 +59,10 @@ type AgentInterface interface {
 	GetOrphans(ctx context.Context) []OrphanInfo
 	RemoveOrphan(orphan OrphanInfo) error
 	AuditLogger() *audit.Logger
+	// ProjectsFile/ProjidFile return the agent's configured
+	// /etc/projects, /etc/projid paths -- see projectFiles below.
+	ProjectsFile() string
+	ProjidFile() string
 	// HAActive reports whether this instance currently owns quota
 	// enforcement (see agent.QuotaAgent.HAActive, #11). Always true when
 	// HA gating is disabled. Checked before a destructive orphan-delete
@@ -183,6 +187,18 @@ func (ui *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, dashboardHTML)
 }
 
+// projectFiles returns the projects/projid paths GetDirUsages should read
+// project name/ID -> path mappings from. Prefers the agent's configured
+// paths (present whenever the UI is embedded in the main daemon); falls
+// back to the standard locations for the standalone `nfs-quota-agent ui`
+// subcommand, which has no agent (and no Kubernetes client of any kind).
+func (ui *Server) projectFiles() (projectsFile, projidFile string) {
+	if ui.agent != nil {
+		return ui.agent.ProjectsFile(), ui.agent.ProjidFile()
+	}
+	return "/etc/projects", "/etc/projid"
+}
+
 func (ui *Server) handleAPIStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -194,7 +210,8 @@ func (ui *Server) handleAPIStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dirUsages, _ := status.GetDirUsages(ui.basePath, fsType)
+	projectsFile, projidFile := ui.projectFiles()
+	dirUsages, _ := status.GetDirUsages(ui.basePath, fsType, projectsFile, projidFile)
 
 	var totalUsed, totalQuota uint64
 	var warningCount, exceededCount, okCount int
@@ -300,7 +317,8 @@ func (ui *Server) handleAPIQuotas(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	fsType, _ := quota.DetectFSType(ui.basePath)
-	dirUsages, err := status.GetDirUsages(ui.basePath, fsType)
+	projectsFile, projidFile := ui.projectFiles()
+	dirUsages, err := status.GetDirUsages(ui.basePath, fsType, projectsFile, projidFile)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -86,6 +86,8 @@ func (f *fakeAgent) RemoveOrphan(o OrphanInfo) error {
 	return nil
 }
 func (f *fakeAgent) AuditLogger() *audit.Logger { return f.logger }
+func (f *fakeAgent) ProjectsFile() string       { return "/etc/projects" }
+func (f *fakeAgent) ProjidFile() string         { return "/etc/projid" }
 func (f *fakeAgent) HAActive() bool {
 	if f.haActive == nil {
 		return true


### PR DESCRIPTION
## Summary

Implements #13's `Drifted` condition: independent on-disk read-back drift detection for `QuotaPolicy`-managed claims, piggybacking on the existing `syncAllQuotas` periodic cycle (no new watch loop).

- Three-state `Drifted` condition (`True`/`False`/`Unknown`) plus a new bounded `status.driftedClaims` sample (capped at 20, mirrors `failingClaims`).
- Fetch-once-per-cycle filesystem-wide quota report, compared per won claim against `ExpectedEnforcedBytes` (from #10).
- Freshly-mutated claims excluded via a new `ensureQuotaMutated` (thin `(bool, error)` wrapper) that returns the real mutation signal directly, instead of inferring it from a before/after cache read — the inferred version is ABA-vulnerable against the watch path's reconcile queue running in a separate goroutine.

## Review history

Iterated through 6 Codex review passes (2 sequential + 3 parallel focused + 1 that hit Codex's usage limit before it could run). Fixed every substantive finding:

- **P1** — report-fetch failures fell through to a falsely-healthy `Drifted=False`; fixed with the `Unknown`/`DriftCheckUnavailable` state.
- **P2** — each claim's drift check independently re-scanned the whole filesystem; fixed with the lazy fetch-once-per-cycle cache.
- **Medium** — same-call mutation detection had an ABA race against the concurrent watch path; fixed via `ensureQuotaMutated`'s direct return value.
- **Low** — `DriftErr`/`DriftUnknown` precedence in `setDrifted` was checked in the wrong order; reordered defensively.
- 6 test-quality gaps (unsynchronized shared test state, vacuous assertions, discarded `NestedSlice`/`NestedInt64` errors, etc.) — all patched.

**Known, accepted gap** (documented in `agent.go` and `docs/quotapolicy-design.md`, not fixed): a watch-path reconcile worker can still mutate a claim in a different goroutine between the shared report snapshot being fetched and that claim's comparison, producing a stale, self-correcting false positive next cycle — not a missed real problem or silently wrong enforcement. Closing it fully would mean either defeating the fetch-once optimization or adding cross-goroutine locking the reconcile queue doesn't expose a hook for.

**Depends on #10 / PR #68** (`feat/quota-readback-verification`, unmerged) for `verifyQuotaOnDisk`/`ExpectedEnforcedBytes` — sequence this PR after that one merges.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` all green, including new `policy_test.go`/`status_test.go` cases
- [x] `helm lint ./charts/nfs-quota-agent` clean
- [x] Every fix mutation-verified individually (bug reintroduced → test fails for the right reason → restored → clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT