### PR TITLE
docs: make filesystem enforcement the adoption contract

### DIFF
--- a/docs/ADOPTION-GUIDE.md
+++ b/docs/ADOPTION-GUIDE.md
@@ -1,0 +1,45 @@
+# NFS Quota Agent Adoption Guide
+
+> First success is **filesystem quota enforcement**, not merely a running DaemonSet.
+
+## 1. Preconditions
+
+Use an NFS server node with a supported local filesystem and the quota feature enabled for that filesystem. Constrain the DaemonSet to the actual NFS server nodes; the project requires privileged host access and should not be scheduled broadly.
+
+Implemented backends are summarized in `docs/IMPLEMENTATION-STATUS.md`: XFS project quota, ext4 project quota, and Btrfs qgroup quota.
+
+## 2. Minimal adoption flow
+
+1. Install/configure the Helm chart for the NFS server path and provisioner in use.
+2. Confirm the agent is running only on the intended server node(s).
+3. Create a test PVC/PV through the supported NFS path.
+4. Confirm the PV receives quota status and the agent reports `applied` rather than only discovering the volume.
+5. Write data beyond the requested capacity from a test workload.
+6. Verify the filesystem refuses growth at the configured quota boundary.
+7. Inspect Prometheus/audit evidence if enabled.
+
+The test is incomplete if it stops at `kubectl get pvc` or pod readiness.
+
+## 3. Evidence classes
+
+Keep these claims separate:
+
+- unit/stubbed command-runner tests;
+- built-container capability checks for required filesystem commands;
+- Kubernetes integration evidence;
+- real quota-enabled filesystem enforcement E2E.
+
+Only the last class proves actual quota enforcement.
+
+## 4. Read next
+
+- `docs/IMPLEMENTATION-STATUS.md` — implemented capabilities
+- `docs/architecture.md` — architecture
+- `docs/feature-guide.md` — features and configuration
+- `docs/security.md` — privileged/runtime boundary
+- `docs/ha-dr.md` — resilience
+- `docs/quotapolicy-design.md` — advisory policy design
+
+## 5. Known boundary
+
+Namespace policy views are advisory and do not replace PV-capacity-to-filesystem-quota enforcement. Changes to host paths, privileged permissions, project-ID mapping, filesystem command construction, or exported APIs require stronger review and runtime evidence.

--- a/docs/ADOPTION-GUIDE.md
+++ b/docs/ADOPTION-GUIDE.md
@@ -6,7 +6,7 @@
 
 Use an NFS server node with a supported local filesystem and the quota feature enabled for that filesystem. Constrain the DaemonSet to the actual NFS server nodes; the project requires privileged host access and should not be scheduled broadly.
 
-Implemented backends are summarized in `docs/IMPLEMENTATION-STATUS.md`: XFS project quota, ext4 project quota, and Btrfs qgroup quota.
+Implemented backends are summarized in the README's [Supported Filesystems](../README.md#supported-filesystems) table and kept current, per-backend, in `hack/compatibility-matrix.json`: XFS project quota, ext4 project quota, and Btrfs qgroup quota.
 
 ## 2. Minimal adoption flow
 
@@ -33,7 +33,7 @@ Only the last class proves actual quota enforcement.
 
 ## 4. Read next
 
-- `docs/IMPLEMENTATION-STATUS.md` — implemented capabilities
+- `README.md` ([Supported Filesystems](../README.md#supported-filesystems)) and `hack/compatibility-matrix.json` — implemented capabilities
 - `docs/architecture.md` — architecture
 - `docs/feature-guide.md` — features and configuration
 - `docs/security.md` — privileged/runtime boundary


### PR DESCRIPTION
## Summary
Add an adoption guide centered on the actual product outcome: server-side filesystem quota enforcement.

Separates stub/unit, container capability, Kubernetes integration, and real filesystem E2E evidence.

Part of the 2026-08 CnE OSS portfolio documentation review.