### PR TITLE
fix(quota): validateQuotaArg the remaining unvalidated argv paths in the package

### DIFF
--- a/internal/quota/btrfs.go
+++ b/internal/quota/btrfs.go
@@ -26,6 +26,9 @@ import (
 
 // CheckBtrfsQuotaAvailable checks if btrfs binary is available and quotas are enabled
 func CheckBtrfsQuotaAvailable(quotaPath string) error {
+	if err := validateQuotaArg("quotaPath", quotaPath); err != nil {
+		return err
+	}
 	if _, err := defaultRunner.Run("btrfs", "--version"); err != nil {
 		return fmt.Errorf("btrfs command not found: %w", err)
 	}
@@ -45,6 +48,10 @@ func CheckBtrfsQuotaAvailable(quotaPath string) error {
 
 // ApplyBtrfsQuota applies btrfs subvolume quota
 func ApplyBtrfsQuota(path string, sizeBytes int64) error {
+	if err := validateQuotaArg("path", path); err != nil {
+		return err
+	}
+
 	// Require target dir to be a subvolume
 	output, err := defaultRunner.Run("btrfs", "subvolume", "show", path)
 	if err != nil {

--- a/internal/quota/btrfs_test.go
+++ b/internal/quota/btrfs_test.go
@@ -78,6 +78,22 @@ func TestCheckBtrfsQuotaAvailable(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("invalid quotaPath returns error and zero exec calls", func(t *testing.T) {
+		r := &fakeRunner{}
+		withFakeRunner(t, r)
+
+		err := CheckBtrfsQuotaAvailable("/data proj")
+		if err == nil {
+			t.Fatal("expected error from quotaPath validation")
+		}
+		if !strings.Contains(err.Error(), "invalid quotaPath") {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("expected zero exec calls, got %d", len(r.calls))
+		}
+	})
 }
 
 func TestApplyBtrfsQuota(t *testing.T) {
@@ -149,6 +165,22 @@ func TestApplyBtrfsQuota(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "failed to set btrfs quota limit") {
 			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid path returns error and zero exec calls", func(t *testing.T) {
+		r := &fakeRunner{}
+		withFakeRunner(t, r)
+
+		err := ApplyBtrfsQuota("/data/proj ect", 10737418240)
+		if err == nil {
+			t.Fatal("expected error from path validation")
+		}
+		if !strings.Contains(err.Error(), "invalid path") {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("expected zero exec calls, got %d", len(r.calls))
 		}
 	})
 }

--- a/internal/quota/detect.go
+++ b/internal/quota/detect.go
@@ -32,6 +32,10 @@ const (
 
 // DetectFSType detects filesystem type using df -T
 func DetectFSType(path string) (string, error) {
+	if err := validateQuotaArg("path", path); err != nil {
+		return "", err
+	}
+
 	output, err := defaultRunner.Run("df", "-T", path)
 	if err != nil {
 		return "", err
@@ -57,6 +61,10 @@ func DetectFSType(path string) (string, error) {
 
 // DetectFSTypeWithFindmnt detects filesystem type using findmnt (more reliable)
 func DetectFSTypeWithFindmnt(path string) (string, error) {
+	if err := validateQuotaArg("path", path); err != nil {
+		return "", err
+	}
+
 	output, err := defaultRunner.Run("findmnt", "-n", "-o", "FSTYPE", path)
 	if err != nil {
 		// Fallback to df -T

--- a/internal/quota/detect_test.go
+++ b/internal/quota/detect_test.go
@@ -95,6 +95,19 @@ func TestDetectFSType(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("invalid path returns error and zero exec calls", func(t *testing.T) {
+		r := &fakeRunner{}
+		withFakeRunner(t, r)
+
+		_, err := DetectFSType("/data proj")
+		if err == nil {
+			t.Fatal("expected error from path validation")
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("expected zero exec calls, got %d", len(r.calls))
+		}
+	})
 }
 
 func TestDetectFSTypeWithFindmnt(t *testing.T) {
@@ -164,6 +177,19 @@ func TestDetectFSTypeWithFindmnt(t *testing.T) {
 
 		if _, err := DetectFSTypeWithFindmnt("/data"); err == nil {
 			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("invalid path returns error and zero exec calls", func(t *testing.T) {
+		r := &fakeRunner{}
+		withFakeRunner(t, r)
+
+		_, err := DetectFSTypeWithFindmnt("/data proj")
+		if err == nil {
+			t.Fatal("expected error from path validation")
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("expected zero exec calls, got %d", len(r.calls))
 		}
 	})
 }

--- a/internal/quota/ext4.go
+++ b/internal/quota/ext4.go
@@ -26,6 +26,9 @@ import (
 
 // CheckExt4QuotaAvailable checks if quota tools are available for ext4
 func CheckExt4QuotaAvailable(quotaPath string) error {
+	if err := validateQuotaArg("quotaPath", quotaPath); err != nil {
+		return err
+	}
 	// Check if quotactl/setquota command is available
 	if _, err := defaultRunner.Run("setquota", "-V"); err != nil {
 		return fmt.Errorf("setquota command not found (install quota package): %w", err)
@@ -48,6 +51,9 @@ func CheckExt4QuotaAvailable(quotaPath string) error {
 
 // ApplyExt4Quota applies ext4 project quota
 func ApplyExt4Quota(quotaPath, path, projectName string, projectID uint32, sizeBytes int64, projectsFile, projidFile string) error {
+	if err := validateQuotaArg("quotaPath", quotaPath); err != nil {
+		return err
+	}
 	if err := validateQuotaArg("path", path); err != nil {
 		return err
 	}

--- a/internal/quota/ext4_test.go
+++ b/internal/quota/ext4_test.go
@@ -81,6 +81,22 @@ func TestCheckExt4QuotaAvailable(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("invalid quotaPath returns error and zero exec calls", func(t *testing.T) {
+		r := &fakeRunner{}
+		withFakeRunner(t, r)
+
+		err := CheckExt4QuotaAvailable("/data proj")
+		if err == nil {
+			t.Fatal("expected error from quotaPath validation")
+		}
+		if !strings.Contains(err.Error(), "invalid quotaPath") {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("expected zero exec calls, got %d", len(r.calls))
+		}
+	})
 }
 
 func TestApplyExt4Quota(t *testing.T) {
@@ -309,6 +325,23 @@ func TestApplyExt4Quota(t *testing.T) {
 			t.Fatal("expected error from name validation")
 		}
 		if !strings.Contains(err.Error(), "invalid projectName") {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("expected zero exec calls, got %d", len(r.calls))
+		}
+	})
+
+	t.Run("invalid quotaPath returns error and zero exec calls", func(t *testing.T) {
+		r := &fakeRunner{}
+		withFakeRunner(t, r)
+
+		dir := t.TempDir()
+		err := ApplyExt4Quota("/data proj", "/data/proj6", "proj6", 2006, 1024, filepath.Join(dir, "projects"), filepath.Join(dir, "projid"))
+		if err == nil {
+			t.Fatal("expected error from quotaPath validation")
+		}
+		if !strings.Contains(err.Error(), "invalid quotaPath") {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if len(r.calls) != 0 {

--- a/internal/quota/project.go
+++ b/internal/quota/project.go
@@ -462,6 +462,9 @@ func RemoveQuotaByID(basePath, fsType, projectID string) error {
 	if err := validateQuotaArg("basePath", basePath); err != nil {
 		return err
 	}
+	if err := validateQuotaArg("projectID", projectID); err != nil {
+		return err
+	}
 
 	switch fsType {
 	case FSTypeXFS:

--- a/internal/quota/project_test.go
+++ b/internal/quota/project_test.go
@@ -806,6 +806,25 @@ func TestRemoveQuotaByID(t *testing.T) {
 			t.Errorf("expected zero exec calls, got %d", len(r.calls))
 		}
 	})
+
+	t.Run("invalid projectID returns error and zero exec calls", func(t *testing.T) {
+		// projectID is a string here (unlike ApplyXFSQuota/ApplyExt4Quota's
+		// numeric projectID), sourced from callers that may have parsed it
+		// out of /etc/projid content -- an independent review found it
+		// reaching xfs_quota/setquota argv unvalidated at both call sites.
+		r := &fakeRunner{}
+		withFakeRunner(t, r)
+		err := RemoveQuotaByID("/data", FSTypeXFS, "1001 extra")
+		if err == nil {
+			t.Fatal("expected error from projectID validation")
+		}
+		if !strings.Contains(err.Error(), "invalid projectID") {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("expected zero exec calls, got %d", len(r.calls))
+		}
+	})
 }
 
 // A rejected name must leave pre-existing content alone, not merely avoid

--- a/internal/quota/xfs.go
+++ b/internal/quota/xfs.go
@@ -24,6 +24,9 @@ import (
 
 // CheckXFSQuotaAvailable checks if xfs_quota command is available
 func CheckXFSQuotaAvailable(quotaPath string) error {
+	if err := validateQuotaArg("quotaPath", quotaPath); err != nil {
+		return err
+	}
 	if _, err := defaultRunner.Run("xfs_quota", "-V"); err != nil {
 		return fmt.Errorf("xfs_quota command not found: %w", err)
 	}
@@ -44,6 +47,9 @@ func CheckXFSQuotaAvailable(quotaPath string) error {
 
 // ApplyXFSQuota applies XFS project quota
 func ApplyXFSQuota(quotaPath, path, projectName string, projectID uint32, sizeBytes int64, projectsFile, projidFile string) error {
+	if err := validateQuotaArg("quotaPath", quotaPath); err != nil {
+		return err
+	}
 	if err := validateQuotaArg("path", path); err != nil {
 		return err
 	}

--- a/internal/quota/xfs_test.go
+++ b/internal/quota/xfs_test.go
@@ -81,6 +81,22 @@ func TestCheckXFSQuotaAvailable(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("invalid quotaPath returns error and zero exec calls", func(t *testing.T) {
+		r := &fakeRunner{}
+		withFakeRunner(t, r)
+
+		err := CheckXFSQuotaAvailable("/data proj")
+		if err == nil {
+			t.Fatal("expected error from quotaPath validation")
+		}
+		if !strings.Contains(err.Error(), "invalid quotaPath") {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("expected zero exec calls, got %d", len(r.calls))
+		}
+	})
 }
 
 func TestApplyXFSQuota(t *testing.T) {
@@ -230,6 +246,23 @@ func TestApplyXFSQuota(t *testing.T) {
 			t.Fatal("expected error from name validation")
 		}
 		if !strings.Contains(err.Error(), "invalid projectName") {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("expected zero exec calls, got %d", len(r.calls))
+		}
+	})
+
+	t.Run("invalid quotaPath returns error and zero exec calls", func(t *testing.T) {
+		r := &fakeRunner{}
+		withFakeRunner(t, r)
+
+		dir := t.TempDir()
+		err := ApplyXFSQuota("/data proj", "/data/proj6", "proj6", 1006, 1024, filepath.Join(dir, "projects"), filepath.Join(dir, "projid"))
+		if err == nil {
+			t.Fatal("expected error from quotaPath validation")
+		}
+		if !strings.Contains(err.Error(), "invalid quotaPath") {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if len(r.calls) != 0 {


### PR DESCRIPTION
## Summary

Follow-up to PR #79, which explicitly deferred the rest of this class of gap ("not fixed here") to keep that PR reviewable. A dedicated Codex sweep of every `defaultRunner.Run` call site in `internal/quota` found 12 real, currently-unfixed gaps across 9 function entry points — confirmed by direct code inspection before fixing, then independently re-reviewed against the final staged diff.

CLAUDE.md's own stated policy: "In internal/quota, a bare exec.Command, or an operator-controlled string reaching argv without passing validateQuotaArg, is a defect regardless of what the tests say."

## Fixed (one `validateQuotaArg` call per function entry, before its first `defaultRunner.Run`)

- `xfs.go`: `CheckXFSQuotaAvailable`'s `quotaPath`, `ApplyXFSQuota`'s `quotaPath`
- `ext4.go`: `CheckExt4QuotaAvailable`'s `quotaPath`, `ApplyExt4Quota`'s `quotaPath`
- `btrfs.go`: `CheckBtrfsQuotaAvailable`'s `quotaPath`, `ApplyBtrfsQuota`'s `path`
- `detect.go`: `DetectFSType`'s `path`, `DetectFSTypeWithFindmnt`'s `path`
- `project.go`: `RemoveQuotaByID`'s `projectID` (a string here, unlike `ApplyXFSQuota`/`ApplyExt4Quota`'s numeric `projectID`, and can originate from parsed `/etc/projid` content)

These are operator-configured (`--quota-path`) or filesystem-report-derived values rather than directly attacker-controlled PV/PVC annotation content — lower practical risk than PR #79's fixes — but every one of these functions has a sibling in the same package that already validates the equivalent parameter, so this was also an internal inconsistency.

## Tests

One "invalid `<param>` returns error and zero exec calls" subtest per fixed function, matching the existing style exactly. Two representative mutations verified (`RemoveQuotaByID`'s `projectID`, `DetectFSType`'s `path`) — removing the corresponding check makes the new subtest fail for the right reason.

## Verification

`go test -race -count=1 ./...` green across every package (9 new subtests, no existing test needed changes). `gofmt -l .` / `go build ./...` / `go vet ./...` clean, `helm lint` clean. **Independent Codex review of the final staged diff: PASS** on placement, behavior-preservation, test correctness, and completeness.

## Test plan

- [x] `go test -race -count=1 ./...` green
- [x] Mutation tests on 2 representative fixes
- [x] Independent Codex review: PASS
- [x] `gofmt -l .`, `go vet ./...`, `helm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rLX59BybTETYhfqxuqovT