### PR TITLE
fix(quotapolicy): refuse a QuotaPolicy quota decrease below current usage

### DIFF
--- a/docs/quotapolicy-design.md
+++ b/docs/quotapolicy-design.md
@@ -208,13 +208,16 @@ but something changed it since).
 Reasons are a fixed vocabulary (`Reason*` constants in the types file:
 `SelectorValid`, `SelectorInvalid`, `NoMatchingClaims`, `AllClaimsApplied`,
 `PartiallyApplied`, `NotYetReconciled`, `EnforcementFailed`,
-`FilesystemUnavailable`, `ProjectIDExhausted`, `QuotaDriftDetected`,
-`NoDrift`, `ExceedsLimitRangeMax`, `WithinLimitRange`, `NoLimitRange`) so
-that dashboards and scripts built against them don't rot as the controller
-grows more call sites. `ProjectIDExhausted` anticipates the collision
-fallback in `hashProjectName` running out of room, though the controller PR
-may find it never needs to report that reason in practice — it's included
-now so the vocabulary doesn't need a breaking addition for it later.
+`FilesystemUnavailable`, `ProjectIDExhausted`, `UnsafeShrinkRejected`,
+`QuotaDriftDetected`, `NoDrift`, `ExceedsLimitRangeMax`, `WithinLimitRange`,
+`NoLimitRange`) so that dashboards and scripts built against them don't rot
+as the controller grows more call sites. `ProjectIDExhausted` anticipates
+the collision fallback in `hashProjectName` running out of room, though the
+controller PR may find it never needs to report that reason in practice —
+it's included now so the vocabulary doesn't need a breaking addition for it
+later. `UnsafeShrinkRejected` surfaces through `Degraded`/`FailingClaims`
+like any other enforcement failure — see §11's "Shrink guard" for the
+`ensureQuota`-level check that produces it.
 
 ## 6. Status: no usage, no history, bounded samples only
 
@@ -388,6 +391,59 @@ already reject `minQuota > maxQuota`, `defaultQuota < minQuota`, and
 itself push a value from a real, admitted `QuotaPolicy` back above
 `maxQuota` — the two outcomes are mutually exclusive in practice for a valid
 object.
+
+### Shrink guard: refusing a decrease below current usage
+
+#3/#14 both ask that a `QuotaPolicy` change reducing `maxQuota` below a
+claim's *current* usage not be applied silently. Project quota is
+inherently non-destructive here — none of the xfs/ext4/btrfs backends ever
+delete or truncate existing files when a hard limit drops, they only
+reject future writes once usage already exceeds the new limit (`EDQUOT`) —
+so the risk isn't data loss, it's an operator changing a policy and
+unknowingly cutting off a tenant's writes with no warning.
+
+`ensureQuota` checks this immediately before calling into the filesystem
+backend, whenever the new size is both a genuine decrease
+(`sizeBytes < oldQuota`, not the initial apply) and would actually be
+unsafe: `currentUsageBytes` reads the same `status.GetDirUsages` report the
+web UI and `/metrics` already use, and the decrease is refused only when
+current usage exceeds the *enforced* new limit — not the raw requested
+value, and not some percentage margin below the old one.
+`expectedEnforcedBytes` floors to the same KB boundary
+`ApplyXFSQuota`/`ApplyExt4Quota` do before ever calling `xfs_quota`/
+`setquota` (btrfs applies the exact byte value), so a request within one KB
+of the boundary can't look safe against the raw value while the limit that
+actually reaches the filesystem is already below current usage — the same
+class of mismatch the #10 CRITICAL rounding bug was. Beyond that flooring,
+this bound needs no policy judgment call: usage already above the enforced
+new limit means the change would immediately start rejecting writes, true
+regardless of how conservative or aggressive an operator wants shrinks to
+be in general.
+
+A refusal doesn't touch `appliedQuotas` or the filesystem at all — the
+previous quota stays in force exactly as before — and surfaces through the
+same `EnforcementErr`/`FailingClaims` machinery every other enforcement
+failure uses, with `Reason: UnsafeShrinkRejected`, rather than a new status
+field. When the usage report itself can't be read, the shrink proceeds:
+`currentUsageBytes` returns `ok=false`, which this check treats as "no
+evidence this is unsafe," not "assume the worst" — the alternative (block
+every shrink whenever the report has a hiccup) would make legitimate
+policy decreases permanently stuck behind an unrelated report failure.
+
+**Known, accepted gaps** (an independent review pass raised both; neither
+is fixed here): usage is sampled once, synchronously, inside the same
+`a.mu`-held critical section that then calls `applyQuota` — an NFS client
+can still write between the sample and the apply, so this narrows the
+unsafe-shrink window without closing it completely (closing it fully would
+need transactional filesystem semantics this agent doesn't have). And when
+the quota report has no entry for a path, `GetDirUsages` falls back to
+summing apparent file sizes (`filepath.Walk`), which can undercount true
+usage for sparse or preallocated files — a shrink this guard treats as
+safe could still turn out unsafe in that specific case. Both are pre-existing
+properties of `GetDirUsages`/`GetDirSize` (already relied on by `/metrics`
+and the web UI), not something this guard introduces; fixing either is a
+reasonable follow-up, not a blocker for this guard being a net improvement
+over not checking at all.
 
 ### Reconcile cadence, and why the watch path resolves against a cache
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -933,6 +933,23 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, e
 	oldQuota := a.appliedQuotas[localPath]
 	isUpdate := oldQuota > 0 && oldQuota != sizeBytes
 
+	if isUpdate && sizeBytes < oldQuota {
+		enforcedBytes := expectedEnforcedBytes(a.fsType, sizeBytes)
+		if used, ok := a.currentUsageBytes(localPath); ok && used > uint64(enforcedBytes) {
+			shrinkErr := fmt.Errorf("%w: new quota %s (enforced as %s) is below current usage %s for PV %s",
+				errUnsafeShrink, util.FormatBytes(sizeBytes), util.FormatBytes(enforcedBytes), util.FormatBytes(int64(used)), pv.Name)
+			if a.auditLogger != nil {
+				a.auditLogger.LogQuotaUpdate(pv.Name, localPath, projectName, projectID, oldQuota, sizeBytes, a.fsType, shrinkErr)
+			}
+			a.updateQuotaStatus(ctx, pv, QuotaStatusFailed, 0)
+			slog.Warn("Refusing quota decrease below current usage",
+				"pv", pv.Name, "path", localPath,
+				"currentQuota", util.FormatBytes(oldQuota), "requestedQuota", util.FormatBytes(sizeBytes),
+				"currentUsage", util.FormatBytes(int64(used)))
+			return shrinkErr
+		}
+	}
+
 	err = a.applyQuota(localPath, projectName, projectID, sizeBytes)
 
 	if a.auditLogger != nil {
@@ -958,6 +975,70 @@ func (a *QuotaAgent) ensureQuota(ctx context.Context, pv *v1.PersistentVolume, e
 	)
 
 	return nil
+}
+
+// expectedEnforcedBytes mirrors the KB-flooring internal/quota's
+// ApplyXFSQuota/ApplyExt4Quota apply before ever reaching the filesystem
+// (sizeBytes/1024, minimum 1KB; btrfs applies the exact byte value via
+// qgroup limit, no flooring) so the shrink guard below compares against
+// what will actually be enforced, not the raw requested value. Comparing
+// against the raw value would let a shrink request within one KB of the
+// boundary look safe when the floored limit actually applied is already
+// below current usage -- the same class of mismatch the #10 CRITICAL
+// rounding bug was (see CLAUDE.md). This duplicates the floor arithmetic
+// already inline in xfs.go/ext4.go rather than exporting a shared helper,
+// to keep this change scoped to the shrink guard; if a shared
+// ExpectedEnforcedBytes-style helper is added later, this should call that
+// instead of maintaining its own copy.
+func expectedEnforcedBytes(fsType string, sizeBytes int64) int64 {
+	switch fsType {
+	case quota.FSTypeXFS, quota.FSTypeExt4:
+		sizeKB := sizeBytes / 1024
+		if sizeKB == 0 {
+			sizeKB = 1
+		}
+		return sizeKB * 1024
+	default:
+		return sizeBytes
+	}
+}
+
+// currentUsageBytes returns the on-disk usage GetDirUsages currently
+// reports for localPath, so ensureQuota can refuse a quota decrease that
+// would immediately put the volume over its new limit. ok is false when
+// the filesystem-wide usage report couldn't be read at all, or didn't
+// contain an entry for this path -- both are treated as "unknown," not
+// "zero," so a report hiccup can never falsely justify (or falsely block)
+// a shrink.
+//
+// Two accepted, undocumented-elsewhere limitations inherited from
+// GetDirUsages/GetDirSize, not introduced by this check: (1) when the
+// quota report has no usage entry for localPath, GetDirSize falls back to
+// summing apparent file sizes via filepath.Walk, which can undercount the
+// true quota-accounted usage for sparse or preallocated files -- a shrink
+// this guard treats as safe could still be unsafe in that case; (2) called
+// from ensureQuota, this runs while a.mu is held and, for the report path,
+// invokes a real quota-report subprocess or a full recursive directory
+// walk -- both read-only, but unbounded and without a timeout, so a slow
+// report or a very large export blocks every other serialized reconcile
+// for as long as it takes. Both are accepted here rather than fixed:
+// closing (1) requires GetDirUsages itself to read real block counts
+// (st.Blocks*512) instead of apparent size, a change to a helper several
+// other callers (metrics, web UI) already depend on; closing (2) would
+// need a context-aware, cancellable usage read that GetDirUsages doesn't
+// support today. Either is a reasonable follow-up, not required for this
+// guard to be a net safety improvement over not checking at all.
+func (a *QuotaAgent) currentUsageBytes(localPath string) (used uint64, ok bool) {
+	usages, err := status.GetDirUsages(a.nfsBasePath, a.fsType)
+	if err != nil {
+		return 0, false
+	}
+	for _, u := range usages {
+		if u.Path == localPath {
+			return u.Used, true
+		}
+	}
+	return 0, false
 }
 
 // nfsPathToLocal converts NFS server path to local mount path. Delegates to
@@ -1003,6 +1084,12 @@ const maxProjectIDProbe = 4096
 // errProjectIDExhausted is returned by generateProjectID when no free ID
 // was found within maxProjectIDProbe attempts.
 var errProjectIDExhausted = fmt.Errorf("no available project ID found within %d attempts", maxProjectIDProbe)
+
+// errUnsafeShrink is returned by ensureQuota when it refuses to apply a
+// quota decrease that its own currentUsageBytes check found would put the
+// volume over its new limit immediately -- see ensureQuota's shrink guard
+// (#14: "shrink는 unsupported/unsafe 조건에서... 명확히 거부한다").
+var errUnsafeShrink = errors.New("quota decrease rejected: below current on-disk usage")
 
 // generateProjectID generates a unique numeric project ID from project name.
 // Uses the in-memory knownProjectIDs cache (refreshed once per sync cycle).

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1158,3 +1158,149 @@ func TestReadinessOK_BasePathNotAccessible(t *testing.T) {
 		t.Fatalf("reason = %q, want it to mention the base path", reason)
 	}
 }
+
+// TestEnsureQuota_RefusesShrinkBelowCurrentUsage guards #14's shrink-guard
+// acceptance item: a quota decrease that would put a claim's already
+// on-disk usage over the new limit must be refused, not applied, leaving
+// the previous quota in force.
+func TestEnsureQuota_RefusesShrinkBelowCurrentUsage(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, pv, client := ensureQuotaFixture(t, 1)
+	a.fsType = quota.FSTypeXFS
+	ctx := context.Background()
+
+	if err := a.ensureQuota(ctx, pv, 1_000_000); err != nil {
+		t.Fatalf("initial ensureQuota: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if err := os.WriteFile(filepath.Join(localPath, "data.bin"), make([]byte, 500_000), 0644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	err := a.ensureQuota(ctx, pv, 100_000)
+	if err == nil {
+		t.Fatalf("expected a shrink below current usage to be refused")
+	}
+	if !errors.Is(err, errUnsafeShrink) {
+		t.Fatalf("expected errUnsafeShrink, got %v", err)
+	}
+
+	if got := a.appliedQuotas[localPath]; got != 1_000_000 {
+		t.Fatalf("appliedQuotas after refused shrink = %d, want unchanged 1000000", got)
+	}
+
+	updated, getErr := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("get pv: %v", getErr)
+	}
+	if updated.Annotations[AnnotationQuotaStatus] != QuotaStatusFailed {
+		t.Fatalf("expected quota status failed, got %q", updated.Annotations[AnnotationQuotaStatus])
+	}
+}
+
+// TestEnsureQuota_AllowsShrinkAboveCurrentUsage is the companion regression
+// test: a decrease that stays above actual usage is a normal, legitimate
+// shrink and must still be applied -- the guard must not over-trigger on
+// every decrease, only an unsafe one.
+func TestEnsureQuota_AllowsShrinkAboveCurrentUsage(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, pv, _ := ensureQuotaFixture(t, 1)
+	a.fsType = quota.FSTypeXFS
+	ctx := context.Background()
+
+	if err := a.ensureQuota(ctx, pv, 1_000_000); err != nil {
+		t.Fatalf("initial ensureQuota: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if err := os.WriteFile(filepath.Join(localPath, "data.bin"), make([]byte, 1_000), 0644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	if err := a.ensureQuota(ctx, pv, 500_000); err != nil {
+		t.Fatalf("expected a safe shrink (well above current usage) to succeed, got %v", err)
+	}
+	if got := a.appliedQuotas[localPath]; got != 500_000 {
+		t.Fatalf("appliedQuotas after safe shrink = %d, want 500000", got)
+	}
+}
+
+// TestEnsureQuota_AllowsShrinkExactlyEqualToCurrentUsage is the exact-
+// boundary case: the guard rejects only usage strictly above the enforced
+// new limit (`used > enforced`), so a shrink to precisely the current
+// usage must still succeed. 524,288 and 1,048,576 are exact KB multiples
+// so expectedEnforcedBytes's flooring can't shift the boundary in this
+// test.
+func TestEnsureQuota_AllowsShrinkExactlyEqualToCurrentUsage(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, pv, _ := ensureQuotaFixture(t, 1)
+	a.fsType = quota.FSTypeXFS
+	ctx := context.Background()
+
+	if err := a.ensureQuota(ctx, pv, 1_048_576); err != nil {
+		t.Fatalf("initial ensureQuota: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if err := os.WriteFile(filepath.Join(localPath, "data.bin"), make([]byte, 524_288), 0644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	if err := a.ensureQuota(ctx, pv, 524_288); err != nil {
+		t.Fatalf("expected a shrink exactly equal to current usage to succeed, got %v", err)
+	}
+	if got := a.appliedQuotas[localPath]; got != 524_288 {
+		t.Fatalf("appliedQuotas after exact-boundary shrink = %d, want 524288", got)
+	}
+}
+
+// TestEnsureQuota_RefusesShrinkUnsafeOnlyAfterKBFlooring guards the
+// expectedEnforcedBytes fix: xfs/ext4 floor the applied hard limit down to
+// a whole KB (see ApplyXFSQuota/ApplyExt4Quota), so a raw requested value
+// that looks safe against current usage can still be unsafe once floored.
+// 100,500 bytes floors to 100,352 (98KB); usage of 100,400 sits strictly
+// between the two -- safe against the raw value, unsafe against what
+// actually gets enforced -- so the guard must reject it.
+func TestEnsureQuota_RefusesShrinkUnsafeOnlyAfterKBFlooring(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, pv, _ := ensureQuotaFixture(t, 1)
+	a.fsType = quota.FSTypeXFS
+	ctx := context.Background()
+
+	if err := a.ensureQuota(ctx, pv, 200_000); err != nil {
+		t.Fatalf("initial ensureQuota: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if err := os.WriteFile(filepath.Join(localPath, "data.bin"), make([]byte, 100_400), 0644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	err := a.ensureQuota(ctx, pv, 100_500)
+	if err == nil {
+		t.Fatalf("expected rejection: 100500 floors to 100352, below the 100400-byte usage")
+	}
+	if !errors.Is(err, errUnsafeShrink) {
+		t.Fatalf("expected errUnsafeShrink, got %v", err)
+	}
+	if got := a.appliedQuotas[localPath]; got != 200_000 {
+		t.Fatalf("appliedQuotas after refused shrink = %d, want unchanged 200000", got)
+	}
+}
+
+// TestCurrentUsageBytes_UnreadableBasePathReturnsNotOK guards the shrink
+// guard's fail-open behavior: when the usage report can't be read at all
+// (GetDirUsages returns an error), currentUsageBytes must report ok=false
+// rather than treating that as zero usage -- ensureQuota's guard condition
+// (`ok && used > enforced`) then short-circuits and the shrink proceeds
+// instead of being blocked by an unrelated report failure.
+func TestCurrentUsageBytes_UnreadableBasePathReturnsNotOK(t *testing.T) {
+	a := newTestAgent(t, fake.NewSimpleClientset())
+	a.nfsBasePath = filepath.Join(t.TempDir(), "does-not-exist")
+	a.fsType = quota.FSTypeXFS
+
+	if _, ok := a.currentUsageBytes(filepath.Join(a.nfsBasePath, "pvc-1")); ok {
+		t.Fatalf("expected ok=false when the usage report's base path can't be read")
+	}
+}

--- a/internal/agent/policy.go
+++ b/internal/agent/policy.go
@@ -299,12 +299,13 @@ var errLocalDirectoryMissing = errors.New("PV local directory does not exist on 
 // classifyEnforcementError maps an ensureQuota error to one of the fixed
 // Reason* constants for FailingClaim/Degraded reporting, falling back to
 // the generic ReasonEnforcementFailed for anything not specifically
-// recognized. errProjectIDExhausted, errLocalDirectoryMissing, and
-// ErrHAStandby (ha.go) are the only cases distinguished today;
-// docs/quotapolicy-design.md §5 already anticipates ReasonProjectIDExhausted
-// may turn out to be unreachable in practice given the existing
-// collision-fallback in generateProjectID — the same "included for the
-// vocabulary, may never fire" reasoning could apply to any of the three.
+// recognized. errProjectIDExhausted, errLocalDirectoryMissing,
+// ErrHAStandby (ha.go), and errUnsafeShrink (agent.go) are the only cases
+// distinguished today; docs/quotapolicy-design.md §5 already anticipates
+// ReasonProjectIDExhausted may turn out to be unreachable in practice given
+// the existing collision-fallback in generateProjectID — the same
+// "included for the vocabulary, may never fire" reasoning could apply to
+// any of the four.
 func classifyEnforcementError(err error) string {
 	switch {
 	case errors.Is(err, errProjectIDExhausted):
@@ -313,6 +314,8 @@ func classifyEnforcementError(err error) string {
 		return v1alpha1.ReasonFilesystemUnavailable
 	case errors.Is(err, ErrHAStandby):
 		return v1alpha1.ReasonHAStandby
+	case errors.Is(err, errUnsafeShrink):
+		return v1alpha1.ReasonUnsafeShrinkRejected
 	default:
 		return v1alpha1.ReasonEnforcementFailed
 	}

--- a/internal/agent/policy_test.go
+++ b/internal/agent/policy_test.go
@@ -18,6 +18,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -271,4 +272,129 @@ func TestFinishQuotaPolicyCycle_SkipsStatusByDefault(t *testing.T) {
 	if _, found, _ := unstructured.NestedSlice(got.Object, "status", "conditions"); found {
 		t.Fatalf("expected status.conditions to be unset without quotaPolicySingleWriter, got %+v", got.Object["status"])
 	}
+}
+
+// TestSyncAllQuotas_PolicyShrinkBelowUsageSurfacesAsFailingClaim guards
+// #14's shrink-guard acceptance item ("shrink는 unsupported/unsafe
+// 조건에서... 명확히 거부한다"): a QuotaPolicy maxQuota decrease that would
+// put a claim's already-written usage over its new limit must be refused
+// at reconcile time (ensureQuota's errUnsafeShrink guard) rather than
+// applied, and that refusal must be visible in status.failingClaims with
+// ReasonUnsafeShrinkRejected -- not just logged and dropped.
+func TestSyncAllQuotas_PolicyShrinkBelowUsageSurfacesAsFailingClaim(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, _ := quotaPolicyTestFixture(t)
+	a.SetQuotaPolicyEnabled(true)
+	a.SetQuotaPolicySingleWriter(true)
+
+	p := &v1alpha1.QuotaPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "shrinking-policy"},
+		Spec: v1alpha1.QuotaPolicySpec{
+			MaxQuota:   resource.NewQuantity(1_000_000, resource.BinarySI),
+			EnforceMax: true,
+		},
+	}
+	dyn := newFakeQuotaPolicyClient(t, p)
+	a.SetDynamicClient(dyn)
+
+	// Cycle 1: clamps to the policy's 1,000,000-byte max.
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas (cycle 1): %v", err)
+	}
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	if got := a.appliedQuotas[localPath]; got != 1_000_000 {
+		t.Fatalf("applied quota after cycle 1 = %d, want 1000000", got)
+	}
+
+	// Write 500,000 bytes of real on-disk usage, then shrink the policy's
+	// max down to 100,000 -- below that usage.
+	if err := os.WriteFile(filepath.Join(localPath, "data.bin"), make([]byte, 500_000), 0644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+	live, err := dyn.Resource(quotapolicy.GroupVersionResource).Namespace(p.Namespace).Get(context.Background(), p.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get policy before update: %v", err)
+	}
+	if err := unstructured.SetNestedField(live.Object, "100000", "spec", "maxQuota"); err != nil {
+		t.Fatalf("set maxQuota: %v", err)
+	}
+	if _, err := dyn.Resource(quotapolicy.GroupVersionResource).Namespace(p.Namespace).Update(context.Background(), live, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update policy: %v", err)
+	}
+
+	// Cycle 2: the shrink must be refused, leaving the 1,000,000-byte quota
+	// still in force.
+	if err := a.syncAllQuotas(context.Background()); err != nil {
+		t.Fatalf("syncAllQuotas (cycle 2): %v", err)
+	}
+	if got := a.appliedQuotas[localPath]; got != 1_000_000 {
+		t.Fatalf("applied quota after refused shrink = %d, want unchanged 1000000", got)
+	}
+
+	got, err := dyn.Resource(quotapolicy.GroupVersionResource).Namespace(p.Namespace).Get(context.Background(), p.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get policy after cycle 2: %v", err)
+	}
+	matched, found, err := unstructured.NestedInt64(got.Object, "status", "matchedClaims")
+	if err != nil || !found || matched != 1 {
+		t.Fatalf("matchedClaims: found=%v err=%v value=%d, want 1", found, err, matched)
+	}
+	// appliedClaims has `json:",omitempty"`, so a value of 0 (nothing
+	// applied) round-trips as the field being absent, not present-as-zero.
+	applied, found, err := unstructured.NestedInt64(got.Object, "status", "appliedClaims")
+	if err != nil || (found && applied != 0) {
+		t.Fatalf("appliedClaims: found=%v err=%v value=%d, want absent or 0", found, err, applied)
+	}
+	failing, found, err := unstructured.NestedSlice(got.Object, "status", "failingClaims")
+	if err != nil || !found || len(failing) != 1 {
+		t.Fatalf("failingClaims: found=%v err=%v value=%+v, want exactly 1 entry", found, err, failing)
+	}
+	failingClaim, ok := failing[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("failingClaims[0] is not an object: %+v", failing[0])
+	}
+	if ns, _, _ := unstructured.NestedString(failingClaim, "namespace"); ns != "default" {
+		t.Fatalf("failingClaims[0].namespace = %q, want %q", ns, "default")
+	}
+	if name, _, _ := unstructured.NestedString(failingClaim, "name"); name != "pv-1-claim" {
+		t.Fatalf("failingClaims[0].name = %q, want %q", name, "pv-1-claim")
+	}
+	reason, found, err := unstructured.NestedString(failingClaim, "reason")
+	if err != nil || !found || reason != v1alpha1.ReasonUnsafeShrinkRejected {
+		t.Fatalf("failingClaims[0].reason = %q (found=%v err=%v), want %q", reason, found, err, v1alpha1.ReasonUnsafeShrinkRejected)
+	}
+	if status, reason, err := getCondition(got, v1alpha1.ConditionApplied); err != nil || status != string(metav1.ConditionFalse) {
+		t.Fatalf("Applied condition = (status=%q reason=%q err=%v), want status=False", status, reason, err)
+	}
+	degradedStatus, degradedReason, err := getCondition(got, v1alpha1.ConditionDegraded)
+	if err != nil {
+		t.Fatalf("getCondition(Degraded): %v", err)
+	}
+	if degradedStatus != string(metav1.ConditionTrue) {
+		t.Fatalf("Degraded condition status = %q, want True", degradedStatus)
+	}
+	if degradedReason != v1alpha1.ReasonUnsafeShrinkRejected {
+		t.Fatalf("Degraded reason = %q, want %q", degradedReason, v1alpha1.ReasonUnsafeShrinkRejected)
+	}
+}
+
+// getConditionReason returns the Reason of the named condition type from a
+// QuotaPolicy's unstructured status.conditions.
+func getCondition(got *unstructured.Unstructured, condType string) (status, reason string, err error) {
+	conditions, _, err := unstructured.NestedSlice(got.Object, "status", "conditions")
+	if err != nil {
+		return "", "", err
+	}
+	for _, c := range conditions {
+		m, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if m["type"] == condType {
+			status, _ := m["status"].(string)
+			reason, _ := m["reason"].(string)
+			return status, reason, nil
+		}
+	}
+	return "", "", fmt.Errorf("condition %q not found", condType)
 }

--- a/internal/apis/quota/v1alpha1/types.go
+++ b/internal/apis/quota/v1alpha1/types.go
@@ -117,6 +117,7 @@ const (
 	ReasonFilesystemUnavailable = "FilesystemUnavailable"
 	ReasonProjectIDExhausted    = "ProjectIDExhausted"
 	ReasonHAStandby             = "HAStandby"
+	ReasonUnsafeShrinkRejected  = "UnsafeShrinkRejected"
 
 	ReasonQuotaDriftDetected = "QuotaDriftDetected"
 	ReasonNoDrift            = "NoDrift"


### PR DESCRIPTION
## Summary

Closes one of #14's remaining acceptance items: "shrink는 unsupported/unsafe 조건에서... 명확히 거부한다". Project quota is non-destructive by construction, so the risk isn't data loss — it's an operator changing a `QuotaPolicy` and unknowingly cutting a tenant's writes off with no warning.

The bound needed no invented policy threshold: a shrink is unsafe exactly when current usage already exceeds the requested new limit, not some percentage margin below the old one (which a prior #14 comment round explicitly declined to guess at).

- `ensureQuota` (agent.go): before a genuine decrease reaches the filesystem backend, `currentUsageBytes` reads the same `status.GetDirUsages` report `/metrics`/the web UI already use. If usage exceeds the enforced new limit, the change is refused — `appliedQuotas` and the filesystem stay untouched, audit log + PV annotation record it via the existing `LogQuotaUpdate`/`updateQuotaStatus` paths.
- `expectedEnforcedBytes` (new): xfs/ext4 floor the applied hard limit to a whole KB before calling `xfs_quota`/`setquota` — comparing against the raw requested value instead let a request within 1KB of the boundary look safe when the actually-enforced limit was already below usage (same class of bug as #10's CRITICAL rounding fix).
- Report-unreadable → shrink proceeds (fail-open: "no evidence unsafe," not "assume the worst").
- New `ReasonUnsafeShrinkRejected`, wired into the existing `EnforcementErr`/`FailingClaims`/`Degraded` machinery — no new CRD field, no `make generate` needed.

## Review

Two parallel Codex reviews (correctness/concurrency + test-quality) found, and this fixes:
- The KB-flooring mismatch (`expectedEnforcedBytes`).
- Missing exact-boundary + flooring-regression test coverage.
- Missing coverage for the `GetDirUsages`-error fail-open path.
- Under-specified integration assertions (added `matchedClaims`, `FailingClaim` namespace/name, `Applied=False`/`Degraded=True`).

Two findings are documented as accepted, not fixed (see `agent.go`'s `currentUsageBytes` doc comment and `docs/quotapolicy-design.md`): the usage-sample-then-apply TOCTOU window (narrowed, not closed — needs transactional filesystem semantics this agent doesn't have), and `GetDirUsages`'s sparse-file undercount on its `filepath.Walk` fallback (pre-existing, shared with `/metrics`/the web UI).

## Verification

Mutation-tested: reverted `expectedEnforcedBytes` to the raw value, confirmed the new flooring-regression test fails for the right reason, restored, confirmed clean. `gofmt -l .` / `go build ./...` / `go vet ./...` / `go test -race ./...` all green (6 new tests). `helm lint` clean (chart untouched).

Independent of the still-unmerged #68/#70 stack — based directly on `main`.

## Test plan

- [x] `go test -race ./...` green, including 6 new shrink-guard tests
- [x] Mutation test on `expectedEnforcedBytes` (flooring fix) — fails without it, passes with it
- [x] `gofmt -l .`, `go vet ./...`, `helm lint` clean
- [x] Two independent Codex reviews, all findings addressed or explicitly documented as accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT