### PR TITLE
ci(dependabot): ignore uncoordinated k8s/docker bumps, exempt Dockerfile pin-only PRs

### DIFF
--- a/.agents/evals/traces/2026-09-dependabot-k8s-set-and-docker-pins.json
+++ b/.agents/evals/traces/2026-09-dependabot-k8s-set-and-docker-pins.json
@@ -51,15 +51,40 @@
       ]
     },
     {
-      "id": "e6",
-      "type": "completion_claim",
-      "summary": "Both reproduced defects are fixed: the gomod ecosystem now ignores k8s.io/*+sigs.k8s.io/* minor/major bumps so Dependabot cannot re-propose the failing partial k8s bump, and the docker ecosystem ignores golang/alpine minor/major bumps so a future Dockerfile-only base-image bump can't recur; the trace-gate script now exempts a Dependabot Dockerfile digest/tag-only bump the same way it already exempted a GitHub Actions SHA pin bump, verified against the real PR #112 diff. PR #112 itself will be closed with a comment explaining the four-place rule and the new ignore entry once this PR is open."
+      "id": "e8",
+      "type": "external_input",
+      "summary": "Independent review of this PR found one MEDIUM: is_dependabot_dockerfile_pin_only() only rejected a hunk when image AND digest were both unchanged, so a repository-name swap paired with a new digest (e.g. `golang:1.26-alpine@sha256:aaaa` -> `evilcorp/golang:1.26-alpine@sha256:bbbb`) was exempted from the trace requirement -- reproduced by the reviewer calling the function directly. The sibling is_dependabot_action_pin_only already guards against the equivalent case (rejects when the action name changes), so this function should mirror it rather than only checking image==image.",
+      "provenance": "independent review of PR #116",
+      "reviewed": true
     },
     {
-      "id": "e7",
+      "id": "e9",
+      "type": "bug_fix",
+      "summary": "D5: split DOCKERFILE_FROM_RE's single opaque `image` capture group into `repo` (everything before the last `:tag` and before `@sha256:`) and an optional `tag`, and changed is_dependabot_dockerfile_pin_only's comparison to require `repo` identical between old and new (rejecting outright otherwise, mirroring is_dependabot_action_pin_only's action-name-must-match rule) while allowing `tag` and/or `digest` to differ. prefix/suffix equality (--platform=... and AS <stage>) was already required and is unchanged. Also updated the function's docstring to state the repository-must-match invariant explicitly instead of only justifying the tag-change allowance."
+    },
+    {
+      "id": "e10",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "Added 3 new table tests to scripts/ci/test_check_agent_trace_requirement.py: a repository swap with a new digest (dependabot actor) -> not exempt (regression test for the reviewer-found bug); same repository with only the tag changed -> exempt; same repository with only the digest changed -> exempt. The fourth requested case (same repository, both tag and digest changed) was already covered by the pre-existing test_dockerfile_tag_and_digest_bump_is_exempt. python3 -m pytest scripts/ci/ -q passed 13/13 (10 pre-existing + 3 new). Re-ran check-agent-trace-requirement.py against PR #112's real diff (same base/head SHAs and dependabot[bot] actor/author as the original e5 verification): still exit 0, traceExempt true, same reason string -- confirming the fix does not regress the actual PR this task closes. gofmt -l . reported no files; python3 -c yaml.safe_load on .github/dependabot.yml parsed cleanly (both unchanged by this fix, re-checked for completeness).",
+      "scope": "The full scripts/ci/ pytest suite (13 tests) and a real-PR replay of the trace-gate script against PR #112's actual commits, post-fix. Does not re-run the .agents/evals/evaluate.py or gate.py checks from e5 since this fix only touches scripts/ci/, not the trace's own event content beyond this update.",
+      "evidence": [
+        "test:scripts-ci-pytest-13-passed-post-review-fix",
+        "runtime:check-agent-trace-requirement-against-real-pr-112-diff-post-fix-exit-0-exempt",
+        "ci:gofmt-no-files-post-fix",
+        "ci:yaml-safe_load-dependabot-yml-post-fix"
+      ]
+    },
+    {
+      "id": "e11",
+      "type": "completion_claim",
+      "summary": "Both reproduced defects are fixed: the gomod ecosystem now ignores k8s.io/*+sigs.k8s.io/* minor/major bumps so Dependabot cannot re-propose the failing partial k8s bump, and the docker ecosystem ignores golang/alpine minor/major bumps so a future Dockerfile-only base-image bump can't recur; the trace-gate script now exempts a Dependabot Dockerfile digest/tag-only bump the same way it already exempted a GitHub Actions SHA pin bump, verified against the real PR #112 diff. PR #112 itself will be closed with a comment explaining the four-place rule and the new ignore entry once this PR is open. A post-merge-review MEDIUM (repository-swap-with-new-digest exemption bypass) was found and fixed per e9, verified in e10."
+    },
+    {
+      "id": "e12",
       "type": "task_outcome",
       "state": "A",
-      "summary": "Complete at the design, static-validation, real-PR-diff-replay, and local-tooling-run level described in e5. Unverified: the ignore rules only prove out on Dependabot's next scheduled run against the live repository -- this session cannot trigger or observe that run. Also unverified: whether GitHub's Dependabot service accepts `dependency-name: \"k8s.io/*\"` glob-style ignore entries exactly as documented (used the same syntax pattern Dependabot's own docs describe for scoped ignores; not independently confirmed against a real Dependabot config-validation pass, since this repo has no such CI check)."
+      "summary": "Complete at the design, static-validation, real-PR-diff-replay, and local-tooling-run level described in e5 and e10, including the post-review fix in e9 for the repository-swap exemption bypass. Unverified: the ignore rules only prove out on Dependabot's next scheduled run against the live repository -- this session cannot trigger or observe that run. Also unverified: whether GitHub's Dependabot service accepts `dependency-name: \"k8s.io/*\"` glob-style ignore entries exactly as documented (used the same syntax pattern Dependabot's own docs describe for scoped ignores; not independently confirmed against a real Dependabot config-validation pass, since this repo has no such CI check)."
     }
   ]
 }

--- a/.agents/evals/traces/2026-09-dependabot-k8s-set-and-docker-pins.json
+++ b/.agents/evals/traces/2026-09-dependabot-k8s-set-and-docker-pins.json
@@ -76,15 +76,39 @@
       ]
     },
     {
-      "id": "e11",
-      "type": "completion_claim",
-      "summary": "Both reproduced defects are fixed: the gomod ecosystem now ignores k8s.io/*+sigs.k8s.io/* minor/major bumps so Dependabot cannot re-propose the failing partial k8s bump, and the docker ecosystem ignores golang/alpine minor/major bumps so a future Dockerfile-only base-image bump can't recur; the trace-gate script now exempts a Dependabot Dockerfile digest/tag-only bump the same way it already exempted a GitHub Actions SHA pin bump, verified against the real PR #112 diff. PR #112 itself will be closed with a comment explaining the four-place rule and the new ignore entry once this PR is open. A post-merge-review MEDIUM (repository-swap-with-new-digest exemption bypass) was found and fixed per e9, verified in e10."
+      "id": "e13",
+      "type": "external_input",
+      "summary": "A Codex critic pass on PR #116 (head f9481b1) confirmed the repository-swap exemption fix (13 tests pass; multi-line FROM, ARG, alias-only, and mixed-file cases are conservatively non-exempt) but raised one HIGH: per GitHub's Dependabot docs, an `ignore` condition applies to Dependabot *security* update PRs as well as version updates, not only weekly version-update PRs. So a k8s.io/* vulnerability fixed only in a v0.37.x line, or a golang/alpine fix only on a newer minor tag, will not produce a Dependabot security PR under the ignore rules added in this PR. Confirmed against GitHub's docs (https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore): `ignore` suppresses both version-update and security-update pull requests for a matching dependency/range, but Dependabot *alerts* (the Security tab / dependency graph findings) are a separate mechanism and are not affected by `ignore` -- they still fire regardless of this config.",
+      "provenance": "Codex critic pass on PR #116",
+      "reviewed": true
     },
     {
-      "id": "e12",
+      "id": "e14",
+      "type": "decision",
+      "summary": "D6: keep the ignore rules as-is rather than adding a version-updates-only scope -- Dependabot's ignore directive has no such scope option, and even without it the k8s.io/sigs.k8s.io set cannot be auto-bumped by Dependabot regardless of trigger (security or version), since the coordinated-set failure mode reproduced in e2 applies equally to a security-triggered bump of a single k8s.io module. The trade-off (alerts still fire, but no automatic security PR for these ranges; a maintainer must do a manual coordinated bump when an alert lands in an ignored range) is real and needed to be explicit rather than silent, so it was added as an inline NOTE in both ignore blocks in .github/dependabot.yml and as a Trade-off section in the PR body, rather than changed in behavior."
+    },
+    {
+      "id": "e15",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "Docs-only change (comments in .github/dependabot.yml). python3 -c yaml.safe_load parsed cleanly after the edit. Re-ran .agents/evals/evaluate.py on this trace (5/5 behaviors passed, 100%) and .agents/evals/gate.py against the baseline (0 regressions) after appending e13/e14 below.",
+      "scope": "YAML validity of the edited file and this trace's own evaluate/gate checks. No code paths changed, so scripts/ci/ pytest was not re-run for this specific change (already green at 13/13 from the prior fix, unaffected by comment-only edits).",
+      "evidence": [
+        "ci:yaml-safe_load-dependabot-yml-post-notes",
+        "eval:evaluate.py-5-of-5-passed-post-notes",
+        "eval:gate.py-0-regressions-post-notes"
+      ]
+    },
+    {
+      "id": "e16",
+      "type": "completion_claim",
+      "summary": "Both reproduced defects are fixed: the gomod ecosystem now ignores k8s.io/*+sigs.k8s.io/* minor/major bumps so Dependabot cannot re-propose the failing partial k8s bump, and the docker ecosystem ignores golang/alpine minor/major bumps so a future Dockerfile-only base-image bump can't recur; the trace-gate script now exempts a Dependabot Dockerfile digest/tag-only bump the same way it already exempted a GitHub Actions SHA pin bump, verified against the real PR #112 diff. PR #112 itself will be closed with a comment explaining the four-place rule and the new ignore entry once this PR is open. A post-merge-review MEDIUM (repository-swap-with-new-digest exemption bypass) was found and fixed per e9, verified in e10. A Codex critic pass then flagged that `ignore` also suppresses Dependabot security PRs for the ignored ranges (not just version-update PRs); this trade-off is now stated explicitly in both dependabot.yml ignore-block comments and the PR body per e13/e14, with no behavior change since alerts are unaffected and the k8s set cannot be auto-bumped by any trigger regardless."
+    },
+    {
+      "id": "e17",
       "type": "task_outcome",
       "state": "A",
-      "summary": "Complete at the design, static-validation, real-PR-diff-replay, and local-tooling-run level described in e5 and e10, including the post-review fix in e9 for the repository-swap exemption bypass. Unverified: the ignore rules only prove out on Dependabot's next scheduled run against the live repository -- this session cannot trigger or observe that run. Also unverified: whether GitHub's Dependabot service accepts `dependency-name: \"k8s.io/*\"` glob-style ignore entries exactly as documented (used the same syntax pattern Dependabot's own docs describe for scoped ignores; not independently confirmed against a real Dependabot config-validation pass, since this repo has no such CI check)."
+      "summary": "Complete at the design, static-validation, real-PR-diff-replay, and local-tooling-run level described in e5, e10, and e15, including the repository-swap exemption fix in e9 and the security-PR-suppression trade-off now documented per e13/e14. Unverified: the ignore rules only prove out on Dependabot's next scheduled run against the live repository -- this session cannot trigger or observe that run. Also unverified: whether GitHub's Dependabot service accepts `dependency-name: \"k8s.io/*\"` glob-style ignore entries exactly as documented (used the same syntax pattern Dependabot's own docs describe for scoped ignores; not independently confirmed against a real Dependabot config-validation pass, since this repo has no such CI check)."
     }
   ]
 }

--- a/.agents/evals/traces/2026-09-dependabot-k8s-set-and-docker-pins.json
+++ b/.agents/evals/traces/2026-09-dependabot-k8s-set-and-docker-pins.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": "openforge-agent-trace/v1",
+  "consistencyMode": "strict",
+  "traceId": "nfs-quota-agent-issue-26-dependabot-k8s-set-and-docker-pins",
+  "task": "Make the gomod and docker Dependabot ecosystems produce only PRs that can actually go green: ignore k8s.io/*+sigs.k8s.io/* minor/major bumps, ignore golang/alpine minor/major bumps, and extend the trace-gate exemption to Dockerfile digest/tag-only bumps (part of #26)",
+  "changeContext": {
+    "paths": [
+      ".github/dependabot.yml",
+      "scripts/ci/check-agent-trace-requirement.py",
+      "scripts/ci/test_check_agent_trace_requirement.py"
+    ]
+  },
+  "events": [
+    {
+      "id": "e1",
+      "type": "scope_check",
+      "summary": "Scoped to .github/dependabot.yml (add ignore entries) and scripts/ci/check-agent-trace-requirement.py plus its test file (extend the existing dependabot pin-only trace-gate exemption to cover Dockerfile FROM lines). Explicitly out of scope: .github/workflows/ci.yaml, release.yaml, and dependabot-licenses.yaml -- the task constraints named these as untouched, and none of them needed a change for this fix. go.mod/go.sum are not touched; any local repro of the k8s bump failure must be restored afterward."
+    },
+    {
+      "id": "e2",
+      "type": "reproduction",
+      "summary": "Reproduced defect 1 (the failed Dependabot gomod run, 33604053019) locally: in a scratch copy of the repo, `go get k8s.io/api@v0.37.0` upgraded k8s.io/api, k8s.io/apimachinery, k8s.io/kube-openapi, k8s.io/utils, and sigs.k8s.io/structured-merge-diff/v6 while leaving k8s.io/client-go at v0.36.2, then `go mod tidy` failed with an ambiguous-import error walking through k8s.io/apiextensions-apiserver -> k8s.io/apiserver -> google.golang.org/grpc -> google.golang.org/genproto/googleapis/rpc/status found in two modules simultaneously -- the same failure family the run log names (dependency_file_not_resolvable / ambiguous genproto import), confirming the k8s.io/sigs.k8s.io module family cannot be bumped piecemeal by Dependabot's per-module resolver. Confirmed defect 2 directly from `gh pr view 112`: PR #112 is a Dockerfile-only golang 1.26-alpine -> 1.27-alpine bump (1 file, 1 addition, 1 deletion), which both fails the behavior-contract trace gate (Dockerfile* is high-risk in .agents/evals/risk-policy.json and Dependabot cannot author a trace file) and violates CLAUDE.md's four-place Go version bump rule (go.mod, Dockerfile builder stage, ci.yaml go-version fields, chart appVersion must move together).",
+      "evidence": [
+        "run:go-get-k8s.io-api-v0.37.0-then-go-mod-tidy-ambiguous-import-genproto-rpc-status",
+        "read:gh-pr-view-112-files-1-dockerfile-1plus-1minus"
+      ]
+    },
+    {
+      "id": "e3",
+      "type": "external_input",
+      "summary": "Checked `gh issue view 26 --comments` for a maintainer decision on the exact k8s.io ignore syntax before designing one. No comment records a specific dependabot.yml ignore rule for k8s.io/sigs.k8s.io -- the closest is the original gomod-ecosystem rationale (#26 first comment, re-affirmed in the AI-assisted-triage and Codex advisory comments) and a general note that coordinated multi-module bumps and cooling-off policy remain open, larger follow-ups (proposed via Renovate in the Codex advisory pass) not yet decided or implemented. Proceeded with a scoped dependabot.yml `ignore` block as the minimal fix for the reproduced failure, leaving the larger Renovate/CODEOWNERS/cooling-off redesign as a separate, undecided follow-up rather than folding it into this change.",
+      "provenance": "gh issue view 26 --comments",
+      "reviewed": true
+    },
+    {
+      "id": "e4",
+      "type": "bug_fix",
+      "summary": "D1: Added an `ignore` block to the gomod ecosystem in .github/dependabot.yml covering `k8s.io/*` and `sigs.k8s.io/*` for `version-update:semver-major` and `version-update:semver-minor`, with a comment stating the coordinated-set rule, the reproduced failure mode, and that k8s bumps are done manually together with hack/compatibility-matrix.json (#5). Patch updates within the same minor stay enabled since Dependabot's existing `go-dependencies` group already handles those without needing client-go to move in lockstep. D2: Added an `ignore` block to the docker ecosystem for `golang` and `alpine`, same major/minor scope, with a comment pointing at CLAUDE.md's four-place Go version bump rule (golang) and at PR #104/issue #26 D5's apk-closure-changes-the-license-manifest reasoning (alpine) -- both ignore entries leave patch/digest refreshes on the same minor line enabled. D3: Extended scripts/ci/check-agent-trace-requirement.py's dependabot pin-only exemption with a second function, `is_dependabot_dockerfile_pin_only`, mirroring the existing GitHub Actions SHA-pin check's structure (single-hunk-per-changed-line, strict marker/prefix/suffix equality, dependabot[bot] actor+author) but matching `FROM ...@sha256:<64-hex>` lines via a new DOCKERFILE_FROM_RE, and wired it into main() as an `elif` alternative exemption reason. D4: chose to treat a tag-plus-digest change as pin-only (not just a bare digest change) -- justified because the new dependabot.yml ignore rules from D2 already prevent Dependabot from ever proposing a golang/alpine minor or major tag bump, so any tag change this function can see from a real Dependabot PR is a same-minor patch refresh (e.g. 1.26.7-alpine -> 1.26.8-alpine), functionally equivalent to a bare digest refresh for trace-gate purposes. A RUN line or any other Dockerfile* content change still fails the strict single-hunk check and stays non-exempt."
+    },
+    {
+      "id": "e5",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "python3 -c 'import yaml;yaml.safe_load(open(\".github/dependabot.yml\"))' parsed cleanly. Added four new table tests to scripts/ci/test_check_agent_trace_requirement.py (digest-only bump exempt, tag+digest bump exempt, a Dockerfile change also touching a RUN line not exempt, a digest-only bump from a non-dependabot actor not exempt) plus a Dockerfile* rule in the test's local POLICY fixture (it previously only classified .github/workflows/** as high-risk, which would have made every new Dockerfile assertion vacuously pass with traceExempt staying false regardless of the new function's return value -- caught this by inspection before running, not by a failing test). `python3 -m pytest scripts/ci/ -q` passed 10/10 (6 pre-existing + 4 new). Re-ran the real script against the actual PR #112 diff (fetched via `gh pr view 112 --json files,headRefOid,baseRefOid` and a local `git diff --name-only`) with `--github-actor dependabot[bot] --pr-author dependabot[bot]`: exit 0, traceExempt true, reason 'dependabot pin-only bump of Dockerfile FROM image reference(s)' -- confirming the new exemption covers the exact live PR this task closes, not just the synthetic test fixtures. `gofmt -l .` reported no files (no Go source was changed). `git status --short` confirmed go.mod/go.sum were restored untouched after the e2 scratch-copy repro (repro ran in a separate /tmp copy, not this worktree, so no restoration was needed here).",
+      "scope": "YAML validity, the full scripts/ci/ pytest suite including the 4 new table tests, a real-PR replay of the trace-gate script against PR #112's actual commits, and gofmt. Does not cover a live Dependabot run against the new dependabot.yml ignore rules -- that only proves out on Dependabot's next scheduled run, named as the remaining risk.",
+      "evidence": [
+        "ci:yaml-safe_load-dependabot-yml",
+        "test:scripts-ci-pytest-10-passed",
+        "runtime:check-agent-trace-requirement-against-real-pr-112-diff-exit-0-exempt",
+        "ci:gofmt-no-files"
+      ]
+    },
+    {
+      "id": "e6",
+      "type": "completion_claim",
+      "summary": "Both reproduced defects are fixed: the gomod ecosystem now ignores k8s.io/*+sigs.k8s.io/* minor/major bumps so Dependabot cannot re-propose the failing partial k8s bump, and the docker ecosystem ignores golang/alpine minor/major bumps so a future Dockerfile-only base-image bump can't recur; the trace-gate script now exempts a Dependabot Dockerfile digest/tag-only bump the same way it already exempted a GitHub Actions SHA pin bump, verified against the real PR #112 diff. PR #112 itself will be closed with a comment explaining the four-place rule and the new ignore entry once this PR is open."
+    },
+    {
+      "id": "e7",
+      "type": "task_outcome",
+      "state": "A",
+      "summary": "Complete at the design, static-validation, real-PR-diff-replay, and local-tooling-run level described in e5. Unverified: the ignore rules only prove out on Dependabot's next scheduled run against the live repository -- this session cannot trigger or observe that run. Also unverified: whether GitHub's Dependabot service accepts `dependency-name: \"k8s.io/*\"` glob-style ignore entries exactly as documented (used the same syntax pattern Dependabot's own docs describe for scoped ignores; not independently confirmed against a real Dependabot config-validation pass, since this repo has no such CI check)."
+    }
+  ]
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,15 +13,43 @@ updates:
       prefix: "ci"
 
   # Dockerfile's two FROM lines are pinned to digests, not floating tags
-  # (golang:1.26-alpine, alpine:3.21) -- same trade as github-actions above:
+  # (golang:1.26-alpine, alpine:3.24) -- same trade as github-actions above:
   # pinning closes the repointable-tag risk but freezes the base image
   # permanently without something proposing updates.
+  #
+  # golang minor/major bumps are ignored here (#26/#112): CLAUDE.md's
+  # "A Go version bump touches four places" rule means a Dockerfile-only
+  # golang bump is wrong by policy even when it's green -- go.mod, the
+  # Dockerfile builder stage, ci.yaml's go-version fields, and the chart's
+  # appVersion have to move together, and Dependabot's docker updater can
+  # only ever touch the Dockerfile. Patch/digest refreshes (e.g.
+  # 1.26.7-alpine -> 1.26.8-alpine on the same 1.26 line) stay enabled since
+  # they don't require touching the other three places.
+  #
+  # alpine minor bumps (3.24 -> 3.25) are ignored for a related but distinct
+  # reason: a minor Alpine bump changes the apk package closure baked into
+  # the image (PR #104 / issue #26 D5), which regenerates
+  # /licenses/os-packages-manifest.txt -- that's a reviewable content change
+  # to the license inventory, not a pure digest refresh, so it should be a
+  # deliberate PR rather than an automatic weekly one. Patch releases within
+  # the same Alpine minor (3.24.0 -> 3.24.1) are still fine since the apk
+  # index a `3.24-alpine` tag resolves to already moves under a digest
+  # refresh regardless.
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "build"
+    ignore:
+      - dependency-name: "golang"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "alpine"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   # The gomod ecosystem was deliberately left disabled here until CI's
   # License Check job (which fails a PR whenever THIRD_PARTY_LICENSES.md
@@ -37,6 +65,20 @@ updates:
   # Minor/patch bumps are grouped into one PR per week to cut review noise;
   # majors stay individual since a Go major bump can break the API and
   # warrants its own review.
+  #
+  # k8s.io/* and sigs.k8s.io/* are excluded from minor/major bumps (issue
+  # #26 follow-up, first Dependabot gomod run after enabling this ecosystem
+  # in #108): the k8s.io module family (api, apimachinery, client-go,
+  # apiextensions-apiserver, code-generator, ...) plus
+  # sigs.k8s.io/controller-tools must move together as one coordinated set
+  # matched against hack/compatibility-matrix.json (#5) -- client-go v0.36
+  # imports k8s.io/api/scheduling/v1alpha2, which v0.37 removes, so bumping
+  # k8s.io/api alone without client-go breaks `go mod tidy`
+  # (dependency_file_not_resolvable, run 33604053019). Dependabot's gomod
+  # updater resolves each module individually even inside a `groups` block,
+  # so it can never produce the one PR that bumps the whole set together --
+  # only a human-run compatibility-matrix update can. Patch updates within
+  # the same minor (e.g. 0.36.2 -> 0.36.3) are still safe and stay enabled.
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -48,3 +90,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "sigs.k8s.io/*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,10 @@ updates:
   # the same Alpine minor (3.24.0 -> 3.24.1) are still fine since the apk
   # index a `3.24-alpine` tag resolves to already moves under a digest
   # refresh regardless.
+  #
+  # NOTE: `ignore` also suppresses Dependabot *security* PRs for these
+  # ranges; Dependabot alerts still fire and must be handled by a manual
+  # coordinated bump (Go/Alpine via the four-place rule in CLAUDE.md).
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -79,6 +83,10 @@ updates:
   # so it can never produce the one PR that bumps the whole set together --
   # only a human-run compatibility-matrix update can. Patch updates within
   # the same minor (e.g. 0.36.2 -> 0.36.3) are still safe and stay enabled.
+  #
+  # NOTE: `ignore` also suppresses Dependabot *security* PRs for these
+  # ranges; Dependabot alerts still fire and must be handled by a manual
+  # coordinated bump (k8s set with the compatibility matrix, hack/compatibility-matrix.json / #5).
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:

--- a/scripts/ci/check-agent-trace-requirement.py
+++ b/scripts/ci/check-agent-trace-requirement.py
@@ -6,6 +6,15 @@ PIN_LINE_RE = re.compile(
     r'^(?P<indent>\s*)uses:\s+(?P<action>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*)@'
     r'(?P<sha>[0-9a-f]{40})\s+#\s+(?P<version>v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\s*$'
 )
+# Matches a Dockerfile `FROM <image>@sha256:<digest>` line, with the optional
+# `--platform=...` prefix and `AS <stage>` suffix this repo's Dockerfile
+# uses. The repository part before `@sha256:` is captured whole (not split
+# into name/tag) so a tag change (e.g. golang:1.26-alpine -> 1.27-alpine)
+# is visible to the pin-only comparison below rather than silently ignored.
+DOCKERFILE_FROM_RE = re.compile(
+    r'^(?P<prefix>FROM\s+(?:--platform=\S+\s+)?)(?P<image>\S+)@sha256:'
+    r'(?P<digest>[0-9a-f]{64})(?P<suffix>\s+[Aa][Ss]\s+\S+)?\s*$'
+)
 def load_policy(path):
   data=json.loads(Path(path).read_text())
   if data.get("schemaVersion")!="openforge-agent-risk-policy/v1" or not isinstance(data.get("rules"),list): raise ValueError("invalid risk policy")
@@ -70,6 +79,52 @@ def is_dependabot_action_pin_only(changed_files, base_sha, head_sha, github_acto
     if match_old.group("sha") == match_new.group("sha") or match_old.group("version") == match_new.group("version"):
       return False
   return True
+def is_dependabot_dockerfile_pin_only(changed_files, base_sha, head_sha, github_actor, pr_author):
+  """Exempts a Dependabot-authored PR whose only change to Dockerfile* is
+  the image reference (tag and/or digest) on a `FROM ...@sha256:...` line.
+  Tag changes are allowed here, not just digest changes, because the
+  ignore rules in .github/dependabot.yml already keep Dependabot from
+  proposing a golang/alpine minor or major bump on these images -- so a
+  tag change this function ever sees is a same-minor patch refresh (e.g.
+  1.26.7-alpine -> 1.26.8-alpine, or 3.24.0 -> 3.24.1), which is exactly
+  the kind of digest-freshness bump this exemption exists for. A RUN line,
+  apk package list change, or anything else in Dockerfile* still fails
+  the strict single-hunk-per-change check below and stays non-exempt.
+  """
+  if github_actor != "dependabot[bot]" or pr_author != "dependabot[bot]":
+    return False
+  if not changed_files:
+    return False
+  for path in changed_files:
+    if not fnmatch.fnmatchcase(path, "Dockerfile*"):
+      return False
+  if not base_sha or not head_sha:
+    return False
+  try:
+    proc = subprocess.run(
+      ["git", "diff", "--unified=0", base_sha, head_sha, "--", "Dockerfile*"],
+      capture_output=True, text=True, check=True,
+    )
+  except (OSError, subprocess.CalledProcessError):
+    return False
+  hunks = _parse_pin_hunks(proc.stdout)
+  if not hunks:
+    return False
+  for hunk in hunks:
+    if len(hunk) != 2:
+      return False
+    (marker_a, line_a), (marker_b, line_b) = hunk
+    if marker_a != "-" or marker_b != "+":
+      return False
+    match_old = DOCKERFILE_FROM_RE.match(line_a)
+    match_new = DOCKERFILE_FROM_RE.match(line_b)
+    if not match_old or not match_new:
+      return False
+    if match_old.group("prefix") != match_new.group("prefix") or match_old.group("suffix") != match_new.group("suffix"):
+      return False
+    if match_old.group("image") == match_new.group("image") and match_old.group("digest") == match_new.group("digest"):
+      return False
+  return True
 def main():
   p=argparse.ArgumentParser()
   p.add_argument("--policy",required=True)
@@ -89,6 +144,9 @@ def main():
       if is_dependabot_action_pin_only(changed, a.base_sha, a.head_sha, a.github_actor, a.pr_author):
         trace_exempt=True
         trace_exempt_reason="dependabot pin-only bump of GitHub Actions SHA(s) in workflow file(s)"
+      elif is_dependabot_dockerfile_pin_only(changed, a.base_sha, a.head_sha, a.github_actor, a.pr_author):
+        trace_exempt=True
+        trace_exempt_reason="dependabot pin-only bump of Dockerfile FROM image reference(s)"
     result={"schemaVersion":"openforge-agent-risk-result/v1","risk":risk,"traceRequired":required,"traceChanged":trace,"traceExempt":trace_exempt,"traceExemptReason":trace_exempt_reason,"changedFiles":changed,"matches":matches}
     if a.report_out: Path(a.report_out).write_text(json.dumps(result,indent=2)+"\n")
     print(json.dumps(result,indent=2))

--- a/scripts/ci/check-agent-trace-requirement.py
+++ b/scripts/ci/check-agent-trace-requirement.py
@@ -8,11 +8,16 @@ PIN_LINE_RE = re.compile(
 )
 # Matches a Dockerfile `FROM <image>@sha256:<digest>` line, with the optional
 # `--platform=...` prefix and `AS <stage>` suffix this repo's Dockerfile
-# uses. The repository part before `@sha256:` is captured whole (not split
-# into name/tag) so a tag change (e.g. golang:1.26-alpine -> 1.27-alpine)
-# is visible to the pin-only comparison below rather than silently ignored.
+# uses. The repository and tag are captured separately (not as one opaque
+# "image" blob) so the pin-only comparison below can require the repository
+# stay identical while still seeing a tag change (e.g. golang:1.26-alpine ->
+# 1.27-alpine) -- otherwise a repository-name swap (golang -> evilcorp/golang)
+# alongside a new digest would look identical to a legitimate tag/digest
+# refresh. `repo` intentionally excludes ":" so a `name:tag` split lands on
+# the last colon before `@`; tag is optional (a bare `name@sha256:...`
+# reference has none).
 DOCKERFILE_FROM_RE = re.compile(
-    r'^(?P<prefix>FROM\s+(?:--platform=\S+\s+)?)(?P<image>\S+)@sha256:'
+    r'^(?P<prefix>FROM\s+(?:--platform=\S+\s+)?)(?P<repo>[^\s@:]+)(?::(?P<tag>[^\s@]+))?@sha256:'
     r'(?P<digest>[0-9a-f]{64})(?P<suffix>\s+[Aa][Ss]\s+\S+)?\s*$'
 )
 def load_policy(path):
@@ -81,15 +86,20 @@ def is_dependabot_action_pin_only(changed_files, base_sha, head_sha, github_acto
   return True
 def is_dependabot_dockerfile_pin_only(changed_files, base_sha, head_sha, github_actor, pr_author):
   """Exempts a Dependabot-authored PR whose only change to Dockerfile* is
-  the image reference (tag and/or digest) on a `FROM ...@sha256:...` line.
-  Tag changes are allowed here, not just digest changes, because the
-  ignore rules in .github/dependabot.yml already keep Dependabot from
-  proposing a golang/alpine minor or major bump on these images -- so a
-  tag change this function ever sees is a same-minor patch refresh (e.g.
-  1.26.7-alpine -> 1.26.8-alpine, or 3.24.0 -> 3.24.1), which is exactly
-  the kind of digest-freshness bump this exemption exists for. A RUN line,
-  apk package list change, or anything else in Dockerfile* still fails
-  the strict single-hunk-per-change check below and stays non-exempt.
+  the tag and/or digest on a `FROM ...@sha256:...` line -- the repository
+  itself must stay identical (mirrors is_dependabot_action_pin_only's
+  requirement that the action name not change alongside its SHA), so a
+  repository-name swap (e.g. golang -> evilcorp/golang) paired with a new
+  digest is never exempted even though the digest half of that diff looks
+  like a legitimate refresh. Tag changes are allowed on top of that,
+  because the ignore rules in .github/dependabot.yml already keep
+  Dependabot from proposing a golang/alpine minor or major bump on these
+  images -- so a tag change this function ever sees is a same-minor patch
+  refresh (e.g. 1.26.7-alpine -> 1.26.8-alpine, or 3.24.0 -> 3.24.1), which
+  is exactly the kind of digest-freshness bump this exemption exists for.
+  A RUN line, apk package list change, or anything else in Dockerfile*
+  still fails the strict single-hunk-per-change check below and stays
+  non-exempt.
   """
   if github_actor != "dependabot[bot]" or pr_author != "dependabot[bot]":
     return False
@@ -122,7 +132,9 @@ def is_dependabot_dockerfile_pin_only(changed_files, base_sha, head_sha, github_
       return False
     if match_old.group("prefix") != match_new.group("prefix") or match_old.group("suffix") != match_new.group("suffix"):
       return False
-    if match_old.group("image") == match_new.group("image") and match_old.group("digest") == match_new.group("digest"):
+    if match_old.group("repo") != match_new.group("repo"):
+      return False
+    if match_old.group("tag") == match_new.group("tag") and match_old.group("digest") == match_new.group("digest"):
       return False
   return True
 def main():

--- a/scripts/ci/test_check_agent_trace_requirement.py
+++ b/scripts/ci/test_check_agent_trace_requirement.py
@@ -24,6 +24,7 @@ POLICY = {
     "tracePathPrefix": ".agents/evals/traces/",
     "rules": [
         {"risk": "high", "pattern": ".github/workflows/**", "reason": "CI behavior"},
+        {"risk": "high", "pattern": "Dockerfile*", "reason": "release image build boundary"},
     ],
 }
 
@@ -34,6 +35,13 @@ PIN_V4 = "uses: actions/checkout@2222222222222222222222222222222222222222 # v4.0
 # because it only allowed a single "/" in the action reference.
 SUBPATH_PIN_OLD = "uses: github/codeql-action/upload-sarif@3333333333333333333333333333333333333333 # v4.37.8"
 SUBPATH_PIN_NEW = "uses: github/codeql-action/upload-sarif@4444444444444444444444444444444444444444 # v4.37.9"
+
+DIGEST_OLD = "a" * 64
+DIGEST_NEW = "b" * 64
+
+
+def _write_dockerfile(repo_dir, lines):
+    (repo_dir / "Dockerfile").write_text("\n".join(lines) + "\n")
 
 
 def _run_git(args, cwd):
@@ -273,6 +281,143 @@ class TraceRequirementCLITest(unittest.TestCase):
 
         result = self._run_script(
             [".github/workflows/ci.yml"],
+            [
+                "--base-sha",
+                base_sha,
+                "--head-sha",
+                head_sha,
+                "--github-actor",
+                "some-human",
+                "--pr-author",
+                "dependabot[bot]",
+            ],
+        )
+        self.assertEqual(result.returncode, 1, result.stdout)
+        report = json.loads(result.stdout)
+        self.assertFalse(report["traceExempt"])
+
+    def test_dockerfile_digest_only_bump_is_exempt(self):
+        _write_dockerfile(
+            self.repo_dir,
+            [
+                "FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:" + DIGEST_OLD + " AS builder",
+                "RUN apk add --no-cache git",
+                "FROM alpine:3.24@sha256:" + DIGEST_OLD,
+            ],
+        )
+        base_sha = _commit(self.repo_dir, "initial")
+        _write_dockerfile(
+            self.repo_dir,
+            [
+                "FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:" + DIGEST_NEW + " AS builder",
+                "RUN apk add --no-cache git",
+                "FROM alpine:3.24@sha256:" + DIGEST_NEW,
+            ],
+        )
+        head_sha = _commit(self.repo_dir, "bump base image digests")
+
+        result = self._run_script(
+            ["Dockerfile"],
+            [
+                "--base-sha",
+                base_sha,
+                "--head-sha",
+                head_sha,
+                "--github-actor",
+                "dependabot[bot]",
+                "--pr-author",
+                "dependabot[bot]",
+            ],
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertTrue(report["traceExempt"])
+        self.assertIn("Dockerfile", report["traceExemptReason"])
+
+    def test_dockerfile_tag_and_digest_bump_is_exempt(self):
+        # A tag change alongside the digest is still exempt: the ignore
+        # rules in .github/dependabot.yml already keep Dependabot from
+        # proposing a golang/alpine minor or major bump, so any tag change
+        # this function sees is a same-minor patch refresh (e.g.
+        # 1.26.7-alpine -> 1.26.8-alpine) -- functionally the same kind of
+        # freshness bump as a bare digest change.
+        _write_dockerfile(
+            self.repo_dir,
+            ["FROM golang:1.26.7-alpine@sha256:" + DIGEST_OLD + " AS builder"],
+        )
+        base_sha = _commit(self.repo_dir, "initial")
+        _write_dockerfile(
+            self.repo_dir,
+            ["FROM golang:1.26.8-alpine@sha256:" + DIGEST_NEW + " AS builder"],
+        )
+        head_sha = _commit(self.repo_dir, "bump golang patch tag and digest")
+
+        result = self._run_script(
+            ["Dockerfile"],
+            [
+                "--base-sha",
+                base_sha,
+                "--head-sha",
+                head_sha,
+                "--github-actor",
+                "dependabot[bot]",
+                "--pr-author",
+                "dependabot[bot]",
+            ],
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertTrue(report["traceExempt"])
+
+    def test_dockerfile_change_touching_run_line_is_not_exempt(self):
+        _write_dockerfile(
+            self.repo_dir,
+            [
+                "FROM golang:1.26-alpine@sha256:" + DIGEST_OLD + " AS builder",
+                "RUN apk add --no-cache git",
+            ],
+        )
+        base_sha = _commit(self.repo_dir, "initial")
+        _write_dockerfile(
+            self.repo_dir,
+            [
+                "FROM golang:1.26-alpine@sha256:" + DIGEST_NEW + " AS builder",
+                "RUN apk add --no-cache git curl",
+            ],
+        )
+        head_sha = _commit(self.repo_dir, "bump digest and change RUN line")
+
+        result = self._run_script(
+            ["Dockerfile"],
+            [
+                "--base-sha",
+                base_sha,
+                "--head-sha",
+                head_sha,
+                "--github-actor",
+                "dependabot[bot]",
+                "--pr-author",
+                "dependabot[bot]",
+            ],
+        )
+        self.assertEqual(result.returncode, 1, result.stdout)
+        report = json.loads(result.stdout)
+        self.assertFalse(report["traceExempt"])
+
+    def test_dockerfile_digest_bump_non_dependabot_actor_is_not_exempt(self):
+        _write_dockerfile(
+            self.repo_dir,
+            ["FROM alpine:3.24@sha256:" + DIGEST_OLD],
+        )
+        base_sha = _commit(self.repo_dir, "initial")
+        _write_dockerfile(
+            self.repo_dir,
+            ["FROM alpine:3.24@sha256:" + DIGEST_NEW],
+        )
+        head_sha = _commit(self.repo_dir, "bump alpine digest")
+
+        result = self._run_script(
+            ["Dockerfile"],
             [
                 "--base-sha",
                 base_sha,

--- a/scripts/ci/test_check_agent_trace_requirement.py
+++ b/scripts/ci/test_check_agent_trace_requirement.py
@@ -433,6 +433,98 @@ class TraceRequirementCLITest(unittest.TestCase):
         report = json.loads(result.stdout)
         self.assertFalse(report["traceExempt"])
 
+    def test_dockerfile_repository_swap_with_new_digest_is_not_exempt(self):
+        # Regression test for the reviewer-reproduced bug: the repository
+        # itself must stay identical, not just "image changed but that's
+        # fine because the digest also changed". A malicious repository
+        # swap paired with a new (attacker-controlled) digest must never
+        # be exempted from the trace requirement.
+        _write_dockerfile(
+            self.repo_dir,
+            ["FROM golang:1.26-alpine@sha256:" + DIGEST_OLD + " AS builder"],
+        )
+        base_sha = _commit(self.repo_dir, "initial")
+        _write_dockerfile(
+            self.repo_dir,
+            ["FROM evilcorp/golang:1.26-alpine@sha256:" + DIGEST_NEW + " AS builder"],
+        )
+        head_sha = _commit(self.repo_dir, "swap repository and digest")
+
+        result = self._run_script(
+            ["Dockerfile"],
+            [
+                "--base-sha",
+                base_sha,
+                "--head-sha",
+                head_sha,
+                "--github-actor",
+                "dependabot[bot]",
+                "--pr-author",
+                "dependabot[bot]",
+            ],
+        )
+        self.assertEqual(result.returncode, 1, result.stdout)
+        report = json.loads(result.stdout)
+        self.assertFalse(report["traceExempt"])
+
+    def test_dockerfile_same_repo_tag_change_only_is_exempt(self):
+        _write_dockerfile(
+            self.repo_dir,
+            ["FROM golang:1.26.7-alpine@sha256:" + DIGEST_OLD + " AS builder"],
+        )
+        base_sha = _commit(self.repo_dir, "initial")
+        _write_dockerfile(
+            self.repo_dir,
+            ["FROM golang:1.26.8-alpine@sha256:" + DIGEST_OLD + " AS builder"],
+        )
+        head_sha = _commit(self.repo_dir, "bump golang patch tag only")
+
+        result = self._run_script(
+            ["Dockerfile"],
+            [
+                "--base-sha",
+                base_sha,
+                "--head-sha",
+                head_sha,
+                "--github-actor",
+                "dependabot[bot]",
+                "--pr-author",
+                "dependabot[bot]",
+            ],
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertTrue(report["traceExempt"])
+
+    def test_dockerfile_same_repo_digest_change_only_is_exempt(self):
+        _write_dockerfile(
+            self.repo_dir,
+            ["FROM golang:1.26-alpine@sha256:" + DIGEST_OLD + " AS builder"],
+        )
+        base_sha = _commit(self.repo_dir, "initial")
+        _write_dockerfile(
+            self.repo_dir,
+            ["FROM golang:1.26-alpine@sha256:" + DIGEST_NEW + " AS builder"],
+        )
+        head_sha = _commit(self.repo_dir, "bump golang digest only")
+
+        result = self._run_script(
+            ["Dockerfile"],
+            [
+                "--base-sha",
+                base_sha,
+                "--head-sha",
+                head_sha,
+                "--github-actor",
+                "dependabot[bot]",
+                "--pr-author",
+                "dependabot[bot]",
+            ],
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertTrue(report["traceExempt"])
+
     def test_pr_with_trace_file_passes_regardless(self):
         result = self._run_script(
             [


### PR DESCRIPTION
## Summary

- **D1** (`.github/dependabot.yml`, gomod): ignore `k8s.io/*` and `sigs.k8s.io/*` minor/major bumps. Root cause reproduced locally: `go get k8s.io/api@v0.37.0 && go mod tidy` fails with the same ambiguous-genproto-import family the first post-#108 run (33604053019) hit, because client-go stays on v0.36.2 (still importing the v1alpha2 type v0.37 removed) while only k8s.io/api moves — Dependabot's per-module resolver can never propose the whole coordinated set together (that's a manual bump against `hack/compatibility-matrix.json`, #5). Patch bumps within a minor stay enabled via the existing `go-dependencies` group.
- **D2** (`.github/dependabot.yml`, docker): ignore `golang`/`alpine` minor/major bumps. PR #112 is the concrete failure: a Dockerfile-only golang minor bump both trips the behavior-contract trace gate (Dependabot can't author a trace) and violates CLAUDE.md's four-place Go version bump rule. Alpine minor bumps are ignored for a related reason: they change the apk closure recorded in `/licenses/os-packages-manifest.txt` (PR #104 / issue #26 D5), so that should be a deliberate PR, not an automatic weekly one. Patch/digest refreshes on the same minor line stay enabled for both.
- **D3/D4** (`scripts/ci/check-agent-trace-requirement.py`): extended the existing dependabot pin-only trace-gate exemption (previously GitHub Actions SHA pins only) to also cover a Dependabot PR whose only Dockerfile change is a `FROM ...@sha256:...` image reference. Tag changes count as pin-only alongside digest changes — justified because D2's new ignore rules already keep Dependabot from proposing anything but a same-minor patch refresh on these two images. Verified directly against PR #112's real diff (see below).

## Verified

- `python3 -m pytest scripts/ci/ -q` → 10/10 passed (6 pre-existing + 4 new table tests: digest-only exempt, tag+digest exempt, RUN-line change not exempt, non-dependabot actor not exempt).
- `python3 -c 'import yaml;yaml.safe_load(open(".github/dependabot.yml"))'` → parses cleanly.
- Local repro: `go get k8s.io/api@v0.37.0 && go mod tidy` in a scratch copy reproduces `dependency_file_not_resolvable` via an ambiguous `google.golang.org/genproto/googleapis/rpc/status` import; go.mod/go.sum in this worktree were never touched (`git status --short` confirms).
- `gofmt -l .` → no output (no Go source changed).
- Replayed `check-agent-trace-requirement.py` against PR #112's real commits (`gh pr view 112` + local `git diff`) with `--github-actor dependabot[bot] --pr-author dependabot[bot]` → exit 0, `traceExempt: true`, reason `dependabot pin-only bump of Dockerfile FROM image reference(s)`.
- This PR's own diff run through the same script (actor/author = human) → exit 0, `traceRequired: true`, `traceChanged: true` (trace file `.agents/evals/traces/2026-09-dependabot-k8s-set-and-docker-pins.json` included).
- `python3 .agents/evals/evaluate.py` → 5/5 behaviors passed, 100%. `python3 .agents/evals/gate.py` vs baseline → 0 regressions.

## Trade-off

`ignore` also suppresses Dependabot *security* PRs for these ranges; Dependabot alerts still fire and must be handled by a manual coordinated bump (k8s set with the compatibility matrix, hack/compatibility-matrix.json / #5; Go/Alpine via the four-place rule in CLAUDE.md). Confirmed against GitHub's docs: `ignore` conditions apply to both version-update and security-update pull requests, but not to Dependabot alerts themselves (https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore). This trade-off is unavoidable here regardless — the k8s.io/sigs.k8s.io coordinated-set failure applies to a security-triggered single-module bump exactly as it does to a version-update one — so it's stated explicitly in both `.github/dependabot.yml` ignore-block comments rather than hidden.

## Unverified

- The new `ignore` rules only prove out on Dependabot's next scheduled run against the live repo — cannot be exercised from this session.
- Whether GitHub's Dependabot service accepts the `dependency-name: "k8s.io/*"` glob-style ignore syntax exactly as used here; matched Dependabot's documented pattern, not independently confirmed by a config-validation CI check (none exists in this repo).

Part of #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PMya54VMirqPv7zEXY4mq
