### PR TITLE
feat(release): offline-verify a downloaded release bundle against release-manifest.json

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -188,6 +188,18 @@ jobs:
           format: spdx-json
           output-file: dist/sbom.spdx.json
 
+      - name: Checksum SBOM
+        run: |
+          cd dist
+          sha256=$(sha256sum sbom.spdx.json | cut -d' ' -f1)
+          jq -n --arg file "sbom.spdx.json" --arg sha256 "$sha256" '{file: $file, sha256: $sha256}' > sbom-meta.json
+
+      - name: Upload SBOM metadata for manifest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binary-sbom-meta
+          path: dist/sbom-meta.json
+
       - name: Download changelog
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -281,14 +293,23 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Download binary checksums
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binary-checksums
 
+      - name: Download binary SBOM metadata
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: binary-sbom-meta
+
       - name: Generate release manifest
         id: manifest
         run: |
+          compat_sha256=$(sha256sum hack/compatibility-matrix.json | cut -d' ' -f1)
           jq -n \
             --arg tag "${{ github.ref_name }}" \
             --arg commit "${{ github.sha }}" \
@@ -298,22 +319,29 @@ jobs:
             --arg chart_file "${{ needs.helm-release.outputs.chart_file }}" \
             --arg chart_version "${{ needs.helm-release.outputs.chart_version }}" \
             --arg chart_sha256 "${{ needs.helm-release.outputs.chart_sha256 }}" \
+            --arg compat_file "compatibility-matrix.json" \
+            --arg compat_sha256 "$compat_sha256" \
             --slurpfile binaries <(awk '{print "{\"file\":\""$2"\",\"sha256\":\""$1"\"}"}' checksums.txt | jq -s .) \
+            --slurpfile sbom sbom-meta.json \
             '{
-              schemaVersion: 1,
+              schemaVersion: 2,
               tag: $tag,
               sourceCommit: $commit,
               workflowRun: $workflow_run,
               image: { repository: $image, digest: $image_digest },
               chart: { file: $chart_file, version: $chart_version, sha256: $chart_sha256 },
-              binaries: $binaries[0]
+              binaries: $binaries[0],
+              sbom: $sbom[0],
+              compatibilityMatrix: { file: $compat_file, sha256: $compat_sha256 }
             }' > release-manifest.json
           cat release-manifest.json
 
       - name: Publish release manifest
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          files: release-manifest.json
+          files: |
+            release-manifest.json
+            hack/compatibility-matrix.json
           generate_release_notes: false
 
   update-changelog:

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ sbom/
 # Debug files
 __debug_bin*
 
+# Python bytecode cache (hack/verify-release.py and friends)
+__pycache__/
+*.pyc
+
 # Vendor (if not vendoring)
 # vendor/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ We use a `Makefile` to automate common development workflows. The primary make t
 - `make sbom`          - Generates an SBOM (SPDX + CycloneDX) for the Go dependency tree via `trivy` (if installed).
 - `make generate`      - Regenerates deepcopy code and the CRD manifest for `internal/apis/quota/v1alpha1` via `controller-gen`.
 - `make compat-matrix`  - Validates `hack/compatibility-matrix.json` (the machine-readable filesystem/architecture/Kubernetes-version support matrix, #5) has the required shape.
+- `make verify-release RELEASE_DIR=<dir>` - Offline-verifies a downloaded release bundle's binaries/chart/SBOM/compatibility matrix against `release-manifest.json`'s recorded sha256 digests (#16, #26). Defaults `RELEASE_DIR` to the current directory.
 
 If a PR changes `go.mod` or `go.sum`, run `make license` and commit the regenerated `THIRD_PARTY_LICENSES.md` — CI fails the `License Check` job if it goes stale.
 
@@ -73,3 +74,11 @@ Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build
 ## Release Process
 
 We automate our releases through GitHub Actions. Pushing a SemVer-compliant Git tag (e.g., `v1.2.3`) to the repository triggers the release workflow, which compiles release binaries, packages Helm charts, builds multi-arch container images, and generates a changelog entry using `git-cliff`.
+
+Every release publishes a `release-manifest.json` GitHub Release asset recording the source commit, workflow run, container image digest, and sha256 digests of the chart, binaries, SBOM, and `compatibility-matrix.json`. After downloading a release's assets into one directory, verify them offline against that manifest with:
+
+```bash
+make verify-release RELEASE_DIR=<download-dir>
+```
+
+This checks every file's digest against what the release pipeline actually produced; it does not verify the container image itself (that needs registry access — the command to run is printed if the manifest names an image digest). See `hack/verify-release.py` for the full logic.

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,10 @@ REGISTRY?=ghcr.io/dasomel
 IMAGE_NAME=$(REGISTRY)/$(BINARY_NAME)
 VERSION?=latest
 PLATFORMS?=linux/amd64,linux/arm64,linux/arm/v7
+RELEASE_DIR?=.
 
 .PHONY: all build build-linux clean test test-coverage fmt vet tidy lint \
-	license sbom generate compat-matrix \
+	license sbom generate compat-matrix verify-release \
 	docker-build docker-push docker-buildx \
 	helm-lint helm-package helm-install helm-uninstall
 
@@ -107,6 +108,15 @@ data = json.load(open('hack/compatibility-matrix.json')); \
 sections = ['filesystemBackends', 'architectures', 'kubernetesVersions']; \
 missing = [(s, e) for s in sections for e in data.get(s, []) if 'status' not in e or 'evidence' not in e]; \
 sys.exit('missing status/evidence in: ' + repr(missing)) if missing else print('compatibility-matrix.json OK (' + str(sum(len(data.get(s, [])) for s in sections)) + ' entries)')"
+
+# Offline-verify a downloaded release bundle (binaries/chart/sbom/
+# compatibility-matrix) against release-manifest.json's recorded digests.
+# RELEASE_DIR defaults to the current directory -- point it at wherever
+# you downloaded a release's assets. See hack/verify-release.py for what
+# it does and does not check (it cannot verify the container image
+# without registry access).
+verify-release:
+	@python3 hack/verify-release.py $(RELEASE_DIR)
 
 # Build Docker image
 docker-build:

--- a/hack/verify-release.py
+++ b/hack/verify-release.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Offline verification for a downloaded nfs-quota-agent release bundle.
+
+Cross-checks every artifact in a release directory (binaries, the Helm
+chart, sbom.spdx.json, compatibility-matrix.json) against the sha256
+digests recorded in release-manifest.json -- so a downloaded release can
+be trusted without re-running the release pipeline (#16, #26).
+
+Does not touch the network. Verifying the container image itself needs a
+registry (`docker buildx imagetools inspect <repository>@<digest>`); this
+script only prints that instruction rather than attempting it, since
+pulling from a registry is a separate concern from verifying the local
+artifact bundle.
+
+release-manifest.json's ``sbom`` and ``compatibilityMatrix`` fields were
+added in schemaVersion 2; a schemaVersion 1 manifest from an older release
+is verified with those two checks skipped rather than failed.
+
+Usage: hack/verify-release.py [release-dir]
+"""
+import hashlib
+import json
+import os
+import sys
+
+
+def sha256_of(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def check(label, path, want, errors):
+    if not os.path.isfile(path):
+        print(f"MISSING: {label} ({path} not present)")
+        errors.append(label)
+        return
+    got = sha256_of(path)
+    if got != want:
+        print(f"MISMATCH: {label}\n  file:     {path}\n  expected: {want}\n  actual:   {got}")
+        errors.append(label)
+    else:
+        print(f"OK: {label}")
+
+
+def main():
+    release_dir = sys.argv[1] if len(sys.argv) > 1 else "."
+    manifest_path = os.path.join(release_dir, "release-manifest.json")
+    if not os.path.isfile(manifest_path):
+        print(f"FAIL: release-manifest.json not found in {release_dir}", file=sys.stderr)
+        return 1
+
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+
+    errors = []
+    schema_version = manifest.get("schemaVersion", 0)
+
+    for binary in manifest.get("binaries", []):
+        check(f"binary {binary['file']}", os.path.join(release_dir, binary["file"]), binary["sha256"], errors)
+
+    chart = manifest.get("chart")
+    if chart:
+        check(f"chart {chart['file']}", os.path.join(release_dir, chart["file"]), chart["sha256"], errors)
+
+    sbom = manifest.get("sbom")
+    if sbom:
+        check(f"sbom {sbom['file']}", os.path.join(release_dir, sbom["file"]), sbom["sha256"], errors)
+    elif schema_version < 2:
+        print("SKIP: sbom (release-manifest schemaVersion < 2, no sbom digest recorded)")
+
+    compat = manifest.get("compatibilityMatrix")
+    if compat:
+        check(
+            f"compatibilityMatrix {compat['file']}",
+            os.path.join(release_dir, compat["file"]),
+            compat["sha256"],
+            errors,
+        )
+    elif schema_version < 2:
+        print("SKIP: compatibilityMatrix (release-manifest schemaVersion < 2, not recorded)")
+
+    image = manifest.get("image", {})
+    if image.get("repository") and image.get("digest"):
+        print(
+            f"NOT VERIFIED (needs registry access): image {image['repository']}@{image['digest']}\n"
+            f"  Run: docker buildx imagetools inspect {image['repository']}@{image['digest']}"
+        )
+
+    print()
+    if errors:
+        sys.stdout.flush()
+        print(f"FAIL: {len(errors)} artifact(s) failed verification: {', '.join(errors)}", file=sys.stderr)
+        return 1
+
+    print(
+        f"OK: release {manifest.get('tag', '?')} "
+        f"(source commit {manifest.get('sourceCommit', '?')}) verified against {manifest_path}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes the "offline verification" acceptance criterion shared by #16 and #26 — until now `release-manifest.json` was published but nothing consumed it. Also closes #16's "Kubernetes version/backend compatibility matrix가 release evidence에 포함된다" — `hack/compatibility-matrix.json` was never attached to a release.

- `release.yaml`: `release-manifest.json` bumps `schemaVersion` 1→2, adding `sbom` (file+sha256) and `compatibilityMatrix` (file+sha256) fields. `hack/compatibility-matrix.json` is now published as a release asset.
- `hack/verify-release.py` (new, stdlib-only): given a downloaded release directory, cross-checks every binary/chart/sbom/compatibility-matrix sha256 against the manifest. Old schemaVersion-1 manifests degrade to SKIP (not fail) for the two new fields.
- `make verify-release RELEASE_DIR=<dir>` wired up, documented in `CONTRIBUTING.md`'s Release Process section.

## Verification

Synthetic release bundle + hand-built manifest, mutation-tested directly:
- clean bundle → all OK, exit 0
- tampered binary → MISMATCH for that file only, exit 1 → restored → clean
- missing artifact → MISSING for that file only, exit 1 → restored → clean
- schemaVersion-1-shaped manifest → SKIP for the two new fields with an explicit reason, everything else still verified, exit 0 (proves old real releases aren't reported as broken)

`gofmt -l .` / `go build ./...` / `go vet ./...` clean (regression check, untouched by this diff). `actionlint`'s only finding on `release.yaml` is a pre-existing shellcheck note on a line this diff doesn't touch. `python3 -m py_compile` confirms the script loads clean.

## Remaining (not this PR)

- Container image itself still isn't offline-verifiable (needs registry access — the verifier prints the `docker buildx imagetools inspect` command instead of running it).
- `egress-policy` stays `audit`, not `block` (#26) — no access to the StepSecurity dashboard that would supply a real observed-endpoint allowlist.
- Dependency diff review/cooling policy and E2E-evidence-linked-to-release-identity remain unaddressed (#16, #26).

## Test plan

- [x] Synthetic bundle mutation-tests (see Verification above)
- [x] `gofmt -l .`, `go build ./...`, `go vet ./...` clean
- [x] `actionlint .github/workflows/release.yaml` — no new findings
- [x] `python3 -m py_compile hack/verify-release.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT