### PR TITLE
ci(release): guard chart metadata before publishing

### DIFF
--- a/.agents/evals/traces/2026-09-release-preflight-guards.json
+++ b/.agents/evals/traces/2026-09-release-preflight-guards.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": "openforge-agent-trace/v1",
+  "consistencyMode": "strict",
+  "traceId": "nfs-quota-agent-issue-26-release-preflight-guards",
+  "task": "Fail closed before a v* release publishes chart metadata that disagrees with the tag, and correct the air-gap verification command (Part of #26)",
+  "changeContext": {
+    "paths": [
+      ".github/workflows/release.yaml",
+      "Makefile",
+      "CONTRIBUTING.md",
+      "README.md",
+      ".agents/evals/traces/2026-09-release-preflight-guards.json"
+    ]
+  },
+  "events": [
+    {
+      "id": "e1",
+      "type": "external_input",
+      "summary": "The release pre-flight report identified a tag/chart metadata mismatch and a non-runnable air-gap verification example, and specified fail-closed workflow and Make guards before publishing.",
+      "provenance": "Codex release pre-flight report",
+      "reviewed": true
+    },
+    {
+      "id": "e2",
+      "type": "scope_check",
+      "summary": "Scoped to release preflight metadata validation, its local Make equivalent and release documentation, the README air-gap verifier invocation, and release-bundle skopeo provenance. Chart.yaml values are intentionally untouched because setting them is the maintainer's release-time decision; no action pins, Harden Runner audit mode, allowlists, permissions, or existing step order were changed."
+    },
+    {
+      "id": "e3",
+      "type": "reproduction",
+      "summary": "The local Chart.yaml has version 0.4.1 and appVersion 0.3.0. Before this change, a v0.4.1 tag could proceed to publishing jobs without comparing either value to the tag, while README's standalone --bundle invocation omitted the required manifest.",
+      "evidence": [
+        "runtime:make-release-preflight-v0.4.1-failed-version-appVersion-mismatch",
+        "artifact:README-air-gap-command-missing-manifest-before-fix"
+      ]
+    },
+    {
+      "id": "e4",
+      "type": "bug_fix",
+      "summary": "Added release-preflight as the first release workflow job, after its required audit-mode Harden Runner and checkout, normalizing GITHUB_REF_NAME by removing v, printing the tag, Chart.yaml version, and appVersion, and failing unless all three agree. Every later publishing job now needs this job. Added the same fail-closed check as make release-preflight TAG=vX.Y.Z with an overrideable CHART_FILE for scratch testing, and documented the maintainer release-time version decision. README now uses the out-of-band verifier command with --bundle, --manifest, --trusted-root, and --require-signatures. release-bundle now pins the install to the Candidate version reported by apt-cache policy skopeo and logs skopeo --version.",
+      "evidence": [
+        "artifact:release-yaml-release-preflight-job-and-publishing-needs",
+        "artifact:Makefile-release-preflight-target",
+        "artifact:README-air-gap-require-signatures-command",
+        "artifact:release-bundle-skopeo-candidate-and-version-log"
+      ]
+    },
+    {
+      "id": "e5",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "make release-preflight TAG=v0.4.1 failed as intended with tag=0.4.1, chart version=0.4.1, chart appVersion=0.3.0, and the clear mismatch error. The same target passed against a scratch Chart.yaml copy with appVersion changed only in that copy to 0.4.1. Python YAML safe_load passed. actionlint reported only the two pre-existing SC2035 and SC2129 informational findings, with no new finding from these changes. Evaluation and baseline comparison gates passed.",
+      "scope": "local metadata-guard fail/pass behavior, workflow YAML syntax and actionlint delta, and trace evaluation; a real v* publish was not triggered",
+      "evidence": [
+        "runtime:make-release-preflight-v0.4.1-fail-output",
+        "runtime:make-release-preflight-scratch-chart-pass",
+        "ci:yaml-safe-load-release-yaml-pass",
+        "ci:actionlint-release-yaml-no-new-findings",
+        "test:agents-evals-evaluate-release-preflight-guards-pass",
+        "policy:agents-evals-gate-zero-regressions"
+      ]
+    },
+    {
+      "id": "e6",
+      "type": "completion_claim",
+      "summary": "The release path now stops before publication when the normalized v* tag, chart version, and appVersion differ; maintainers can reproduce the same check locally. The README command supplies all verifier-required trusted inputs, while Chart.yaml version values remain intentionally untouched for release-time selection."
+    },
+    {
+      "id": "e7",
+      "type": "task_outcome",
+      "state": "A",
+      "summary": "Complete for this guard and documentation scope, with local fail/pass, YAML, actionlint-delta, and evaluation-gate evidence recorded in e5. A real tagged release run remains intentionally unperformed because it would publish release artifacts."
+    }
+  ]
+}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,36 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  release-preflight:
+    name: Release Preflight
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            raw.githubusercontent.com:443
+            objects.githubusercontent.com:443
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Require chart metadata to match release tag
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          chart_version=$(sed -nE 's/^version:[[:space:]]*"?([^"#[:space:]]+)"?[[:space:]]*(#.*)?$/\1/p' charts/nfs-quota-agent/Chart.yaml)
+          chart_app_version=$(sed -nE 's/^appVersion:[[:space:]]*"?([^"#[:space:]]+)"?[[:space:]]*(#.*)?$/\1/p' charts/nfs-quota-agent/Chart.yaml)
+          echo "tag=$tag"
+          echo "chart version=$chart_version"
+          echo "chart appVersion=$chart_app_version"
+          if [ "$chart_version" != "$tag" ] || [ "$chart_app_version" != "$tag" ]; then
+            echo "Release preflight failed: tag, Chart.yaml version, and appVersion must all match" >&2
+            exit 1
+          fi
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -92,7 +122,7 @@ jobs:
   build-and-push:
     name: Build and Push Multi-arch Image
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, release-preflight]
     permissions:
       contents: read
       packages: write
@@ -224,7 +254,7 @@ jobs:
   release-binaries:
     name: Release Binaries
     runs-on: ubuntu-latest
-    needs: [test, changelog]
+    needs: [test, changelog, release-preflight]
     permissions:
       contents: write
       id-token: write # needed for keyless cosign signing (Fulcio OIDC token)
@@ -426,7 +456,7 @@ jobs:
   helm-release:
     name: Release Helm Chart
     runs-on: ubuntu-latest
-    needs: [test, changelog]
+    needs: [test, changelog, release-preflight]
     permissions:
       contents: write
       packages: write # needed to push the chart to the ghcr.io OCI registry
@@ -550,7 +580,7 @@ jobs:
   release-manifest:
     name: Publish Release Manifest
     runs-on: ubuntu-latest
-    needs: [build-and-push, release-binaries, helm-release]
+    needs: [build-and-push, release-binaries, helm-release, release-preflight]
     permissions:
       contents: write
       id-token: write # needed for keyless cosign signing (Fulcio OIDC token)
@@ -703,7 +733,7 @@ jobs:
     # convention as the chart's <chart>.tgz.sha256 in helm-release above),
     # not a manifest field.
     runs-on: ubuntu-latest
-    needs: [build-and-push, helm-release, release-manifest]
+    needs: [build-and-push, helm-release, release-manifest, release-preflight]
     permissions:
       contents: write
       id-token: write # needed for keyless cosign signing (Fulcio OIDC token)
@@ -825,7 +855,7 @@ jobs:
   update-changelog:
     name: Update CHANGELOG.md
     runs-on: ubuntu-latest
-    needs: [release-binaries]
+    needs: [release-binaries, release-preflight]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -775,7 +775,16 @@ jobs:
       - name: Install skopeo
         run: |
           sudo apt-get update
-          sudo apt-get install -y skopeo
+          # Pin the exact Candidate reported by `apt-cache policy skopeo` for
+          # this runner image; the candidate is logged for release provenance.
+          skopeo_version=$(apt-cache policy skopeo | awk '/Candidate:/ {print $2}')
+          if [ -z "$skopeo_version" ] || [ "$skopeo_version" = "(none)" ]; then
+            echo "apt-cache policy skopeo did not expose an installable Candidate" >&2
+            exit 1
+          fi
+          echo "Installing skopeo=$skopeo_version"
+          sudo apt-get install -y "skopeo=$skopeo_version"
+          skopeo --version
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,11 @@ Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build
 
 We automate our releases through GitHub Actions. Pushing a SemVer-compliant Git tag (e.g., `v1.2.3`) to the repository triggers the release workflow, which compiles release binaries, packages Helm charts, builds multi-arch container images, and generates a changelog entry using `git-cliff`.
 
+Before creating that tag, run `make release-preflight TAG=v1.2.3`. It fails
+unless `charts/nfs-quota-agent/Chart.yaml`'s `version` and `appVersion` both
+match the normalized tag (`1.2.3`). Set those Chart values as part of the
+maintainer's release-time version decision; the preflight only verifies them.
+
 Every release publishes a `release-manifest.json` GitHub Release asset recording the source commit, workflow run, container image digest, and sha256 digests of the chart, binaries, SBOM, and `compatibility-matrix.json`. After downloading a release's assets into one directory, verify them offline against that manifest with:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,13 @@ IMAGE_NAME=$(REGISTRY)/$(BINARY_NAME)
 VERSION?=latest
 PLATFORMS?=linux/amd64,linux/arm64,linux/arm/v7
 RELEASE_DIR?=.
+CHART_FILE?=charts/$(BINARY_NAME)/Chart.yaml
 
 .PHONY: all build build-linux clean test test-coverage fmt vet tidy lint \
 	license sbom generate compat-matrix compat-matrix-validate verify-release \
 	docker-build docker-push docker-buildx \
 	helm-lint helm-package helm-install helm-uninstall update-chart-digest \
-	release-bundle release-manifest-local
+	release-bundle release-manifest-local release-preflight
 
 # values.yaml to write image.digest into -- see update-chart-digest below.
 VALUES_FILE?=charts/$(BINARY_NAME)/values.yaml
@@ -194,6 +195,24 @@ sys.exit('missing status/evidence in: ' + repr(missing)) if missing else print('
 # without registry access).
 verify-release:
 	@python3 hack/verify-release.py $(RELEASE_DIR)
+
+# Fail before publishing a release whose chart metadata does not describe the
+# v* tag. CHART_FILE is overrideable so this guard can be exercised on a
+# scratch copy without changing the maintainer-controlled release values.
+release-preflight:
+	@test -n "$(TAG)" || { echo "Set TAG=vX.Y.Z" >&2; exit 1; }
+	@test -f "$(CHART_FILE)" || { echo "Chart file not found: $(CHART_FILE)" >&2; exit 1; }
+	@tag="$(TAG)"; \
+	case "$$tag" in v?*) normalized_tag="$${tag#v}" ;; *) echo "TAG must start with v: $$tag" >&2; exit 1 ;; esac; \
+	chart_version=$$(sed -nE 's/^version:[[:space:]]*"?([^"#[:space:]]+)"?[[:space:]]*(#.*)?$$/\1/p' "$(CHART_FILE)"); \
+	chart_app_version=$$(sed -nE 's/^appVersion:[[:space:]]*"?([^"#[:space:]]+)"?[[:space:]]*(#.*)?$$/\1/p' "$(CHART_FILE)"); \
+	echo "tag=$$normalized_tag"; \
+	echo "chart version=$$chart_version"; \
+	echo "chart appVersion=$$chart_app_version"; \
+	if [ "$$chart_version" != "$$normalized_tag" ] || [ "$$chart_app_version" != "$$normalized_tag" ]; then \
+		echo "Release preflight failed: tag, Chart.yaml version, and appVersion must all match" >&2; \
+		exit 1; \
+	fi
 
 # Build a single offline/air-gap install bundle (#5) from ALREADY-BUILT
 # inputs -- this target does not build the image or the chart itself, it
@@ -375,5 +394,6 @@ help:
 	@echo "  helm-uninstall   - Uninstall Helm release"
 	@echo "  update-chart-digest - Pin charts/nfs-quota-agent's image.digest (DIGEST=sha256:<64hex> or IMAGE=<repo:tag>)"
 	@echo "  verify-release   - Offline-verify a downloaded release bundle (RELEASE_DIR=...)"
+	@echo "  release-preflight - Require Chart.yaml version/appVersion to match TAG=vX.Y.Z"
 	@echo "  release-manifest-local - Produce a schemaVersion 4 release-manifest.json locally to exercise the schema"
 	@echo "  release-bundle   - Build an offline/air-gap install tar.gz (IMAGE_REF=..., CHART_TGZ=... required)"

--- a/README.md
+++ b/README.md
@@ -196,13 +196,21 @@ with `hack/update-chart-digest.py` or `--set image.digest=...`, then
 Verify a downloaded bundle before trusting it:
 
 ```bash
-python3 hack/verify-release.py --bundle nfs-quota-agent-<version>-offline.tar.gz
+# Use a trusted, separate checkout — never the verifier or trusted root
+# packaged inside the bundle being verified.
+git clone --depth 1 --branch v<version> https://github.com/dasomel/nfs-quota-agent.git /tmp/nfs-quota-agent-verify
+
+python3 /tmp/nfs-quota-agent-verify/hack/verify-release.py \
+  --bundle nfs-quota-agent-<version>-offline.tar.gz \
+  --manifest release-manifest.json \
+  --trusted-root /tmp/nfs-quota-agent-verify/hack/sigstore-trusted-root.json \
+  --require-signatures
 ```
 
 This checks the bundle archive's own checksum, that the OCI archive's
 image digest matches the release manifest's, and that the chart `.tgz`
-inside the bundle matches the release manifest's chart checksum. Add
-`--require-signatures` to also demand a valid cosign signature. To build a
+inside the bundle matches the release manifest's chart checksum, and requires
+valid cosign signatures for both the manifest and the bundle. To build a
 bundle locally instead of downloading one, see `make help`'s
 `release-bundle` target (needs an already-built image reference and an
 already-packaged chart — `IMAGE_REF=... CHART_TGZ=...`).


### PR DESCRIPTION
## Release preflight guard

Adds a fail-closed first release job that normalizes `vX.Y.Z` and requires Chart.yaml `version` and `appVersion` to match it before any publishing job can run. Publishing jobs now require the guard.

## Local Make verification

`make release-preflight TAG=v0.4.1` intentionally fails against the current Chart metadata:

```text
tag=0.4.1
chart version=0.4.1
chart appVersion=0.3.0
Release preflight failed: tag, Chart.yaml version, and appVersion must all match
make: *** [release-preflight] Error 1
```

A scratch Chart.yaml copy with both values set to `0.4.1` passes:

```text
tag=0.4.1
chart version=0.4.1
chart appVersion=0.4.1
```

## Air-gap and bundle provenance

Updates the README air-gap verification command to include the manifest, trusted root, and required signatures. The release-bundle job pins the `apt-cache policy skopeo` Candidate and logs `skopeo --version`.

Part of #26

Chart values intentionally untouched — set at release time

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01WxGaWLcL1sMhozNcvu9XhC