### PR TITLE
fix(agent): close shrink guard bypass on process restart

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -89,6 +89,20 @@ type QuotaAgent struct {
 	knownProjectIDs map[uint32]string // cache of projid file; refreshed once per sync cycle
 	auditLogger     *audit.Logger
 
+	// priorEnforcedFromDisk and primeOnce back ensureQuotaMutated's shrink
+	// guard's restart case: appliedQuotas is purely in-memory, so it reads
+	// as empty on a fresh process even for a claim that already has a real
+	// on-disk quota from before this process started. Run() calls
+	// primeAppliedQuotasFromDiskOnce before the first sync, fetching the
+	// filesystem-wide quota report exactly once (primeOnce) and recording
+	// each path's real on-disk hard limit here -- a single bulk read done
+	// once at startup, not one read per ambiguous claim, so a burst of
+	// many first-touches (many new PVs at once, or a restart with many
+	// pre-existing ones) costs one report fetch, not N. See
+	// primeAppliedQuotasFromDiskOnce.
+	priorEnforcedFromDisk map[string]uint64
+	primeOnce             sync.Once
+
 	// haActiveFile, when non-empty, gates every quota mutation (ensureQuota,
 	// RemoveOrphan) on this file's existence: present means this instance is
 	// the active/owning node for quota enforcement, absent means standby.
@@ -213,21 +227,22 @@ const readinessSyncFailureThreshold = 3
 // NewQuotaAgent creates a new QuotaAgent
 func NewQuotaAgent(client kubernetes.Interface, nfsBasePath, nfsServerPath, provisionerName string) *QuotaAgent {
 	return &QuotaAgent{
-		client:            client,
-		nfsBasePath:       nfsBasePath,
-		nfsServerPath:     nfsServerPath,
-		provisionerName:   provisionerName,
-		quotaPath:         nfsBasePath,
-		projectsFile:      "/etc/projects",
-		projidFile:        "/etc/projid",
-		stateDir:          "/var/lib/nfs-quota-agent",
-		syncInterval:      30 * time.Second,
-		appliedQuotas:     make(map[string]int64),
-		knownProjectIDs:   make(map[uint32]string),
-		cleanupInterval:   1 * time.Hour,
-		orphanGracePeriod: 24 * time.Hour,
-		cleanupDryRun:     true,
-		orphanLastSeen:    make(map[string]time.Time),
+		client:                client,
+		nfsBasePath:           nfsBasePath,
+		nfsServerPath:         nfsServerPath,
+		provisionerName:       provisionerName,
+		quotaPath:             nfsBasePath,
+		projectsFile:          "/etc/projects",
+		projidFile:            "/etc/projid",
+		stateDir:              "/var/lib/nfs-quota-agent",
+		syncInterval:          30 * time.Second,
+		appliedQuotas:         make(map[string]int64),
+		priorEnforcedFromDisk: make(map[string]uint64),
+		knownProjectIDs:       make(map[uint32]string),
+		cleanupInterval:       1 * time.Hour,
+		orphanGracePeriod:     24 * time.Hour,
+		cleanupDryRun:         true,
+		orphanLastSeen:        make(map[string]time.Time),
 	}
 }
 
@@ -536,6 +551,14 @@ func (a *QuotaAgent) Run(ctx context.Context) error {
 	if err := a.loadProjects(); err != nil {
 		slog.Warn("Failed to load existing projects", "error", err)
 	}
+
+	// Snapshot the real on-disk quota report once, before the first sync
+	// touches anything -- see priorEnforcedFromDisk's doc comment and
+	// ensureQuotaMutated's shrink guard for why: appliedQuotas starts
+	// empty every restart, and without this snapshot the guard can't tell
+	// a claim that's genuinely new from one whose on-disk quota was
+	// already lower than current usage before this process even started.
+	a.primeAppliedQuotasFromDiskOnce()
 
 	// Initial sync
 	if err := a.syncAllQuotas(ctx); err != nil {
@@ -1074,8 +1097,41 @@ func (a *QuotaAgent) ensureQuotaMutated(ctx context.Context, pv *v1.PersistentVo
 	oldQuota := a.appliedQuotas[localPath]
 	isUpdate := oldQuota > 0 && oldQuota != sizeBytes
 
-	if isUpdate && sizeBytes < oldQuota {
-		enforcedBytes := quota.ExpectedEnforcedBytes(a.fsType, sizeBytes)
+	// currentEnforced is what the shrink guard below treats as "the real
+	// quota already in force for this claim." Prefer appliedQuotas
+	// (oldQuota): it's this process's own record of its last successful
+	// apply, exact down to the raw byte value. Only fall back to
+	// priorEnforcedFromDisk -- a one-time snapshot of the real on-disk
+	// report taken during Run()'s startup sequence, before the first sync
+	// -- when appliedQuotas has no entry at all. That fallback closes a
+	// real gap an independent review caught: appliedQuotas is purely
+	// in-memory, so oldQuota reads as 0 for the first touch of every claim
+	// in a fresh process, including one whose on-disk quota was already
+	// lower than current usage before this process ever started -- gating
+	// the shrink guard on oldQuota alone let that exact case bypass it
+	// entirely.
+	//
+	// The snapshot is taken once in Run(), not lazily here on first use:
+	// an earlier version called primeAppliedQuotasFromDiskOnce from this
+	// function instead, which works for a real restart but silently
+	// injects an extra quota-report subprocess call the first time any
+	// test drives ensureQuota/syncAllQuotas directly without going through
+	// Run() (most of this package's tests do exactly that) -- breaking
+	// fake-runner tests that count or order-inject failures on specific
+	// calls (TestPVReconcileQueueRetriesFailedItems) and, at production
+	// scale, turning a burst of many first-touches (many new PVs created
+	// at once) into one report fetch each instead of the one total a
+	// single Run()-time snapshot costs (TestWatchPVsEventStormAtScale
+	// caught that as a 10s timeout). A test that wants this fallback
+	// populated calls primeAppliedQuotasFromDiskOnce itself, the same way
+	// Run() does, rather than relying on it firing implicitly.
+	currentEnforced := uint64(oldQuota)
+	if currentEnforced == 0 {
+		currentEnforced = a.priorEnforcedFromDisk[localPath]
+	}
+
+	enforcedBytes := quota.ExpectedEnforcedBytes(a.fsType, sizeBytes)
+	if currentEnforced > 0 && uint64(enforcedBytes) < currentEnforced {
 		if used, ok := a.currentUsageBytes(localPath); ok && used > uint64(enforcedBytes) {
 			shrinkErr := fmt.Errorf("%w: new quota %s (enforced as %s) is below current usage %s for PV %s",
 				errUnsafeShrink, util.FormatBytes(sizeBytes), util.FormatBytes(enforcedBytes), util.FormatBytes(int64(used)), pv.Name)
@@ -1085,7 +1141,7 @@ func (a *QuotaAgent) ensureQuotaMutated(ctx context.Context, pv *v1.PersistentVo
 			a.updateQuotaStatus(ctx, pv, QuotaStatusFailed, 0)
 			slog.Warn("Refusing quota decrease below current usage",
 				"pv", pv.Name, "path", localPath,
-				"currentQuota", util.FormatBytes(oldQuota), "requestedQuota", util.FormatBytes(sizeBytes),
+				"currentEnforced", util.FormatBytes(int64(currentEnforced)), "requestedQuota", util.FormatBytes(sizeBytes),
 				"currentUsage", util.FormatBytes(int64(used)))
 			return false, shrinkErr
 		}
@@ -1173,6 +1229,38 @@ func (a *QuotaAgent) currentUsageBytes(localPath string) (used uint64, ok bool) 
 		}
 	}
 	return 0, false
+}
+
+// primeAppliedQuotasFromDiskOnce populates priorEnforcedFromDisk from one
+// filesystem-wide quota report read, the first time (and only the first
+// time, across this process's whole lifetime) it's called -- see
+// priorEnforcedFromDisk's doc comment on the QuotaAgent struct for why
+// ensureQuotaMutated's shrink guard needs this. Called from Run() before
+// the first sync, while no other goroutine can be touching agent state
+// yet -- still takes a.mu itself around the map write, both for
+// correctness if that ever changes and because a test simulating a
+// restart (constructing a fresh *QuotaAgent directly, as most of this
+// package's tests do) calls this the same way Run() does, with no such
+// guarantee. A report read failure leaves priorEnforcedFromDisk empty
+// rather than retrying on every subsequent call: this is a best-effort
+// snapshot for the restart case, not a mechanism the guard depends on for
+// its default (report-readable) behavior, and a one-time miss shouldn't
+// turn into a permanent per-call retry cost.
+func (a *QuotaAgent) primeAppliedQuotasFromDiskOnce() {
+	a.primeOnce.Do(func() {
+		usages, err := status.GetDirUsages(a.nfsBasePath, a.fsType, a.projectsFile, a.projidFile)
+		if err != nil {
+			slog.Warn("Could not prime the shrink guard's on-disk quota snapshot at startup", "error", err)
+			return
+		}
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		for _, u := range usages {
+			if u.Quota > 0 {
+				a.priorEnforcedFromDisk[u.Path] = u.Quota
+			}
+		}
+	})
 }
 
 // nfsPathToLocal converts NFS server path to local mount path. Delegates to

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1370,6 +1370,82 @@ func TestEnsureQuota_RefusesShrinkBelowCurrentUsage(t *testing.T) {
 	}
 }
 
+// TestEnsureQuota_RestartDoesNotBypassShrinkGuard guards a real gap an
+// independent review caught: gating the shrink guard on
+// appliedQuotas[localPath] (isUpdate/oldQuota) means the guard reads as
+// "not an update, don't check" for the first touch of every claim in a
+// fresh process, since appliedQuotas is a purely in-memory cache that
+// starts empty on every restart -- including a restart where the on-disk
+// quota was already lower than current usage before the process even
+// started. This builds two independent *QuotaAgent instances sharing
+// nothing but the same on-disk directory/projects file and the same fake
+// kernel state, exactly like TestSyncAllQuotas_RestartWithFreshCacheReconcilesDriftedQuota
+// does for the convergence property -- process 2's appliedQuotas is
+// empty, but the real on-disk quota process 1 applied must still be
+// visible to the guard.
+func TestEnsureQuota_RestartDoesNotBypassShrinkGuard(t *testing.T) {
+	runner, state := xfsHappyRunnerWithState()
+	withFakeRunner(t, runner)
+
+	pv := newBoundPV("pv-1", "/exports/pvc-1", 1)
+	base := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(base, "pvc-1"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	client := fake.NewSimpleClientset(pv)
+
+	newAgent := func() *QuotaAgent {
+		a := NewQuotaAgent(client, base, "/exports", "example.com/nfs")
+		a.SetProjectsFile(filepath.Join(base, "projects"))
+		a.SetProjidFile(filepath.Join(base, "projid"))
+		a.SetStateDir(t.TempDir())
+		a.fsType = quota.FSTypeXFS
+		return a
+	}
+
+	ctx := context.Background()
+
+	// "Process 1": establishes a real 1,048,576-byte (1MiB, a clean KB
+	// multiple so xfs's KB-flooring doesn't shift the value) quota on
+	// disk.
+	a1 := newAgent()
+	if err := a1.ensureQuota(ctx, pv, 1_048_576); err != nil {
+		t.Fatalf("process 1 initial apply: %v", err)
+	}
+
+	// Real usage that would make a shrink to 100,000 unsafe.
+	state.setUsedBytes(500_000)
+
+	// "Process 2": a brand new QuotaAgent -- appliedQuotas starts empty,
+	// exactly like a real restart. It has no cached memory of the
+	// 1,048,576-byte quota process 1 applied, but the real on-disk quota
+	// (via the shared projects/projid files and fake kernel state) still
+	// reflects it. primeAppliedQuotasFromDiskOnce is called explicitly
+	// here because this test constructs the agent directly instead of
+	// going through Run(), which is what actually calls it in production
+	// (see agent.go's Run() and priorEnforcedFromDisk's doc comment for
+	// why it isn't called lazily from inside ensureQuotaMutated instead).
+	a2 := newAgent()
+	a2.primeAppliedQuotasFromDiskOnce()
+	err := a2.ensureQuota(ctx, pv, 100_000)
+	if err == nil {
+		t.Fatalf("expected the shrink to be refused even with an empty appliedQuotas cache (restart)")
+	}
+	if !errors.Is(err, errUnsafeShrink) {
+		t.Fatalf("expected errUnsafeShrink, got %v", err)
+	}
+
+	state.mu.Lock()
+	var onDisk int64
+	for _, bytes := range state.applied {
+		onDisk = bytes
+	}
+	state.mu.Unlock()
+	if onDisk != 1_048_576 {
+		t.Fatalf("on-disk quota after refused restart shrink = %d, want unchanged 1048576", onDisk)
+	}
+}
+
 // TestEnsureQuota_AllowsShrinkAboveCurrentUsage is the companion regression
 // test: a decrease that stays above actual usage is a normal, legitimate
 // shrink and must still be applied -- the guard must not over-trigger on
@@ -1393,6 +1469,41 @@ func TestEnsureQuota_AllowsShrinkAboveCurrentUsage(t *testing.T) {
 	}
 	if got := a.appliedQuotas[localPath]; got != 500_000 {
 		t.Fatalf("appliedQuotas after safe shrink = %d, want 500000", got)
+	}
+}
+
+// TestEnsureQuota_AllowsGrowThatDoesNotFullyClearOverQuota is the other
+// side of the currentEnforced comparison the restart fix introduced: an
+// *increase* relative to the current on-disk quota must never be blocked
+// just because usage still exceeds it afterward -- the volume was already
+// in that state before this apply (the old, even lower, quota already
+// couldn't accommodate it), so applying a larger-but-still-insufficient
+// quota is strictly an improvement, not a new problem this guard exists to
+// prevent. A naive "block whenever used > new enforced" check (without
+// comparing against what's currently enforced) would wrongly reject this.
+func TestEnsureQuota_AllowsGrowThatDoesNotFullyClearOverQuota(t *testing.T) {
+	runner, state := xfsHappyRunnerWithState()
+	withFakeRunner(t, runner)
+	a, pv, _ := ensureQuotaFixture(t, 1)
+	a.fsType = quota.FSTypeXFS
+	ctx := context.Background()
+
+	if err := a.ensureQuota(ctx, pv, 100_000); err != nil {
+		t.Fatalf("initial ensureQuota: %v", err)
+	}
+
+	localPath := a.nfsPathToLocal("/exports/pvc-1")
+	// Usage already exceeds the 100,000-byte quota just applied -- project
+	// quota doesn't retroactively enforce, so this is a legitimate state.
+	state.setUsedBytes(150_000)
+
+	// A grow to 120,000: still below usage, but strictly larger than the
+	// 100,000 currently enforced. Must succeed.
+	if err := a.ensureQuota(ctx, pv, 120_000); err != nil {
+		t.Fatalf("expected a grow that doesn't fully clear an existing over-quota condition to succeed, got %v", err)
+	}
+	if got := a.appliedQuotas[localPath]; got != 120_000 {
+		t.Fatalf("appliedQuotas after grow = %d, want 120000", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

An independent Codex review of today's session's merged work found a real HIGH-severity gap in PR #72's shrink guard: it gates on `appliedQuotas[localPath]` (`isUpdate`/`oldQuota`), a purely in-memory cache that starts empty on every process restart. `oldQuota` reads as `0` for the first touch of every claim in a fresh process — including a claim whose real on-disk quota was already lower than current usage before the process ever started — so `isUpdate` reads `false` and the guard never runs at all. Any restart followed by a QuotaPolicy-driven decrease could apply a quota already below current usage with zero safety check.

## Fix

Added `priorEnforcedFromDisk`, a one-time (`sync.Once`) snapshot of the real on-disk quota report taken in `Run()` before the first sync. The shrink guard falls back to it whenever `appliedQuotas` has no entry, so "is this actually a decrease" is judged against on-disk reality on a cold cache, not just against what this process happens to remember.

Two design iterations before landing here, both caught by running the full test suite:
- A lazy first-use snapshot inside `ensureQuotaMutated` broke `TestPVReconcileQueueRetriesFailedItems` (injects an extra report subprocess call that consumed a fake-runner's intended failure injection before the real apply attempt).
- Removing the `isUpdate` gate entirely and checking on every apply made `TestWatchPVsEventStormAtScale` time out (many new PVs at once, each paying for a fresh report fetch).

`Run()`-time snapshotting costs exactly one subprocess call total per process lifetime and never fires during direct `ensureQuota`/`syncAllQuotas` test calls that bypass `Run()`.

## Tests

- `TestEnsureQuota_RestartDoesNotBypassShrinkGuard`: two independent `*QuotaAgent` instances sharing only the same on-disk directory/state — process 1 applies, process 2 (fresh cache) attempts an unsafe shrink and must be refused.
- `TestEnsureQuota_AllowsGrowThatDoesNotFullyClearOverQuota`: an *increase* relative to the currently-enforced quota must never be blocked just because usage still exceeds it afterward.

Both mutation-tested — reverting the relevant comparison makes the corresponding test fail for the right reason.

## Verification

`go test -race -count=1 ./...` green across every package, run 3x consecutively to rule out the flakiness this fix itself was chasing. `gofmt -l .` / `go build ./...` / `go vet ./...` clean, `helm lint` clean (chart untouched).

## Test plan

- [x] `go test -race -count=1 ./...` green, run 3x
- [x] Mutation tests on both new assertions
- [x] `gofmt -l .`, `go vet ./...`, `helm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT