### PR TITLE
ci(security): add positive-control negative egress check

### DIFF
--- a/.agents/evals/traces/2026-09-negative-egress-positive-control.json
+++ b/.agents/evals/traces/2026-09-negative-egress-positive-control.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": "openforge-agent-trace/v1",
+  "consistencyMode": "strict",
+  "traceId": "nfs-quota-agent-issue-26-negative-egress-positive-control",
+  "task": "Redesign the negative CI egress check so it proves the harden-runner block actually works, instead of passing vacuously (#26)",
+  "changeContext": {
+    "paths": [
+      ".github/workflows/ci.yaml",
+      "scripts/ci/check-egress-block.sh",
+      "scripts/ci/test-check-egress-block.sh",
+      ".agents/**"
+    ]
+  },
+  "events": [
+    {
+      "id": "e1",
+      "type": "external_input",
+      "summary": "Read gh issue view 26 --comments in full. The Codex/GPT advisory pass proposed item 8: a go:generate fixture that attempts a TCP/HTTPS connection to an unallowlisted controlled endpoint and writes a sentinel only on success, with a dedicated harden-runner block job asserting the sentinel is absent. A separate independent review pass on the same issue thread (different context, same repo owner) rejected this design by name: 'go build/go test do not execute go:generate directives by definition, so a sentinel-absent assertion passes forever whether or not harden-runner is even present -- it re-confirms Go toolchain semantics, not the egress boundary. Sentinel absence is also multi-valued: egress block, dead test endpoint, DNS hiccup, fixture typo, or command never running all look identical.' The same review named the fix: a positive control proving an allowed destination is reachable, a local listener instead of an external allowed target being acceptable, and deletion of any go build/go test assertion. This task implements exactly that correction, not the original item-8 design",
+      "provenance": "gh issue view 26 --comments (dasomel, repo owner, association: owner) -- two comments: the Codex advisory design pass and the independent review pass that rejected item 8",
+      "reviewed": true
+    },
+    {
+      "id": "e2",
+      "type": "scope_check",
+      "summary": "Scoped to appending one new job (Egress Block Positive Control) to .github/workflows/ci.yaml, a new scripts/ci/check-egress-block.sh plus its scripts/ci/test-check-egress-block.sh sibling, and this trace. No prior negative-egress code existed anywhere in git history (git log --all --oneline | grep -iE 'negative|egress' shows only the unrelated License Check egress-diagnosis fix, #95) -- this is new code, not a fix to a landed vacuous test. Did not touch release.yaml (still audit mode per #26's own decision record, unrelated to this job), did not touch any other ci.yaml job or its allowed-endpoints, and did not add scripts/ci/check-go-generate.py (the review's secondary, independent suggestion; out of scope for this task, which is 'part of #26' for the negative-egress redesign specifically). No doc under docs/ or SECURITY.md/CONTRIBUTING.md describes the egress-check mechanics at a level this change would make stale, so none were edited"
+    },
+    {
+      "id": "e3",
+      "type": "reproduction",
+      "summary": "Confirmed the vacuous-pass failure mode the review described is real by running the new script's own ci-mode logic locally, where egress is NOT blocked: bash scripts/ci/check-egress-block.sh ci printed 'egress-check negative-control: target=https://example.com result=http:200' and exited 1 with '::error::egress-check: NEGATIVE CONTROL FAILED -- non-allowlisted destination https://example.com was reachable'. This is the correct behavior (this script does distinguish the two states) and also demonstrates what a sentinel-only design cannot show: an absent-sentinel design run in this same unblocked environment would have produced no evidence either way, whereas this design produces an explicit, named failure",
+      "evidence": [
+        "cli:check-egress-block-ci-local-unblocked-fails-negative-control"
+      ]
+    },
+    {
+      "id": "e4",
+      "type": "bug_fix",
+      "summary": "scripts/ci/check-egress-block.sh implements probe(url) -> one of http:<code>|dns_failure|connection_refused|timeout|tls_failure|empty_reply|curl_error_<n> via curl exit codes, and three modes: `ci` (real check, run in the new harden-runner block job) probes a loopback listener for network-stack sanity, then the positive control (https://github.com, already required by every job's actions/checkout so it is a genuine allowlist member, not an invented exception) and the negative control (https://example.com, permanently absent from every allowlist in ci.yaml per a comment added to the file's top rationale block), failing with a distinctly worded error for whichever half misbehaves; `selftest` (runnable anywhere, no CI or blocked egress required) verifies the same probe()/is_reachable()/is_blocked() logic against a real local python3 http.server, a closed loopback port, and an RFC 2606 .invalid hostname; `probe URL [TIMEOUT]` is a thin seam printing one classification for the test sibling to drive with a faked curl. ci.yaml gained one appended job (Egress Block Positive Control, contents:read, harden-runner block with the same github.com/api.github.com/*.githubusercontent.com allowlist as the Dependency Review job) running the self-test then the real check, plus a top-of-file comment recording that example.com must stay off every allowlist in this file so the negative control keeps meaning something"
+    },
+    {
+      "id": "e5",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "scripts/ci/test-check-egress-block.sh: 12/12 assertions passed. 7 probe() classification cases driven by a faked curl on PATH (ok/dns/refused/timeout/tls/empty/unrecognized-exit-code), 4 run_ci() end-to-end cases via per-URL faked curl (both controls correct -> PASS; negative control reachable -> FAIL naming NEGATIVE CONTROL; positive control unreachable -> FAIL naming POSITIVE CONTROL; negative control gives an unrecognized curl exit -> FAIL naming it ambiguous, not treated as a block), and the script's real (unfaked) selftest mode exits 0 with '4 passed, 0 failed'. shellcheck reported nothing on either script (rc 0). Two bugs were caught and fixed during this verification itself, both in the test harness rather than the shipped script: python3 -m http.server's startup line sat in a stdout block buffer when redirected to a log file and was never seen by the poll loop (fixed with python3 -u); and a bash trap referencing a function-local variable after the function returned failed under set -u on script exit (fixed with ${loop_pid:-})",
+      "scope": "the shipped script's classification and control logic under emulated and real-but-unblocked curl/network conditions; whether harden-runner's real block behavior on a GitHub-hosted runner actually produces the connection_refused/dns_failure/timeout outcomes this script expects is explicitly not covered by this local run and is stated as unverified until observed on the actual CI job",
+      "evidence": [
+        "test:scripts/ci/test-check-egress-block.sh",
+        "lint:shellcheck"
+      ]
+    },
+    {
+      "id": "e6",
+      "type": "verification",
+      "status": "passed",
+      "summary": "python3 -c 'import yaml,sys;yaml.safe_load(...)' on .github/workflows/ci.yaml parsed cleanly; actionlint .github/workflows/ci.yaml exited 0 with no findings; python3 scripts/ci/check-mutable-inputs.py .github/workflows/ci.yaml passed for 1 file (the appended job's one action reference, actions/checkout, is the same already-pinned 40-char SHA used by every other job, so no new mutable input was introduced)",
+      "scope": "static shape and pin validity of the appended workflow job; does not run the workflow",
+      "evidence": [
+        "lint:yaml-safe-load",
+        "lint:actionlint",
+        "ci-guard:check-mutable-inputs"
+      ]
+    },
+    {
+      "id": "e7",
+      "type": "completion_claim",
+      "summary": "The negative egress check called out in #26 review as passing vacuously is redesigned with a positive control: scripts/ci/check-egress-block.sh's ci mode fails unless an allowlisted destination is reachable AND a permanently non-allowlisted one is not, both proven capable of failing (e3, e5) rather than assumed. Whether the new CI job actually observes harden-runner's real block behavior on GitHub's runners is confirmed by the CI run on this change's own pull request, not by local evidence alone"
+    },
+    {
+      "id": "e8",
+      "type": "task_outcome",
+      "state": "A",
+      "summary": "Complete at the self-test, local ci-mode, lint, and guard level per e5-e6; the real-runner observation of both control halves happening in the same job is confirmed via gh pr checks and the job's own log lines on this change's PR, not asserted from local evidence"
+    }
+  ]
+}

--- a/.agents/evals/traces/2026-09-negative-egress-positive-control.json
+++ b/.agents/evals/traces/2026-09-negative-egress-positive-control.json
@@ -100,10 +100,10 @@
       "id": "e11",
       "type": "verification",
       "status": "passed",
-      "summary": "Pushed the retry commit and re-watched PR #109 with gh pr checks 109 --watch: all jobs passed again including 'Egress Block Positive Control', and its log again showed both control halves distinctly (loopback-sanity and positive-control each logging one attempt before succeeding on the first try, negative-control still a single probe reported as blocked), confirming the retry code path did not change the job's real outcome on this run and did not need to actually retry to pass",
-      "scope": "one additional real CI run after the retry change; does not by itself demonstrate the retry recovering from a real transient failure, since none occurred on this run",
+      "summary": "Pushed the retry commit (92cbae2) and re-watched PR #109 with gh pr checks 109 --watch: all jobs passed again. Pulled the new run's log with gh run view 33602119896 --log --job 100157942554 | grep -i egress-check: loopback-sanity attempt 1/3 result=http:200, positive-control attempt 1/3 target=https://github.com result=http:200, negative-control (single probe, unchanged) target=https://example.com result=connection_refused, RESULT: PASS. Both control halves observed distinctly again; the retry succeeded on its first attempt so it did not need to actually retry to pass, confirming the retry code path did not change the job's real outcome on this run",
+      "scope": "one additional real CI run (33602119896, job 100157942554) after the retry change; does not by itself demonstrate the retry recovering from a real transient failure, since none occurred on this run",
       "evidence": [
-        "ci:pr-109-second-run-egress-check-log-lines"
+        "ci:pr-109-run-33602119896-job-100157942554-egress-check-log-lines"
       ]
     },
     {

--- a/.agents/evals/traces/2026-09-negative-egress-positive-control.json
+++ b/.agents/evals/traces/2026-09-negative-egress-positive-control.json
@@ -72,14 +72,50 @@
     },
     {
       "id": "e8",
-      "type": "completion_claim",
-      "summary": "The negative egress check called out in #26 review as passing vacuously is redesigned with a positive control: scripts/ci/check-egress-block.sh's ci mode fails unless an allowlisted destination is reachable AND a permanently non-allowlisted one is not, both proven capable of failing (e3, e5) and, per e7, proven correct against harden-runner's real block behavior on an actual GitHub-hosted runner -- the exact gap the rejected go:generate design left open"
+      "type": "external_input",
+      "summary": "An independent review pass of PR #109 (the merged-through-here diff, evaluated by a context that did not author it) returned PASS with one LOW-severity finding: probe() in check-egress-block.sh:31 (now the positive-control call site) is a single curl attempt with no retry, so a transient github.com delay or 5xx response fails the positive control and the whole CI run for a reason unrelated to egress policy. The finding explicitly scoped the fix: add a bounded retry to the positive control AND the loopback probe only, never the negative control -- a retry on the negative control would only widen the window for one transient successful connection to be mistaken for reachable, which is evidence bias in exactly the wrong direction for an error-detection check",
+      "provenance": "independent code-review pass on PR #109 (dasomel/nfs-quota-agent), relayed by the task coordinator with the finding's file:line and full rationale",
+      "reviewed": true
     },
     {
       "id": "e9",
+      "type": "bug_fix",
+      "summary": "Added probe_with_retry(url, timeout, attempts, sleep_s, label) to check-egress-block.sh: retries probe() up to RETRY_ATTEMPTS_DEFAULT=3 times with RETRY_SLEEP_DEFAULT=2s between attempts, logging every attempt's classification (to stderr, so it does not pollute the $(...) -captured final result) with the given label, returning as soon as an attempt is_reachable or the last classification once attempts are exhausted. run_ci() now calls it for the loopback sanity probe and the positive control; the negative control's `blocked_result=$(probe \"$blocked_url\")` call was left untouched -- still exactly one attempt, per the review's explicit instruction not to retry it. Module header comment and the function's own docstring both record why the negative control must never gain this retry",
+      "evidence": [
+        "diff:scripts/ci/check-egress-block.sh-probe_with_retry"
+      ]
+    },
+    {
+      "id": "e10",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "scripts/ci/test-check-egress-block.sh grew from 12 to 13 assertions and the shipped script's own selftest from 4 to 6 internal checks. New coverage: 2 selftest assertions (probe_with_retry returns immediately on a reachable first attempt; probe_with_retry exhausts all 3 attempts and returns the last classification when never reachable), replacing the 7 fixed run_ci_case calls' env-var wiring with an `env NAME=VALUE` pattern (a literal `\"$var\"=\"$val\"` prefix does not work as a dynamic-name assignment in bash -- confirmed by reproducing the exact 'command not found' failure before switching), a stateful FAKE_CURL_URL_<slug>_SEQ mode in the fake curl (comma-separated modes consumed one per call, clamped to the last entry, counter kept in FAKE_CURL_STATE_DIR) to simulate a flaky positive control across retries, and 2 new/changed run_ci_case rows: 'positive control fails twice then succeeds -> overall PASS' (SEQ dns,dns,ok) asserting both exit 0 and that a third attempt log line with the eventual http:200 appears, and 'positive control unreachable after all retry attempts' (constant dns) asserting POSITIVE CONTROL FAILED plus an explicit 'attempt 3/3' log line so the retry count itself is verified, not just the final verdict. All 13/13 passed; the negative control cases (both controls correct, negative reachable, ambiguous result) were re-run unchanged and still pass, confirming the retry addition did not alter negative-control behavior. shellcheck rc=0 on both scripts. bash scripts/ci/check-egress-block.sh ci re-run locally (egress unblocked) still correctly fails on the single-shot negative control, unaffected by the positive-control retry",
+      "scope": "the retry addition's effect on both scripts under emulated (faked curl) and real-but-unblocked local conditions; whether a real transient github.com failure recovers via this retry on an actual runner is not exercised by any local or faked case and remains to be observed only if such a transient failure happens to occur on a future CI run",
+      "evidence": [
+        "test:scripts/ci/test-check-egress-block.sh-13-assertions",
+        "lint:shellcheck"
+      ]
+    },
+    {
+      "id": "e11",
+      "type": "verification",
+      "status": "passed",
+      "summary": "Pushed the retry commit and re-watched PR #109 with gh pr checks 109 --watch: all jobs passed again including 'Egress Block Positive Control', and its log again showed both control halves distinctly (loopback-sanity and positive-control each logging one attempt before succeeding on the first try, negative-control still a single probe reported as blocked), confirming the retry code path did not change the job's real outcome on this run and did not need to actually retry to pass",
+      "scope": "one additional real CI run after the retry change; does not by itself demonstrate the retry recovering from a real transient failure, since none occurred on this run",
+      "evidence": [
+        "ci:pr-109-second-run-egress-check-log-lines"
+      ]
+    },
+    {
+      "id": "e12",
+      "type": "completion_claim",
+      "summary": "The negative egress check called out in #26 review as passing vacuously is redesigned with a positive control: scripts/ci/check-egress-block.sh's ci mode fails unless an allowlisted destination is reachable AND a permanently non-allowlisted one is not, both proven capable of failing (e3, e5) and, per e7, proven correct against harden-runner's real block behavior on an actual GitHub-hosted runner. Per e8-e11, the positive control and loopback probe now tolerate a bounded number of transient failures via retry, while the negative control was deliberately left single-shot so a real block failure cannot be masked by a lucky retry"
+    },
+    {
+      "id": "e13",
       "type": "task_outcome",
       "state": "A",
-      "summary": "Complete: self-test, local ci-mode, lint, and guard level (e5-e6) plus real-runner observation of both control halves passing correctly in the same job on PR #109's own CI run (e7). No remaining unverified claim about this task's core design goal; standard caveats are that this covers one runner/run and the specific github.com/example.com pair, not every allowlist configuration"
+      "summary": "Complete: self-test, local ci-mode, lint, and guard level (e5-e6, e10) plus real-runner observation of both control halves passing correctly across two separate CI runs on PR #109 (e7, e11), the second confirming the retry addition did not regress the negative control or the overall job outcome. No remaining unverified claim about this task's core design goal; standard caveats are that this covers two runs on one runner and the specific github.com/example.com pair, not every allowlist configuration, and that the retry's actual recovery behavior on a genuine transient failure has not been observed since none occurred during verification"
     }
   ]
 }

--- a/.agents/evals/traces/2026-09-negative-egress-positive-control.json
+++ b/.agents/evals/traces/2026-09-negative-egress-positive-control.json
@@ -62,14 +62,24 @@
     },
     {
       "id": "e7",
-      "type": "completion_claim",
-      "summary": "The negative egress check called out in #26 review as passing vacuously is redesigned with a positive control: scripts/ci/check-egress-block.sh's ci mode fails unless an allowlisted destination is reachable AND a permanently non-allowlisted one is not, both proven capable of failing (e3, e5) rather than assumed. Whether the new CI job actually observes harden-runner's real block behavior on GitHub's runners is confirmed by the CI run on this change's own pull request, not by local evidence alone"
+      "type": "verification",
+      "status": "passed",
+      "summary": "Opened PR #109 with this change and watched it with gh pr checks 109 --watch: every job passed including the new 'Egress Block Positive Control' job (15s). Pulled its log with gh run view 33600601202 --log --job 100153222515 | grep -i egress-check and observed, on a real GitHub-hosted runner under harden-runner egress-policy: block: loopback-sanity result=http:200, positive-control target=https://github.com result=http:200 (the allowlisted destination was reachable), negative-control target=https://example.com result=connection_refused (the non-allowlisted destination was not), and RESULT: PASS. This is the actual proof the redesign exists to provide: both halves of the control were observed distinctly, on the real block boundary, in the same job run -- not asserted from the local unblocked run in e3, which only showed the script can detect a missing block, not that harden-runner's real block produces the expected outcome",
+      "scope": "one real CI run's observation of the new job's positive and negative control outcomes under harden-runner's actual egress-policy: block on ubuntu-latest; does not establish this holds on every future run or every other allowlisted/non-allowlisted host pair",
+      "evidence": [
+        "ci:pr-109-run-33600601202-job-100153222515-egress-check-log-lines"
+      ]
     },
     {
       "id": "e8",
+      "type": "completion_claim",
+      "summary": "The negative egress check called out in #26 review as passing vacuously is redesigned with a positive control: scripts/ci/check-egress-block.sh's ci mode fails unless an allowlisted destination is reachable AND a permanently non-allowlisted one is not, both proven capable of failing (e3, e5) and, per e7, proven correct against harden-runner's real block behavior on an actual GitHub-hosted runner -- the exact gap the rejected go:generate design left open"
+    },
+    {
+      "id": "e9",
       "type": "task_outcome",
       "state": "A",
-      "summary": "Complete at the self-test, local ci-mode, lint, and guard level per e5-e6; the real-runner observation of both control halves happening in the same job is confirmed via gh pr checks and the job's own log lines on this change's PR, not asserted from local evidence"
+      "summary": "Complete: self-test, local ci-mode, lint, and guard level (e5-e6) plus real-runner observation of both control halves passing correctly in the same job on PR #109's own CI run (e7). No remaining unverified claim about this task's core design goal; standard caveats are that this covers one runner/run and the specific github.com/example.com pair, not every allowlist configuration"
     }
   ]
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,13 @@
 # release.yaml builds, without pushing, so a base-digest bump that drops a
 # pinned apk package version fails on every PR instead of only after a
 # release tag is pushed.
+# The Egress Block Positive Control job (#26) does not add new endpoints to
+# this file's allowlist inventory: its "allowed" target is github.com,
+# already required by every job's own actions/checkout, and its "blocked"
+# target (example.com) is deliberately kept off every allowlist in this
+# file forever -- if a future job ever needs to add example.com for a real
+# reason, this job's negative control must be repointed at a different
+# permanently-unlisted host first.
 name: CI
 
 on:
@@ -430,3 +437,41 @@ jobs:
           # The action otherwise queries OpenSSF Scorecard and deps.dev, which
           # are outside this job's evidence-backed GitHub-only allowlist.
           show-openssf-scorecard: false
+
+  egress-block-check:
+    name: Egress Block Positive Control
+    # Proves the harden-runner block above actually blocks egress, rather
+    # than asserting an absence that would be equally true if nothing ever
+    # tried to egress. An earlier design (#26) proposed a go:generate
+    # fixture attempting an external connection and checking for a missing
+    # sentinel; independent review rejected it as passing vacuously --
+    # "sentinel absent" is also what a dead test endpoint, a DNS hiccup, or
+    # a typo'd fixture produces, indistinguishable in the log from an
+    # actual block. scripts/ci/check-egress-block.sh instead runs a
+    # positive control (github.com:443, already required below for
+    # actions/checkout, so it is a real member of this job's own
+    # allowlist) alongside the negative control (example.com, deliberately
+    # absent from the allowlist) plus a loopback sanity probe, and fails
+    # unless the positive control is reachable AND the negative control is
+    # not -- either half misbehaving is a distinct, named failure.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            *.githubusercontent.com:443
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Self-test the egress check script's detection logic
+        run: bash scripts/ci/test-check-egress-block.sh
+
+      - name: Verify egress block has a working positive and negative control
+        run: bash scripts/ci/check-egress-block.sh ci

--- a/scripts/ci/check-egress-block.sh
+++ b/scripts/ci/check-egress-block.sh
@@ -12,6 +12,14 @@
 # behave correctly proves the block is doing its job; either half failing
 # is reported as a distinct, named failure so the log says which broke.
 #
+# The positive control and the loopback sanity probe are retried (bounded,
+# with a short sleep, each attempt logged) because a transient github.com
+# delay/5xx is a false negative unrelated to egress policy and would
+# otherwise fail the whole CI run. The negative control stays single-shot
+# on purpose: retrying it would only widen the window for one transient
+# success to be misread as reachable, biasing the check in the wrong
+# direction -- see the PR review that added this retry.
+#
 # Modes:
 #   ci        Real check for use inside a harden-runner "block" job. Needs
 #             an allowed external destination (must already be on that
@@ -30,6 +38,8 @@
 set -euo pipefail
 
 TIMEOUT_DEFAULT=8
+RETRY_ATTEMPTS_DEFAULT=3
+RETRY_SLEEP_DEFAULT=2
 
 # Classifies one curl attempt against $1 (a full URL) with timeout $2.
 # Prints exactly one of: http:<code> | dns_failure | connection_refused |
@@ -73,6 +83,37 @@ is_blocked() {
   esac
 }
 
+# Retries probe() against $1 (timeout $2) up to $3 attempts (default
+# RETRY_ATTEMPTS_DEFAULT), sleeping $4 seconds (default
+# RETRY_SLEEP_DEFAULT) between attempts, logging every attempt's
+# classification with $5 as the log label. Returns as soon as an attempt
+# is_reachable; otherwise prints the last attempt's classification once
+# attempts are exhausted. Intended ONLY for checks where a transient
+# failure is noise, not signal -- the positive control and the loopback
+# sanity probe. The negative control must never call this: a retry there
+# would only give a transient successful connection more chances to be
+# mistaken for evidence, biasing an error-detection check in the wrong
+# direction.
+probe_with_retry() {
+  local url="$1" timeout="$2" attempts="${3:-$RETRY_ATTEMPTS_DEFAULT}" sleep_s="${4:-$RETRY_SLEEP_DEFAULT}" label="$5"
+  local result attempt
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    result="$(probe "$url" "$timeout")"
+    # Per-attempt progress goes to stderr, not stdout: this function's
+    # stdout is captured whole by callers via $(...), and only the final
+    # classification (echoed once, below or after the loop) belongs there.
+    echo "egress-check ${label}: attempt ${attempt}/${attempts} target=${url} result=${result}" >&2
+    if is_reachable "$result"; then
+      echo "$result"
+      return 0
+    fi
+    if [[ "$attempt" -lt "$attempts" ]]; then
+      sleep "$sleep_s"
+    fi
+  done
+  echo "$result"
+}
+
 start_local_listener() {
   # Serves a fixed sentinel body on 127.0.0.1 at an OS-assigned port.
   # Prints "<pid> <port>" on success. Caller is responsible for killing pid.
@@ -110,20 +151,19 @@ run_ci() {
   read -r loop_pid loop_port < <(start_local_listener)
   trap 'kill "${loop_pid:-}" 2>/dev/null || true' EXIT
 
-  loop_result="$(probe "http://127.0.0.1:${loop_port}/" 5)"
-  echo "egress-check loopback-sanity: target=http://127.0.0.1:${loop_port}/ result=${loop_result}"
+  loop_result="$(probe_with_retry "http://127.0.0.1:${loop_port}/" 5 3 1 "loopback-sanity")"
   if ! is_reachable "$loop_result"; then
-    echo "::error::egress-check: loopback listener unreachable (${loop_result}) -- this is not an egress finding, the runner's local network stack itself is broken, so the controls below cannot be trusted" >&2
+    echo "::error::egress-check: loopback listener unreachable after retries (${loop_result}) -- this is not an egress finding, the runner's local network stack itself is broken, so the controls below cannot be trusted" >&2
     exit 2
   fi
 
-  allowed_result="$(probe "$allowed_url")"
-  echo "egress-check positive-control: target=${allowed_url} result=${allowed_result}"
+  allowed_result="$(probe_with_retry "$allowed_url" "$TIMEOUT_DEFAULT" "$RETRY_ATTEMPTS_DEFAULT" "$RETRY_SLEEP_DEFAULT" "positive-control")"
   if ! is_reachable "$allowed_result"; then
-    echo "::error::egress-check: POSITIVE CONTROL FAILED -- allowlisted destination ${allowed_url} was not reachable (${allowed_result}). Either the harden-runner allowed-endpoints list dropped this host, or egress is broken generally -- this run cannot tell block-is-working apart from network-is-dead, so the negative control below proves nothing" >&2
+    echo "::error::egress-check: POSITIVE CONTROL FAILED -- allowlisted destination ${allowed_url} was not reachable after ${RETRY_ATTEMPTS_DEFAULT} attempts (${allowed_result}). Either the harden-runner allowed-endpoints list dropped this host, or egress is broken generally -- this run cannot tell block-is-working apart from network-is-dead, so the negative control below proves nothing" >&2
     fail=1
   fi
 
+  # Single-shot, deliberately not retried -- see the module header.
   blocked_result="$(probe "$blocked_url")"
   echo "egress-check negative-control: target=${blocked_url} result=${blocked_result}"
   if is_reachable "$blocked_result"; then
@@ -170,6 +210,14 @@ run_selftest() {
   else
     bad "is_reachable/is_blocked predicates agree with probe() on both cases" "see above"
   fi
+
+  # probe_with_retry() must return immediately on a reachable first
+  # attempt (no gratuitous sleeping) and must retry a failing one.
+  result="$(probe_with_retry "http://127.0.0.1:${loop_port}/" 5 3 1 "selftest-retry-immediate")"
+  if is_reachable "$result"; then ok "probe_with_retry returns immediately when the first attempt succeeds"; else bad "probe_with_retry returns immediately when the first attempt succeeds" "$result"; fi
+
+  result="$(probe_with_retry "http://127.0.0.1:1/" 2 3 1 "selftest-retry-exhausted")"
+  if [[ "$result" == "connection_refused" ]]; then ok "probe_with_retry exhausts attempts and returns the last classification when never reachable"; else bad "probe_with_retry exhausts attempts and returns the last classification when never reachable" "$result"; fi
 
   echo "egress-check selftest: ${pass} passed, ${fail} failed"
   [[ "$fail" -eq 0 ]]

--- a/scripts/ci/check-egress-block.sh
+++ b/scripts/ci/check-egress-block.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Proves the CI egress block (step-security/harden-runner, egress-policy:
+# block) actually blocks egress, instead of asserting an absence that is
+# equally true when nothing tried to egress at all. An earlier go:generate-
+# based negative test was rejected in #26 review as "passes vacuously": it
+# could not distinguish "egress blocked" from "nothing attempted egress",
+# so it would report success even with harden-runner removed entirely.
+#
+# This script always runs a positive control (an allowed destination MUST
+# be reachable) alongside the negative control (a non-allowlisted
+# destination MUST NOT be reachable). Only a run that observes both halves
+# behave correctly proves the block is doing its job; either half failing
+# is reported as a distinct, named failure so the log says which broke.
+#
+# Modes:
+#   ci        Real check for use inside a harden-runner "block" job. Needs
+#             an allowed external destination (must already be on that
+#             job's harden-runner allowed-endpoints list) and a
+#             non-allowlisted one, both reachable only over real egress.
+#   selftest  Runs entirely over loopback so it can be exercised on a
+#             developer machine or any CI job, egress-blocked or not, to
+#             verify this script's own reachable/blocked classification
+#             logic is correct. It does not exercise harden-runner.
+#   probe URL [TIMEOUT]
+#             Prints the classification for one URL and exits 0. A thin
+#             seam so the test sibling can drive classification logic
+#             against a faked `curl` on PATH without opening any socket.
+#
+# Env overrides (ci mode): EGRESS_ALLOWED_URL, EGRESS_BLOCKED_URL.
+set -euo pipefail
+
+TIMEOUT_DEFAULT=8
+
+# Classifies one curl attempt against $1 (a full URL) with timeout $2.
+# Prints exactly one of: http:<code> | dns_failure | connection_refused |
+# timeout | tls_failure | empty_reply | curl_error_<n>. Never fails the
+# script itself -- an unreachable target is an expected outcome to
+# classify, not a script error.
+probe() {
+  local url="$1" timeout="${2:-$TIMEOUT_DEFAULT}" code rc
+  set +e
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout "$timeout" --max-time "$timeout" "$url" 2>/dev/null)"
+  rc=$?
+  set -e
+  case "$rc" in
+    0) echo "http:${code}" ;;
+    6) echo "dns_failure" ;;
+    7) echo "connection_refused" ;;
+    28) echo "timeout" ;;
+    35) echo "tls_failure" ;;
+    52 | 56) echo "empty_reply" ;;
+    *) echo "curl_error_${rc}" ;;
+  esac
+}
+
+# True (exit 0) if a probe() result means "reached an HTTP server and got
+# a response", i.e. the destination was NOT blocked.
+is_reachable() {
+  case "$1" in
+    http:*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# True (exit 0) if a probe() result is one of the recognized "the
+# connection never completed" outcomes a network-level egress block
+# produces. Anything else (e.g. an unexpected curl_error_N) is treated as
+# ambiguous, not as evidence of a block, by the callers below.
+is_blocked() {
+  case "$1" in
+    dns_failure | connection_refused | timeout | tls_failure | empty_reply) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+start_local_listener() {
+  # Serves a fixed sentinel body on 127.0.0.1 at an OS-assigned port.
+  # Prints "<pid> <port>" on success. Caller is responsible for killing pid.
+  local dir port pid
+  dir="$(mktemp -d)"
+  echo "egress-check-sentinel" >"$dir/index.html"
+  # -u: unbuffered stdout. Without it, http.server's startup line sits in
+  # Python's block buffer (stdout is a redirected file, not a tty) and the
+  # poll loop below never sees it until the process exits.
+  python3 -u -m http.server 0 --bind 127.0.0.1 --directory "$dir" >"$dir/server.log" 2>&1 &
+  pid=$!
+  # http.server prints "Serving HTTP on 127.0.0.1 port <N> ..." to stdout;
+  # poll the log briefly instead of a fixed sleep, since startup time varies.
+  for _ in $(seq 1 50); do
+    port="$(grep -oE 'port [0-9]+' "$dir/server.log" 2>/dev/null | grep -oE '[0-9]+' | head -1 || true)"
+    [[ -n "$port" ]] && break
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 0.1
+  done
+  if [[ -z "${port:-}" ]]; then
+    kill "$pid" 2>/dev/null || true
+    echo "::error::egress-check: local listener failed to report a port" >&2
+    return 1
+  fi
+  echo "$pid $port"
+}
+
+run_ci() {
+  local allowed_url blocked_url loop_pid loop_port loop_result allowed_result blocked_result fail=0
+
+  allowed_url="${EGRESS_ALLOWED_URL:-https://github.com}"
+  blocked_url="${EGRESS_BLOCKED_URL:-https://example.com}"
+
+  echo "egress-check: starting local loopback listener (network-stack sanity check)"
+  read -r loop_pid loop_port < <(start_local_listener)
+  trap 'kill "${loop_pid:-}" 2>/dev/null || true' EXIT
+
+  loop_result="$(probe "http://127.0.0.1:${loop_port}/" 5)"
+  echo "egress-check loopback-sanity: target=http://127.0.0.1:${loop_port}/ result=${loop_result}"
+  if ! is_reachable "$loop_result"; then
+    echo "::error::egress-check: loopback listener unreachable (${loop_result}) -- this is not an egress finding, the runner's local network stack itself is broken, so the controls below cannot be trusted" >&2
+    exit 2
+  fi
+
+  allowed_result="$(probe "$allowed_url")"
+  echo "egress-check positive-control: target=${allowed_url} result=${allowed_result}"
+  if ! is_reachable "$allowed_result"; then
+    echo "::error::egress-check: POSITIVE CONTROL FAILED -- allowlisted destination ${allowed_url} was not reachable (${allowed_result}). Either the harden-runner allowed-endpoints list dropped this host, or egress is broken generally -- this run cannot tell block-is-working apart from network-is-dead, so the negative control below proves nothing" >&2
+    fail=1
+  fi
+
+  blocked_result="$(probe "$blocked_url")"
+  echo "egress-check negative-control: target=${blocked_url} result=${blocked_result}"
+  if is_reachable "$blocked_result"; then
+    echo "::error::egress-check: NEGATIVE CONTROL FAILED -- non-allowlisted destination ${blocked_url} was reachable (${blocked_result}). The CI egress block did not take effect" >&2
+    fail=1
+  elif ! is_blocked "$blocked_result"; then
+    echo "::error::egress-check: negative control gave an unrecognized result (${blocked_result}) for ${blocked_url} -- treating as ambiguous, not as proof of a block" >&2
+    fail=1
+  fi
+
+  if [[ "$fail" -ne 0 ]]; then
+    echo "egress-check RESULT: FAIL"
+    exit 1
+  fi
+  echo "egress-check RESULT: PASS (loopback=${loop_result} positive=${allowed_result} negative=${blocked_result})"
+}
+
+run_selftest() {
+  local pass=0 fail=0 loop_pid loop_port result
+
+  ok() { echo "PASS: $1"; pass=$((pass + 1)); }
+  bad() { echo "FAIL: $1 (got: $2)"; fail=$((fail + 1)); }
+
+  echo "egress-check selftest: verifying classification logic over loopback only, no CI egress dependency"
+
+  read -r loop_pid loop_port < <(start_local_listener)
+  trap 'kill "${loop_pid:-}" 2>/dev/null || true' EXIT
+
+  result="$(probe "http://127.0.0.1:${loop_port}/" 5)"
+  if is_reachable "$result"; then ok "reachable local listener classifies as http:*"; else bad "reachable local listener classifies as http:*" "$result"; fi
+
+  # A port on loopback nothing is listening on refuses the connection
+  # immediately -- this is the same OS-level signal a firewall REJECT
+  # (as opposed to DROP) rule produces for the blocked-destination case.
+  result="$(probe "http://127.0.0.1:1/" 3)"
+  if [[ "$result" == "connection_refused" ]]; then ok "closed local port classifies as connection_refused"; else bad "closed local port classifies as connection_refused" "$result"; fi
+
+  # A hostname under the reserved .invalid TLD (RFC 2606) can never resolve.
+  result="$(probe "http://definitely-does-not-exist.invalid/" 3)"
+  if [[ "$result" == "dns_failure" ]]; then ok "unresolvable hostname classifies as dns_failure"; else bad "unresolvable hostname classifies as dns_failure" "$result"; fi
+
+  if is_reachable "$(probe "http://127.0.0.1:${loop_port}/" 5)" && [[ "$(probe "http://127.0.0.1:1/" 3)" != "http:"* ]]; then
+    ok "is_reachable/is_blocked predicates agree with probe() on both cases"
+  else
+    bad "is_reachable/is_blocked predicates agree with probe() on both cases" "see above"
+  fi
+
+  echo "egress-check selftest: ${pass} passed, ${fail} failed"
+  [[ "$fail" -eq 0 ]]
+}
+
+main() {
+  local mode="${1:-}"
+  case "$mode" in
+    ci) run_ci ;;
+    selftest) run_selftest ;;
+    probe)
+      shift
+      [[ $# -ge 1 ]] || { echo "usage: $0 probe URL [TIMEOUT]" >&2; exit 64; }
+      probe "$@"
+      ;;
+    *)
+      echo "usage: $0 ci|selftest|probe URL [TIMEOUT]" >&2
+      exit 64
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/ci/test-check-egress-block.sh
+++ b/scripts/ci/test-check-egress-block.sh
@@ -20,11 +20,19 @@ pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
 
 # Writes a fake `curl` to $1/curl that inspects the trailing URL argument
-# and prints the http_code body plus exits with the rc FAKE_CURL_RC (or,
-# for --url-based dispatch, the mode named for that URL in
-# FAKE_CURL_URL_<slug>). Mirrors the real curl invocation this script
-# makes: `curl -sS -o /dev/null -w '%{http_code}' --connect-timeout N
-# --max-time N URL`.
+# and prints the http_code body plus exits with the rc for the resolved
+# mode. Mirrors the real curl invocation this script makes: `curl -sS -o
+# /dev/null -w '%{http_code}' --connect-timeout N --max-time N URL`.
+#
+# Mode resolution, per URL slug:
+#   FAKE_CURL_URL_<slug>_SEQ set   -> comma-separated modes, one per call
+#                                     to this URL in order (state kept in
+#                                     $FAKE_CURL_STATE_DIR/<slug>.count),
+#                                     clamped to the last entry once the
+#                                     sequence is exhausted. Simulates a
+#                                     flaky destination across retries.
+#   FAKE_CURL_URL_<slug> set       -> that fixed mode, every call.
+#   neither set                    -> FAKE_CURL_MODE (default "ok").
 write_fake_curl() {
   local bin="$1"
   cat >"$bin/curl" <<'FAKECURL'
@@ -32,8 +40,21 @@ write_fake_curl() {
 set -euo pipefail
 url="${@: -1}"
 slug="$(printf '%s' "$url" | tr -c 'A-Za-z0-9' '_')"
+seqvar="FAKE_CURL_URL_${slug}_SEQ"
 var="FAKE_CURL_URL_${slug}"
-mode="${!var:-${FAKE_CURL_MODE:-ok}}"
+if [[ -n "${!seqvar:-}" ]]; then
+  statedir="${FAKE_CURL_STATE_DIR:?FAKE_CURL_STATE_DIR must be set to use a _SEQ mode}"
+  countfile="$statedir/${slug}.count"
+  n=0
+  [[ -f "$countfile" ]] && n="$(cat "$countfile")"
+  echo $((n + 1)) >"$countfile"
+  IFS=',' read -r -a seq <<<"${!seqvar}"
+  idx="$n"
+  [[ "$idx" -ge "${#seq[@]}" ]] && idx=$((${#seq[@]} - 1))
+  mode="${seq[$idx]}"
+else
+  mode="${!var:-${FAKE_CURL_MODE:-ok}}"
+fi
 case "$mode" in
   ok) echo -n "200"; exit 0 ;;
   dns) exit 6 ;;
@@ -75,16 +96,26 @@ run_probe weird "curl_error_99"
 # The loopback sanity probe hits a real 127.0.0.1:<port> URL that the fake
 # curl does not special-case, so it falls back to FAKE_CURL_MODE (kept
 # "ok" in every case below) -- only the allowed/blocked URLs are steered
-# per-slug via FAKE_CURL_URL_<slug>.
+# per-slug via FAKE_CURL_URL_<slug> (fixed mode) or FAKE_CURL_URL_<slug>_SEQ
+# (one mode per call, for exercising the positive control's retry).
+STATEDIR="$WORKDIR/state"
 run_ci_case() {
-  local name="$1" allowed_mode="$2" blocked_mode="$3" expect_rc="$4" expect_grep="$5"
+  local name="$1" allowed_mode_var="$2" allowed_mode_val="$3" blocked_mode="$4" expect_rc="$5" expect_grep="$6" extra_grep="${7:-}"
   local out rc
+  rm -rf "$STATEDIR"
+  mkdir -p "$STATEDIR"
+  # env, not a shell assignment prefix: the variable NAME here is itself a
+  # runtime value ($allowed_mode_var), and bash only recognizes "NAME=val"
+  # as an assignment word when NAME is a literal identifier in the source,
+  # not the result of an expansion -- env parses its argument as NAME=val
+  # regardless.
   out="$(PATH="$FAKEBIN:$PATH" \
     FAKE_CURL_MODE=ok \
-    FAKE_CURL_URL_https___github_com="$allowed_mode" \
-    FAKE_CURL_URL_https___example_com="$blocked_mode" \
+    FAKE_CURL_STATE_DIR="$STATEDIR" \
     EGRESS_ALLOWED_URL="https://github.com" \
     EGRESS_BLOCKED_URL="https://example.com" \
+    FAKE_CURL_URL_https___example_com="$blocked_mode" \
+    env "${allowed_mode_var}=${allowed_mode_val}" \
     "$SCRIPT" ci 2>&1)" && rc=0 || rc=$?
   if [[ "$rc" -ne "$expect_rc" ]]; then
     fail "$name: expected exit $expect_rc, got $rc. Output:\n$out"
@@ -94,20 +125,25 @@ run_ci_case() {
     fail "$name: expected output to contain '$expect_grep'. Output:\n$out"
     return
   fi
+  if [[ -n "$extra_grep" ]] && ! grep -q "$extra_grep" <<<"$out"; then
+    fail "$name: expected output to also contain '$extra_grep' (retry attempts were logged). Output:\n$out"
+    return
+  fi
   pass "$name"
 }
 
-run_ci_case "both controls correct" ok dns 0 "egress-check RESULT: PASS"
-run_ci_case "negative control reachable (block not in effect)" ok ok 1 "NEGATIVE CONTROL FAILED"
-run_ci_case "positive control unreachable (allowlist or network broken)" dns dns 1 "POSITIVE CONTROL FAILED"
-run_ci_case "negative control gives an ambiguous result" ok weird 1 "unrecognized result"
+run_ci_case "both controls correct" FAKE_CURL_URL_https___github_com ok dns 0 "egress-check RESULT: PASS"
+run_ci_case "negative control reachable (block not in effect)" FAKE_CURL_URL_https___github_com ok ok 1 "NEGATIVE CONTROL FAILED"
+run_ci_case "positive control unreachable after all retry attempts" FAKE_CURL_URL_https___github_com dns dns 1 "POSITIVE CONTROL FAILED" "positive-control: attempt 3/3"
+run_ci_case "negative control gives an ambiguous result" FAKE_CURL_URL_https___github_com ok weird 1 "unrecognized result"
+run_ci_case "positive control fails twice then succeeds -> overall PASS" FAKE_CURL_URL_https___github_com_SEQ "dns,dns,ok" dns 0 "egress-check RESULT: PASS" "positive-control: attempt 3/3 target=https://github.com result=http:200"
 
 # --- the script's own selftest mode, run for real: no faked curl, real
 # loopback listener. This is the mode CLAUDE.md's design calls for --
 # runnable anywhere, egress-blocked or not, verifying the same
 # probe()/is_reachable()/is_blocked() logic exercised above end to end. ---
 if out="$("$SCRIPT" selftest 2>&1)"; then
-  if grep -q "^egress-check selftest: 4 passed, 0 failed$" <<<"$out"; then
+  if grep -q "^egress-check selftest: 6 passed, 0 failed$" <<<"$out"; then
     pass "real selftest mode passes all its internal assertions"
   else
     fail "real selftest mode exited 0 but assertion count line was unexpected. Output:\n$out"

--- a/scripts/ci/test-check-egress-block.sh
+++ b/scripts/ci/test-check-egress-block.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Self-test for check-egress-block.sh. No real CI egress dependency: probe
+# classification is driven with a fake `curl` on PATH (deterministic, no
+# sockets), and the script's own `selftest` mode is additionally run for
+# real (real curl, a real loopback python3 http.server) since that mode is
+# exactly what proves the script's detection logic without needing a
+# harden-runner-blocked environment. See #26.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-egress-block.sh"
+
+WORKDIR="$(mktemp -d)"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# Writes a fake `curl` to $1/curl that inspects the trailing URL argument
+# and prints the http_code body plus exits with the rc FAKE_CURL_RC (or,
+# for --url-based dispatch, the mode named for that URL in
+# FAKE_CURL_URL_<slug>). Mirrors the real curl invocation this script
+# makes: `curl -sS -o /dev/null -w '%{http_code}' --connect-timeout N
+# --max-time N URL`.
+write_fake_curl() {
+  local bin="$1"
+  cat >"$bin/curl" <<'FAKECURL'
+#!/usr/bin/env bash
+set -euo pipefail
+url="${@: -1}"
+slug="$(printf '%s' "$url" | tr -c 'A-Za-z0-9' '_')"
+var="FAKE_CURL_URL_${slug}"
+mode="${!var:-${FAKE_CURL_MODE:-ok}}"
+case "$mode" in
+  ok) echo -n "200"; exit 0 ;;
+  dns) exit 6 ;;
+  refused) exit 7 ;;
+  timeout) exit 28 ;;
+  tls) exit 35 ;;
+  empty) exit 52 ;;
+  weird) exit 99 ;;
+  *) echo "fake curl: unknown FAKE_CURL mode '$mode'" >&2; exit 99 ;;
+esac
+FAKECURL
+  chmod +x "$bin/curl"
+}
+
+# --- probe() classification, exhaustive over the fake curl's modes ---
+FAKEBIN="$WORKDIR/fakebin"
+mkdir -p "$FAKEBIN"
+write_fake_curl "$FAKEBIN"
+
+run_probe() {
+  # $1 = FAKE_CURL_MODE, $2 = expected classification
+  local got
+  got="$(PATH="$FAKEBIN:$PATH" FAKE_CURL_MODE="$1" "$SCRIPT" probe "http://probe.example.invalid/" 1)"
+  if [[ "$got" == "$2" ]]; then
+    pass "probe() classifies curl exit for mode '$1' as $2"
+  else
+    fail "probe() classifies curl exit for mode '$1' as $2 (got: $got)"
+  fi
+}
+run_probe ok "http:200"
+run_probe dns "dns_failure"
+run_probe refused "connection_refused"
+run_probe timeout "timeout"
+run_probe tls "tls_failure"
+run_probe empty "empty_reply"
+run_probe weird "curl_error_99"
+
+# --- run_ci(), driven per-URL so positive/negative controls differ ---
+# The loopback sanity probe hits a real 127.0.0.1:<port> URL that the fake
+# curl does not special-case, so it falls back to FAKE_CURL_MODE (kept
+# "ok" in every case below) -- only the allowed/blocked URLs are steered
+# per-slug via FAKE_CURL_URL_<slug>.
+run_ci_case() {
+  local name="$1" allowed_mode="$2" blocked_mode="$3" expect_rc="$4" expect_grep="$5"
+  local out rc
+  out="$(PATH="$FAKEBIN:$PATH" \
+    FAKE_CURL_MODE=ok \
+    FAKE_CURL_URL_https___github_com="$allowed_mode" \
+    FAKE_CURL_URL_https___example_com="$blocked_mode" \
+    EGRESS_ALLOWED_URL="https://github.com" \
+    EGRESS_BLOCKED_URL="https://example.com" \
+    "$SCRIPT" ci 2>&1)" && rc=0 || rc=$?
+  if [[ "$rc" -ne "$expect_rc" ]]; then
+    fail "$name: expected exit $expect_rc, got $rc. Output:\n$out"
+    return
+  fi
+  if ! grep -q "$expect_grep" <<<"$out"; then
+    fail "$name: expected output to contain '$expect_grep'. Output:\n$out"
+    return
+  fi
+  pass "$name"
+}
+
+run_ci_case "both controls correct" ok dns 0 "egress-check RESULT: PASS"
+run_ci_case "negative control reachable (block not in effect)" ok ok 1 "NEGATIVE CONTROL FAILED"
+run_ci_case "positive control unreachable (allowlist or network broken)" dns dns 1 "POSITIVE CONTROL FAILED"
+run_ci_case "negative control gives an ambiguous result" ok weird 1 "unrecognized result"
+
+# --- the script's own selftest mode, run for real: no faked curl, real
+# loopback listener. This is the mode CLAUDE.md's design calls for --
+# runnable anywhere, egress-blocked or not, verifying the same
+# probe()/is_reachable()/is_blocked() logic exercised above end to end. ---
+if out="$("$SCRIPT" selftest 2>&1)"; then
+  if grep -q "^egress-check selftest: 4 passed, 0 failed$" <<<"$out"; then
+    pass "real selftest mode passes all its internal assertions"
+  else
+    fail "real selftest mode exited 0 but assertion count line was unexpected. Output:\n$out"
+  fi
+else
+  fail "real selftest mode exited non-zero. Output:\n$out"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What / why

Part of #26. An earlier go:generate-based negative-egress test design (proposed in #26's Codex advisory pass, item 8) was rejected in an independent review pass on the same issue thread as "passing vacuously": `go build`/`go test` never execute `go:generate` directives, so an "absent sentinel" assertion holds even with `harden-runner` removed entirely — indistinguishable in the log from a dead test endpoint, a DNS hiccup, or a fixture typo. That design never landed as code (verified via `git log --all` across the repo).

This PR implements the review's own prescribed fix: a **positive control**, not just a negative one.

## Decisions

- **D1**: Use `github.com` (already required by every job's `actions/checkout`) as the positive-control target instead of inventing a new allowlist entry — this proves the *real* allowlist admits traffic, not just that a script can open a loopback socket.
- **D2**: Use `example.com` as the permanently-non-allowlisted negative-control target, and record in `ci.yaml`'s top comment block that it must never be added to any job's allowlist in this file, or the negative control stops meaning anything.
- **D3**: Add a loopback sanity probe (local `python3 -m http.server`) run before both controls, so a total runner network failure is reported as "loopback unreachable — not an egress finding" rather than being misread as "the block is working."
- **D4**: Classify `curl` exit codes into `dns_failure` / `connection_refused` / `timeout` / `tls_failure` / `empty_reply` / `http:<code>` so the CI log names which failure mode occurred, per the design constraint.
- **D5**: Ship a `selftest` mode that needs no CI and no real egress block — it exercises the same classification logic against a real local listener, a closed loopback port, and an RFC 2606 `.invalid` hostname, so the detection logic itself is provably correct independent of any runner's actual block behavior.

## Files

- `.github/workflows/ci.yaml` — new "Egress Block Positive Control" job appended (only addition; no other job touched), plus a top-comment note recording D2.
- `scripts/ci/check-egress-block.sh` — `ci` / `selftest` / `probe` modes.
- `scripts/ci/test-check-egress-block.sh` — 12 assertions (7 curl-exit-code classifications via a faked `curl` on PATH, 4 end-to-end `run_ci()` cases, 1 real unfaked `selftest` run).
- `.agents/evals/traces/2026-09-negative-egress-positive-control.json` — behavior-contract trace (required for `.github/workflows/**`, `scripts/ci/**`, `.agents/**`).

## Verified

```
$ bash -n scripts/ci/check-egress-block.sh && echo OK          # OK
$ shellcheck scripts/ci/check-egress-block.sh scripts/ci/test-check-egress-block.sh   # rc=0, no findings
$ bash scripts/ci/test-check-egress-block.sh                   # 12 passed, 0 failed
$ bash scripts/ci/check-egress-block.sh selftest                # egress-check selftest: 4 passed, 0 failed
$ bash scripts/ci/check-egress-block.sh ci                      # locally, egress NOT blocked:
    egress-check negative-control: target=https://example.com result=http:200
    ::error::egress-check: NEGATIVE CONTROL FAILED ... exit 1
    # proves the check correctly fails when there is no real block, i.e. it is not vacuous
$ python3 -c 'import yaml,sys;yaml.safe_load(open(sys.argv[1]))' .github/workflows/ci.yaml   # OK
$ actionlint .github/workflows/ci.yaml                           # rc=0
$ python3 scripts/ci/check-mutable-inputs.py .github/workflows/ci.yaml   # passed for 1 file
$ python3 .agents/evals/evaluate.py .agents/evals/traces/2026-09-negative-egress-positive-control.json   # 5/5 passed, 100%
$ python3 .agents/evals/gate.py --trace ... --baseline .agents/evals/baseline.eval.json   # 0 regressions
$ python3 scripts/ci/check-agent-trace-requirement.py --policy .agents/evals/risk-policy.json --changed-files ...   # rc=0, traceRequired=true, traceChanged=true
```

## Unverified

The real `harden-runner` block behavior on a GitHub-hosted runner (does it actually produce `dns_failure`/`connection_refused`/`timeout` for `example.com`, and does `github.com` stay reachable under `block` mode) has not yet been observed — only reproduced locally where egress is unblocked (confirms the script correctly *fails* in that state, per the local run above). Will watch `gh pr checks` after opening this PR and paste the new job's log lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PMya54VMirqPv7zEXY4mq