### PR TITLE
refactor(agent): dedup expectedEnforcedBytes into quota.ExpectedEnforcedBytes

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1075,7 +1075,7 @@ func (a *QuotaAgent) ensureQuotaMutated(ctx context.Context, pv *v1.PersistentVo
 	isUpdate := oldQuota > 0 && oldQuota != sizeBytes
 
 	if isUpdate && sizeBytes < oldQuota {
-		enforcedBytes := expectedEnforcedBytes(a.fsType, sizeBytes)
+		enforcedBytes := quota.ExpectedEnforcedBytes(a.fsType, sizeBytes)
 		if used, ok := a.currentUsageBytes(localPath); ok && used > uint64(enforcedBytes) {
 			shrinkErr := fmt.Errorf("%w: new quota %s (enforced as %s) is below current usage %s for PV %s",
 				errUnsafeShrink, util.FormatBytes(sizeBytes), util.FormatBytes(enforcedBytes), util.FormatBytes(int64(used)), pv.Name)
@@ -1135,32 +1135,6 @@ func (a *QuotaAgent) ensureQuotaMutated(ctx context.Context, pv *v1.PersistentVo
 	)
 
 	return true, nil
-}
-
-// expectedEnforcedBytes mirrors the KB-flooring internal/quota's
-// ApplyXFSQuota/ApplyExt4Quota apply before ever reaching the filesystem
-// (sizeBytes/1024, minimum 1KB; btrfs applies the exact byte value via
-// qgroup limit, no flooring) so the shrink guard below compares against
-// what will actually be enforced, not the raw requested value. Comparing
-// against the raw value would let a shrink request within one KB of the
-// boundary look safe when the floored limit actually applied is already
-// below current usage -- the same class of mismatch the #10 CRITICAL
-// rounding bug was (see CLAUDE.md). This duplicates the floor arithmetic
-// already inline in xfs.go/ext4.go rather than exporting a shared helper,
-// to keep this change scoped to the shrink guard; if a shared
-// ExpectedEnforcedBytes-style helper is added later, this should call that
-// instead of maintaining its own copy.
-func expectedEnforcedBytes(fsType string, sizeBytes int64) int64 {
-	switch fsType {
-	case quota.FSTypeXFS, quota.FSTypeExt4:
-		sizeKB := sizeBytes / 1024
-		if sizeKB == 0 {
-			sizeKB = 1
-		}
-		return sizeKB * 1024
-	default:
-		return sizeBytes
-	}
 }
 
 // currentUsageBytes returns the on-disk usage GetDirUsages currently

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1424,37 +1424,6 @@ func TestEnsureQuota_AllowsShrinkExactlyEqualToCurrentUsage(t *testing.T) {
 	}
 }
 
-// TestExpectedEnforcedBytes guards the expectedEnforcedBytes fix directly:
-// xfs/ext4 floor the applied hard limit down to a whole KB (see
-// ApplyXFSQuota/ApplyExt4Quota's identical sizeKB := sizeBytes/1024,
-// minimum 1KB arithmetic) before it ever reaches the filesystem, so the
-// shrink guard must compare current usage against that floored value, not
-// the raw requested one -- otherwise a request within 1KB of the boundary
-// can look safe when the limit that actually gets enforced is already
-// below usage (the same class of mismatch as the #10 CRITICAL rounding
-// bug). btrfs applies the exact byte value via qgroup limit, no flooring.
-func TestExpectedEnforcedBytes(t *testing.T) {
-	tests := []struct {
-		name      string
-		fsType    string
-		sizeBytes int64
-		want      int64
-	}{
-		{"xfs floors down to whole KB", quota.FSTypeXFS, 100_500, 100_352},
-		{"xfs exact KB multiple is unchanged", quota.FSTypeXFS, 524_288, 524_288},
-		{"xfs below 1KB floors up to the 1KB minimum", quota.FSTypeXFS, 500, 1024},
-		{"ext4 floors identically to xfs", quota.FSTypeExt4, 100_500, 100_352},
-		{"btrfs applies the exact byte value, no flooring", quota.FSTypeBtrfs, 100_500, 100_500},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := expectedEnforcedBytes(tc.fsType, tc.sizeBytes); got != tc.want {
-				t.Errorf("expectedEnforcedBytes(%q, %d) = %d, want %d", tc.fsType, tc.sizeBytes, got, tc.want)
-			}
-		})
-	}
-}
-
 // TestCurrentUsageBytes_UnreadableBasePathReturnsNotOK guards the shrink
 // guard's fail-open behavior: when the usage report can't be read at all
 // (GetDirUsages returns an error), currentUsageBytes must report ok=false


### PR DESCRIPTION
## Summary

PR #72's shrink guard added a local `expectedEnforcedBytes` in `agent.go`, explicitly flagged as short-term duplication pending a shared helper. That helper (`quota.ExpectedEnforcedBytes`, PR #68/#10) was already merged to `main` by the time #72 got rebased onto it — the duplication became live tech debt at merge time, just missed during that merge.

- `ensureQuotaMutated`'s shrink guard now calls `quota.ExpectedEnforcedBytes` directly.
- Removed the local copy and its dedicated `agent_test.go` table test (`internal/quota/report_test.go`'s `TestExpectedEnforcedBytes` already covers the same function more thoroughly).
- No behavior change — both implementations were byte-for-byte identical arithmetic.

## Verification

`gofmt -l .` / `go build ./...` / `go vet ./...` / `go test -race ./...` all green — shrink-guard integration tests still pass unchanged, confirming the shared helper behaves identically. `helm lint` clean (chart untouched).

## Test plan

- [x] `go test -race ./...` green, no test count regression beyond the intentional dedup removal
- [x] `gofmt -l .`, `go vet ./...`, `helm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT