### PR TITLE
fix(quota): validateQuotaArg two more argv-bound paths an independent review caught

### DIFF
--- a/internal/quota/btrfs.go
+++ b/internal/quota/btrfs.go
@@ -70,6 +70,10 @@ func ApplyBtrfsQuota(path string, sizeBytes int64) error {
 
 // GetBtrfsQuotaReport parses btrfs qgroup show report
 func GetBtrfsQuotaReport(basePath string) (map[string]uint64, map[string]uint64, error) {
+	if err := validateQuotaArg("basePath", basePath); err != nil {
+		return nil, nil, err
+	}
+
 	output, err := defaultRunner.Run("btrfs", "qgroup", "show", "-re", "--raw", basePath)
 	if err != nil {
 		return make(map[string]uint64), make(map[string]uint64), fmt.Errorf("failed to run btrfs qgroup show: %w, output: %s", err, string(output))

--- a/internal/quota/btrfs_test.go
+++ b/internal/quota/btrfs_test.go
@@ -153,6 +153,25 @@ func TestApplyBtrfsQuota(t *testing.T) {
 	})
 }
 
+// TestGetBtrfsQuotaReport_InvalidArgument guards a real inconsistency an
+// independent review caught: GetXFSQuotaReport/GetExt4QuotaReport both
+// validate basePath before it reaches argv, but GetBtrfsQuotaReport never
+// did -- despite basePath being the exact same kind of operator-configured
+// value in all three (report.go's GetXFSQuotaReport/GetExt4QuotaReport
+// mirror this same assertion for their own basePath parameter).
+func TestGetBtrfsQuotaReport_InvalidArgument(t *testing.T) {
+	r := &fakeRunner{}
+	withFakeRunner(t, r)
+
+	_, _, err := GetBtrfsQuotaReport("/data/proj ect")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("expected zero calls, got %d", len(r.calls))
+	}
+}
+
 func TestGetBtrfsQuotaReport(t *testing.T) {
 	t.Run("well-formed output", func(t *testing.T) {
 		r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {

--- a/internal/quota/ext4.go
+++ b/internal/quota/ext4.go
@@ -83,6 +83,20 @@ func ApplyExt4Quota(quotaPath, path, projectName string, projectID uint32, sizeB
 				return nil // skip errors, continue walking
 			}
 			if d.IsDir() {
+				// p is a real directory entry under path, not
+				// operator-supplied text, but a tenant writing into their
+				// own volume still controls subdirectory names -- pass it
+				// through the same argv-safety gate every other value
+				// reaching defaultRunner.Run in this package does, rather
+				// than assuming a discovered filesystem path can't need
+				// it. A name that fails validation is skipped (not a walk
+				// failure): the entry just doesn't get +P set, same
+				// no-op-and-continue outcome as any other chattr failure
+				// on one entry here.
+				if err := validateQuotaArg("path", p); err != nil {
+					slog.Debug("skipping chattr for entry with an invalid path", "path", p, "error", err)
+					return nil
+				}
 				if _, chErr := defaultRunner.Run("chattr", "+P", "-p", fmt.Sprintf("%d", projectID), p); chErr != nil {
 					slog.Debug("chattr failed for entry", "path", p, "error", chErr)
 				} else if p == path {

--- a/internal/quota/ext4_test.go
+++ b/internal/quota/ext4_test.go
@@ -18,6 +18,7 @@ package quota
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -147,6 +148,60 @@ func TestApplyExt4Quota(t *testing.T) {
 		}
 		if setquotaCalls != 1 {
 			t.Errorf("expected 1 setquota call, got %d", setquotaCalls)
+		}
+	})
+
+	t.Run("skips an invalid path discovered during the walk fallback instead of passing it to chattr", func(t *testing.T) {
+		// A subdirectory name a tenant wrote into their own volume can
+		// legally contain a space, even though validateQuotaArg rejects
+		// it as an argv value -- #7's independent review flagged this
+		// walk fallback as reaching defaultRunner.Run with a discovered
+		// path that was never validated. This must skip that one entry
+		// (not fail the walk, not pass the invalid path to chattr), while
+		// still successfully projecting the root and every valid entry.
+		dir := t.TempDir()
+		projPath := filepath.Join(dir, "projdir")
+		if err := makeDirWithSubdir(projPath); err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		badSubdir := filepath.Join(projPath, "bad dir")
+		if err := os.MkdirAll(badSubdir, 0o755); err != nil {
+			t.Fatalf("mkdir bad subdir: %v", err)
+		}
+
+		r := &fakeRunner{fn: func(name string, args ...string) ([]byte, error) {
+			if name == "chattr" && containsArg(args, "-R") {
+				return []byte("chattr -R failed"), errors.New("boom")
+			}
+			return []byte("ok"), nil
+		}}
+		withFakeRunner(t, r)
+
+		err := ApplyExt4Quota("/data", projPath, "proj-invalid-walk", 2010, 1024,
+			filepath.Join(dir, "projects"), filepath.Join(dir, "projid"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		for _, c := range r.calls {
+			if c.name != "chattr" {
+				continue
+			}
+			for _, arg := range c.args {
+				if arg == badSubdir {
+					t.Fatalf("chattr was called with the invalid path %q, want it skipped", badSubdir)
+				}
+			}
+		}
+
+		var rootProjected bool
+		for _, c := range r.calls {
+			if c.name == "chattr" && containsArg(c.args, projPath) {
+				rootProjected = true
+			}
+		}
+		if !rootProjected {
+			t.Fatalf("expected the root directory to still be chattr'd despite the invalid sibling entry")
 		}
 	})
 


### PR DESCRIPTION
## Summary

CLAUDE.md's own stated policy: "In internal/quota, a bare exec.Command, or an operator-controlled string reaching argv without passing validateQuotaArg, is a defect regardless of what the tests say." An independent Codex review of today's session's merged work found two instances.

- **`internal/quota/ext4.go`**: `ApplyExt4Quota`'s `chattr -R` fallback walks the target directory and shells out `chattr +P -p <id> <p>` per subdirectory found — `p` is a real filesystem path a tenant writing into their own volume can still name arbitrarily, and nothing validated it before argv, unlike every other value reaching argv in this package. Now skipped (not passed to `chattr`) if invalid.
- **`internal/quota/btrfs.go`**: `GetBtrfsQuotaReport` never validated `basePath` at all, unlike its exact counterparts `GetXFSQuotaReport`/`GetExt4QuotaReport`, which both validate the same parameter. Now matches.

Both are pre-existing gaps surfaced by an independent review looking at the btrfs code path #13's Drifted condition (PR #70) now exercises more often — not something introduced by today's other PRs.

**Not fixed here** (flagged as a follow-up): `ApplyBtrfsQuota`/`CheckBtrfsQuotaAvailable` and `CheckXFSQuotaAvailable`/`CheckExt4QuotaAvailable` also don't validate their path parameters — left out to keep this PR reviewable, since those are operator-configured deployment-time constants (`--quota-path`), not per-claim paths, and the existing `CheckXFSQuotaAvailable` gap shows this is a pre-existing repo-wide pattern.

## Tests

- `TestApplyExt4Quota`'s new subtest: a directory tree with one valid and one invalid ("bad dir") subdirectory name — asserts `chattr` is never called with the invalid path while valid entries still get projected.
- `TestGetBtrfsQuotaReport_InvalidArgument`: mirrors `TestGetXFSQuotaReport_InvalidArgument` exactly.

Both mutation-tested — removing the corresponding `validateQuotaArg` call makes the new test fail for the right reason.

## Verification

`go test -race -count=1 ./...` green across every package. `gofmt -l .` / `go build ./...` / `go vet ./...` clean, `helm lint` clean (chart untouched). No existing test needed changes.

## Test plan

- [x] `go test -race -count=1 ./...` green
- [x] Mutation tests on both new assertions
- [x] `gofmt -l .`, `go vet ./...`, `helm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT