### PR TITLE
test(agent): verify a process restart converges drifted quota to desired state

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1505,3 +1505,81 @@ func TestSyncAllQuotas_APIListFailureMutatesNothing(t *testing.T) {
 		t.Fatalf("appliedQuotas changed on a List() failure: got %d, want unchanged %d", got, before)
 	}
 }
+
+// TestSyncAllQuotas_RestartWithFreshCacheReconcilesDriftedQuota guards
+// #10's "startup detects metadata/quota mismatch and converges to desired
+// state" acceptance item. appliedQuotas is purely in-memory, so a process
+// restart always starts with an empty cache; ensureQuotaMutated's cache-hit
+// fast path only fires on an *existing* entry that matches, so an empty
+// cache guarantees the very first post-restart sync cycle re-applies every
+// PV from its own desired state -- convergence falls out of that
+// unconditionally, with no separate "was there drift" detection step
+// needed. This proves the property end-to-end: a second, independently
+// constructed *QuotaAgent (nothing shared with the first except the same
+// on-disk directory and fake kernel state, exactly like a real restart)
+// must repair a quota that drifted out-of-band while the first "process"
+// was down.
+func TestSyncAllQuotas_RestartWithFreshCacheReconcilesDriftedQuota(t *testing.T) {
+	runner, state := xfsHappyRunnerWithState()
+	withFakeRunner(t, runner)
+
+	pv := newBoundPV("pv-1", "/exports/pvc-1", 1)
+	pv.Annotations = map[string]string{"pv.kubernetes.io/provisioned-by": "example.com/nfs"}
+	client := fake.NewSimpleClientset(pv)
+	base := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(base, "pvc-1"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	newAgent := func() *QuotaAgent {
+		a := NewQuotaAgent(client, base, "/exports", "example.com/nfs")
+		a.SetProjectsFile(filepath.Join(base, "projects"))
+		a.SetProjidFile(filepath.Join(base, "projid"))
+		a.SetStateDir(t.TempDir())
+		a.fsType = quota.FSTypeXFS
+		return a
+	}
+
+	ctx := context.Background()
+
+	// "Process 1": normal startup, applies the PV's 1Gi capacity.
+	a1 := newAgent()
+	if err := a1.syncAllQuotas(ctx); err != nil {
+		t.Fatalf("syncAllQuotas (process 1): %v", err)
+	}
+	localPath := a1.nfsPathToLocal("/exports/pvc-1")
+	if got := a1.appliedQuotas[localPath]; got != oneGiBytes {
+		t.Fatalf("applied quota after process 1 = %d, want %d", got, oneGiBytes)
+	}
+
+	// Process 1 is now gone (crash, restart, redeploy). While it's down,
+	// someone changes the on-disk quota directly, bypassing the agent
+	// entirely -- exactly what an out-of-band xfs_quota invocation would
+	// do.
+	state.mu.Lock()
+	for id := range state.applied {
+		state.applied[id] = oneGiBytes / 2
+	}
+	state.mu.Unlock()
+
+	// "Process 2": a brand new QuotaAgent sharing nothing with a1 except
+	// the same on-disk directory/projects file and the same fake kernel
+	// state -- appliedQuotas starts empty, exactly like a real restart.
+	a2 := newAgent()
+	if err := a2.syncAllQuotas(ctx); err != nil {
+		t.Fatalf("syncAllQuotas (process 2, first cycle): %v", err)
+	}
+	if got := a2.appliedQuotas[localPath]; got != oneGiBytes {
+		t.Fatalf("appliedQuotas after restart = %d, want %d (restart must converge to desired state)", got, oneGiBytes)
+	}
+
+	state.mu.Lock()
+	var onDisk int64
+	for _, bytes := range state.applied {
+		onDisk = bytes
+	}
+	state.mu.Unlock()
+	if onDisk != oneGiBytes {
+		t.Fatalf("on-disk quota after restart = %d, want %d -- restart must repair drift introduced while the agent was down", onDisk, oneGiBytes)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #10's "startup detects metadata/quota mismatch and converges to desired state" acceptance item with a code-only, no-infra-needed test. **No production code changed** — `appliedQuotas` is purely in-memory, so a real restart always starts with an empty cache, and `ensureQuotaMutated`'s cache-hit fast path only fires on an *existing* entry matching the desired size. An empty cache therefore guarantees the very first post-restart sync cycle re-applies every PV from its own desired state — convergence falls out of that unconditionally.

`TestSyncAllQuotas_RestartWithFreshCacheReconcilesDriftedQuota` builds two independent `*QuotaAgent` instances sharing nothing but the same on-disk directory/projects file and the same fake kernel state — exactly like a real process restart. Process 1 applies 1Gi; while it's "down," the on-disk quota is changed out-of-band to 512Mi. Process 2 (fresh cache) must repair this on its very first sync cycle.

## Verification

Mutation-tested against the actual regression class this guards: pre-seeding process 2's `appliedQuotas` with a value matching the *desired* state (as a hypothetical future "warm-start from cached state" shortcut might do) makes the test fail — the drifted value survives instead of being repaired — confirming sensitivity to the real bug class, not just "nothing gets applied."

`gofmt -l .` / `go build ./...` / `go vet ./...` / `go test -race ./...` all green. `helm lint` clean (chart untouched). Independent of every other branch — based directly on `main`, touches only `agent_test.go`.

## Test plan

- [x] `go test -race ./...` green, including the new test
- [x] Mutation test against the "warm-start trusts stale cache" regression class
- [x] `gofmt -l .`, `go vet ./...`, `helm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT