### PR TITLE
test(agent): verify a Kubernetes API list failure never manufactures orphans

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -32,7 +32,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 
 	"github.com/dasomel/nfs-quota-agent/internal/audit"
 	"github.com/dasomel/nfs-quota-agent/internal/history"
@@ -1156,5 +1158,40 @@ func TestReadinessOK_BasePathNotAccessible(t *testing.T) {
 	}
 	if !strings.Contains(reason, "base path not accessible") {
 		t.Fatalf("reason = %q, want it to mention the base path", reason)
+	}
+}
+
+// TestSyncAllQuotas_APIListFailureMutatesNothing guards #11's "Kubernetes
+// API 장애... 발생해도 stale state만으로 destructive action을 하지 않는다"
+// acceptance item for the periodic sync path: when the PV list call itself
+// fails, syncAllQuotas must return the error immediately rather than
+// falling through with a stale or empty PV list -- which would look
+// exactly like "every previously-tracked PV disappeared" to
+// pruneAppliedQuotas. Confirms both the returned error and that no cached
+// state was touched.
+func TestSyncAllQuotas_APIListFailureMutatesNothing(t *testing.T) {
+	withFakeRunner(t, xfsHappyRunner())
+	a, pv, _ := ensureQuotaFixture(t, 1)
+	a.fsType = quota.FSTypeXFS
+	ctx := context.Background()
+
+	if err := a.ensureQuota(ctx, pv, 0); err != nil {
+		t.Fatalf("seed ensureQuota: %v", err)
+	}
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	before := a.appliedQuotas[localPath]
+	if before == 0 {
+		t.Fatalf("expected a seeded appliedQuotas entry")
+	}
+
+	a.client.(*fake.Clientset).PrependReactor("list", "persistentvolumes", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("simulated API server outage")
+	})
+
+	if err := a.syncAllQuotas(ctx); err == nil {
+		t.Fatalf("expected syncAllQuotas to return the List() error, got nil")
+	}
+	if got := a.appliedQuotas[localPath]; got != before {
+		t.Fatalf("appliedQuotas changed on a List() failure: got %d, want unchanged %d", got, before)
 	}
 }

--- a/internal/agent/orphan_test.go
+++ b/internal/agent/orphan_test.go
@@ -18,13 +18,16 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 
 	"github.com/dasomel/nfs-quota-agent/internal/audit"
 	"github.com/dasomel/nfs-quota-agent/internal/quota"
@@ -340,5 +343,47 @@ func TestRunAutoCleanupTicks(t *testing.T) {
 
 	if _, err := os.Stat(orphanDir); err != nil {
 		t.Fatalf("dry-run auto-cleanup must not remove the directory: %v", err)
+	}
+}
+
+// TestFindOrphans_APIListFailureFindsNoOrphans guards #11's "Kubernetes API
+// 장애... 발생해도 stale state만으로 destructive action을 하지 않는다"
+// acceptance item for the orphan-cleanup path specifically: findOrphans
+// must treat "the PV list call itself failed" as "I don't know what's
+// valid," not as "the API returned zero PVs," which would make every
+// directory on disk look orphaned and eligible for deletion. The
+// production code already does this correctly (see findOrphans' early
+// return on err != nil) -- this test exists so that guarantee is verified
+// behavior, not just something true on inspection.
+func TestFindOrphans_APIListFailureFindsNoOrphans(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("list", "persistentvolumes", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("simulated API server outage")
+	})
+
+	a := newTestAgent(t, client)
+	a.orphanGracePeriod = 0 // would make anything found immediately eligible for deletion
+
+	// A real, existing directory that would be flagged (and, with a zero
+	// grace period, immediately deletable) if the list failure were ever
+	// mistaken for "no valid paths."
+	staleDir := filepath.Join(a.nfsBasePath, "looks-orphaned-but-isnt")
+	if err := os.MkdirAll(staleDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	orphans := a.findOrphans(context.Background())
+	if len(orphans) != 0 {
+		t.Fatalf("findOrphans on a List() failure returned %d orphan(s), want 0 -- a stale/failed API view must never manufacture deletion candidates: %+v", len(orphans), orphans)
+	}
+	if _, err := os.Stat(staleDir); err != nil {
+		t.Fatalf("directory must still exist: %v", err)
+	}
+
+	// cleanupOrphans (the actual deletion driver) must be a no-op too, not
+	// just findOrphans in isolation.
+	a.cleanupOrphans(context.Background())
+	if _, err := os.Stat(staleDir); err != nil {
+		t.Fatalf("cleanupOrphans must not have deleted anything on a List() failure: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Addresses one of #11's (HA/DR) acceptance items with a code-only, no-infra-needed change: "Kubernetes API 장애/replication 장애가 발생해도 stale state만으로 destructive action을 하지 않는다".

Investigation found the production code already does the right thing at both call sites — `findOrphans` (orphan.go) and `syncAllQuotas` (agent.go) both return immediately on a `PersistentVolumes().List()` error rather than falling through with an empty/stale PV list, which would otherwise look exactly like "every tracked PV disappeared" and make every on-disk directory or every `appliedQuotas` entry look orphaned/gone. **No production code changed** — this closes the gap between "true on inspection" and "verified by a test."

- `TestFindOrphans_APIListFailureFindsNoOrphans`: a `List()` failure yields zero orphans, and `cleanupOrphans` (the actual deletion driver) doesn't delete anything even with `orphanGracePeriod=0`.
- `TestSyncAllQuotas_APIListFailureMutatesNothing`: a `List()` failure returns an error and leaves `appliedQuotas` completely untouched.

## Verification

Both mutation-tested: temporarily made each function's error path treat the failure as an empty PV list (the exact bug class this guards against), confirmed the corresponding test fails, restored, confirmed clean.

`gofmt -l .` / `go build ./...` / `go vet ./...` / `go test -race ./...` all green. `helm lint` clean (chart untouched).

Independent of every other branch in flight (#66-#72) — based directly on `main`, touches only two test files.

## Test plan

- [x] `go test -race ./...` green, including the 2 new tests
- [x] Mutation test on both guarded call sites — fails without the (pre-existing) guard, passes with it
- [x] `gofmt -l .`, `go vet ./...`, `helm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT