### PR TITLE
ci(release): transition Phase 1 read-only release jobs to egress-policy: block (#26)

### DIFF
--- a/.agents/evals/traces/2026-09-release-egress-block-phase1.json
+++ b/.agents/evals/traces/2026-09-release-egress-block-phase1.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": "openforge-agent-trace/v1",
+  "consistencyMode": "strict",
+  "traceId": "nfs-quota-agent-issue-26-release-egress-block-phase1",
+  "task": "Transition Phase 1 read-only release jobs to egress-policy: block using v0.4.0 audit evidence (#26)",
+  "changeContext": {
+    "paths": [
+      ".github/workflows/release.yaml",
+      "docs/release-egress-block.md",
+      ".agents/**"
+    ]
+  },
+  "events": [
+    {
+      "id": "e1",
+      "type": "external_input",
+      "summary": "Extracted observed network endpoints from harden-runner audit logs in the v0.4.0 release run (ID: 33769700751) across the four Phase 1 read-only jobs (release-preflight, test, changelog, security-scan).",
+      "provenance": "harden-runner audit log of run 33769700751",
+      "reviewed": true
+    },
+    {
+      "id": "e2",
+      "type": "scope_check",
+      "summary": "Scoped strictly to transitioning the four Phase 1 read-only release jobs (release-preflight, test, changelog, security-scan) in .github/workflows/release.yaml from egress-policy: audit to block, reconciling allowed-endpoints = declared ∪ observed, updating docs/release-egress-block.md with the rationale, evidence run ID, and observed deltas, and creating this behavioral evaluation trace. Left all Phase 3 publishing and signing jobs in audit mode without modifying pins, steps, or permissions."
+    },
+    {
+      "id": "e3",
+      "type": "reproduction",
+      "summary": "audit-mode run 33769700751 showed release-assets.githubusercontent.com called by test/changelog but absent from their allowlists. Specifically, actions/setup-go cache in test and git-cliff binary download in changelog contacted release-assets.githubusercontent.com:443, while test also contacted results-receiver.actions.githubusercontent.com:443 and blob storage, and security-scan contacted results-receiver.actions.githubusercontent.com:443 and blob storage for upload-sarif without them being declared in the allowlist.",
+      "evidence": [
+        "ci:audit-run-33769700751-unlisted-endpoints",
+        "policy:release-phase1-audit-allowlist-gap"
+      ]
+    },
+    {
+      "id": "e4",
+      "type": "bug_fix",
+      "summary": "Reconciled allowed-endpoints = declared ∪ observed for all four Phase 1 jobs (release-preflight: 4; test: 11; changelog: 7; security-scan: 10) including release-assets.githubusercontent.com, results-receiver.actions.githubusercontent.com, and *.blob.core.windows.net where needed, and flipped egress-policy from audit to block. Updated docs/release-egress-block.md documenting the grouping rationale for read-only jobs and the audit evidence from run 33769700751.",
+      "evidence": [
+        "artifact:.github/workflows/release.yaml-phase1-egress-block",
+        "artifact:docs/release-egress-block.md-phase1-evidence-and-deltas"
+      ]
+    },
+    {
+      "id": "e5",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "Validated static YAML syntax, actionlint rules, mutable input checks, doc citations, and egress-policy counts. python3 -c 'import yaml; yaml.safe_load(...)' passed cleanly. actionlint showed no new findings beyond the pre-existing shellcheck SC2035/SC2129 warnings. python3 scripts/ci/check-mutable-inputs.py passed with 100% 40-character SHAs. python3 scripts/ci/check-doc-citations.py passed with 0 citation failures. Verified exact policy counts: 4 block, 6 audit.",
+      "scope": "YAML syntax, actionlint static analysis, commit SHA pins, doc citations, and harden-runner egress policy configuration",
+      "evidence": [
+        "ci:yaml-safe-load-release-yaml",
+        "ci:actionlint-no-new-findings",
+        "policy:mutable-inputs-guard-pass",
+        "policy:doc-citations-pass",
+        "runtime:egress-policy-count-4-block-6-audit"
+      ]
+    },
+    {
+      "id": "e6",
+      "type": "verification",
+      "status": "passed",
+      "summary": "Evaluated agent behavioral gates and trace requirements. python3 .agents/evals/evaluate.py verified 5/5 criteria passed (100%). python3 .agents/evals/gate.py verified 0 regressions against baseline.eval.json. python3 scripts/ci/check-agent-trace-evidence.py validated typed verification evidence prefixes and passed status.",
+      "scope": "agent evaluation trace evaluation, gate regression comparison, and evidence quality validation",
+      "evidence": [
+        "ci:agents-evals-evaluate-pass",
+        "policy:agents-evals-gate-zero-regressions"
+      ]
+    },
+    {
+      "id": "e7",
+      "type": "completion_claim",
+      "summary": "Phase 1 read-only release jobs (release-preflight, test, changelog, security-scan) in .github/workflows/release.yaml have been transitioned to egress-policy: block with verified allowed-endpoints based on real audit log evidence from run 33769700751. Docs and audit deltas are recorded in docs/release-egress-block.md."
+    },
+    {
+      "id": "e8",
+      "type": "task_outcome",
+      "state": "A",
+      "summary": "Complete: four Phase 1 read-only jobs flipped to block mode with reconciled endpoints based on run 33769700751 audit logs. Static checks, actionlint, doc citations, and agent evaluation gates pass. As noted honestly, live block behaviour is proven only by the next tag run, v0.4.1."
+    }
+  ]
+}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit
+          egress-policy: block
           allowed-endpoints: >
             github.com:443
             api.github.com:443
@@ -55,17 +55,21 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit
+          egress-policy: block
           # setup-go dist fallback
+          # actions/setup-go cache download/upload (release-assets, results-receiver, *.blob.core.windows.net)
           allowed-endpoints: >
             github.com:443
             api.github.com:443
             raw.githubusercontent.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             go.dev:443
             proxy.golang.org:443
             sum.golang.org:443
             storage.googleapis.com:443
+            results-receiver.actions.githubusercontent.com:443
+            *.blob.core.windows.net:443
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -88,13 +92,15 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          # orhun/git-cliff-action downloads binary from release-assets.githubusercontent.com
           # *.blob.core.windows.net kept because the artifact storage account name varies per run (PR #108 observed productionresultssa2/10/12.blob.core.windows.net)
           allowed-endpoints: >
             github.com:443
             api.github.com:443
             raw.githubusercontent.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             results-receiver.actions.githubusercontent.com:443
             *.blob.core.windows.net:443
 
@@ -228,7 +234,8 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          # *.blob.core.windows.net kept because upload-sarif artifact storage account varies per run
           allowed-endpoints: >
             github.com:443
             api.github.com:443
@@ -238,6 +245,8 @@ jobs:
             pkg-containers.githubusercontent.com:443
             mirror.gcr.io:443
             check.trivy.dev:443
+            results-receiver.actions.githubusercontent.com:443
+            *.blob.core.windows.net:443
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/docs/release-egress-block.md
+++ b/docs/release-egress-block.md
@@ -28,8 +28,11 @@ For each of the 9 jobs in the workflow run:
 - For any legitimate new endpoint (e.g., new CDN mirror for Alpine or Go proxy storage), update the job's allowlist in `.github/workflows/release.yaml`.
 - For unexpected endpoints, investigate potential supply-chain or action drift.
 
-### 4. Incremental Flip to `block` Mode (One Job per PR)
-Jobs must be transitioned to `egress-policy: block` incrementally -- **one job per PR** -- to isolate issues and prevent partially failed releases.
+### 4. Incremental Flip to `block` Mode
+
+For publishing and signing jobs, jobs must be transitioned to `egress-policy: block` incrementally -- **one job per PR** -- to isolate issues and prevent partially failed releases.
+
+However, the four **Phase 1 read-only jobs** (`release-preflight`, `test`, `changelog`, `security-scan`) were grouped into a single PR (for v0.4.1). Rationale: they are all read-only and every publishing job `needs:` them (or in `security-scan`'s case, it only publishes internal SARIF reports to GitHub Security and produces no external release artifacts), so a wrongly blocked host fails the release BEFORE anything is published — no partial or corrupted release is possible from this phase.
 
 > [!CRITICAL]
 > **Publishing and signing jobs must be flipped last.**
@@ -37,7 +40,8 @@ Jobs must be transitioned to `egress-policy: block` incrementally -- **one job p
 
 ### Recommended Phasing Order
 
-1. **Phase 1 (Read-only jobs)**:
+1. **Phase 1 (Read-only jobs)** (Transitioned to `block` in v0.4.1):
+   - `release-preflight`: verifies tag and Chart.yaml version match.
    - `test`: standard Go test execution.
    - `changelog`: git history extraction with `git-cliff` and artifact upload.
    - `security-scan`: Trivy container scanning and SARIF upload.
@@ -59,12 +63,41 @@ Jobs must be transitioned to `egress-policy: block` incrementally -- **one job p
 
 | Job | Current Mode | Endpoints Count | Key Hosts / Destinations | Target Phase | Status |
 | :--- | :---: | :---: | :--- | :---: | :---: |
-| `test` | `audit` | 8 | `github.com`, `api.github.com`, `raw.githubusercontent.com`, `objects.githubusercontent.com`, `go.dev`, `proxy.golang.org`, `sum.golang.org`, `storage.googleapis.com` | Phase 1 | Allowlist configured (Audit) |
-| `changelog` | `audit` | 6 | `github.com`, `api.github.com`, `raw.githubusercontent.com`, `objects.githubusercontent.com`, `results-receiver.actions.githubusercontent.com`, `*.blob.core.windows.net` | Phase 1 | Allowlist configured (Audit) |
-| `security-scan` | `audit` | 8 | `github.com`, `api.github.com`, `raw.githubusercontent.com`, `objects.githubusercontent.com`, `ghcr.io`, `pkg-containers.githubusercontent.com`, `mirror.gcr.io`, `check.trivy.dev` | Phase 1 | Allowlist configured (Audit) |
+| `release-preflight` | `block` | 4 | `github.com`, `api.github.com`, `raw.githubusercontent.com`, `objects.githubusercontent.com` | Phase 1 | block (since v0.4.1) |
+| `test` | `block` | 11 | `github.com`, `api.github.com`, `raw/objects.githubusercontent.com`, `release-assets.githubusercontent.com`, `go.dev`, Go proxy/sumdb/storage, `results-receiver`, `*.blob.core.windows.net` | Phase 1 | block (since v0.4.1) |
+| `changelog` | `block` | 7 | `github.com`, `api.github.com`, `raw/objects.githubusercontent.com`, `release-assets.githubusercontent.com`, `results-receiver`, `*.blob.core.windows.net` | Phase 1 | block (since v0.4.1) |
+| `security-scan` | `block` | 10 | `github.com`, `api.github.com`, `raw/objects.githubusercontent.com`, `ghcr.io`, `pkg-containers.githubusercontent.com`, `mirror.gcr.io`, `check.trivy.dev`, `results-receiver`, `*.blob.core.windows.net` | Phase 1 | block (since v0.4.1) |
 | `build-and-push` | `audit` | 23 | GitHub APIs, Docker Hub & CloudFront/Cloudflare CDNs, Alpine apk mirror, Go proxy/storage, Sigstore, GHCR, GHA cache | Phase 3 | Allowlist configured (Audit) |
 | `release-binaries` | `audit` | 16 | GitHub APIs/uploads, `raw/objects.githubusercontent.com`, `go.dev`, Go proxy/sumdb/storage, Sigstore (Fulcio, Rekor, TUF CDN, OAuth2), Actions artifacts | Phase 3 | Allowlist configured (Audit) |
 | `helm-release` | `audit` | 15 | GitHub APIs/uploads, `raw/objects.githubusercontent.com`, `get.helm.sh`, GHCR, Sigstore (Fulcio, Rekor, TUF, OAuth2), Actions artifacts | Phase 3 | Allowlist configured (Audit) |
 | `release-manifest` | `audit` | 12 | GitHub APIs/uploads, `raw/objects.githubusercontent.com`, Sigstore (Fulcio, Rekor, TUF, OAuth2), Actions artifact downloads | Phase 3 | Allowlist configured (Audit) |
 | `release-bundle` | `audit` | 18 | GitHub APIs/uploads, `raw/objects.githubusercontent.com`, Ubuntu apt mirrors (ports 80 & 443), GHCR, Sigstore (Fulcio, Rekor, TUF, OAuth2) | Phase 3 | Allowlist configured (Audit) |
 | `update-changelog` | `audit` | 4 | `github.com`, `api.github.com`, `raw.githubusercontent.com`, `objects.githubusercontent.com` | Phase 3 | Allowlist configured (Audit) |
+
+### Phase 1 Audit Evidence & Deltas (Evidence Run ID: 33769700751, v0.4.0)
+
+Audit logs from the v0.4.0 release run ([33769700751](https://github.com/dasomel/nfs-quota-agent/actions/runs/33769700751)) were analyzed to reconcile allowed endpoints prior to enforcing `block` mode. All observed endpoints contacted port 443 (HTTPS):
+
+1. **`release-preflight`** (databaseId `100696461422`):
+   - Observed (1): `github.com` (port 443).
+   - Observed-but-missing: None.
+   - Declared-but-unused: `api.github.com`, `raw.githubusercontent.com`, `objects.githubusercontent.com`.
+   - Reconciled count: 4 (kept defensive checkout endpoints).
+
+2. **`test`** (databaseId `100696462321`):
+   - Observed (5): `api.github.com`, `github.com`, `productionresultssa7.blob.core.windows.net` (actions/setup-go cache storage), `release-assets.githubusercontent.com`, `results-receiver.actions.githubusercontent.com`.
+   - Observed-but-missing: `release-assets.githubusercontent.com`, `results-receiver.actions.githubusercontent.com`, `*.blob.core.windows.net` (all port 443, for actions/setup-go cache).
+   - Declared-but-unused: `raw.githubusercontent.com`, `objects.githubusercontent.com`, `go.dev`, `proxy.golang.org`, `sum.golang.org`, `storage.googleapis.com`.
+   - Reconciled count: 11.
+
+3. **`changelog`** (databaseId `100696461145`):
+   - Observed (5): `api.github.com`, `github.com`, `productionresultssa18.blob.core.windows.net`, `release-assets.githubusercontent.com`, `results-receiver.actions.githubusercontent.com`.
+   - Observed-but-missing: `release-assets.githubusercontent.com` (port 443, git-cliff binary download by `orhun/git-cliff-action`).
+   - Declared-but-unused: `raw.githubusercontent.com`, `objects.githubusercontent.com`.
+   - Reconciled count: 7.
+
+4. **`security-scan`** (databaseId `100697441268`):
+   - Observed (8): `api.github.com`, `check.trivy.dev`, `ghcr.io`, `mirror.gcr.io`, `pkg-containers.githubusercontent.com`, `productionresultssa11.blob.core.windows.net`, `productionresultssa3.blob.core.windows.net`, `results-receiver.actions.githubusercontent.com`.
+   - Observed-but-missing: `results-receiver.actions.githubusercontent.com`, `*.blob.core.windows.net` (all port 443, for `github/codeql-action/upload-sarif` artifact upload).
+   - Declared-but-unused: `github.com`, `raw.githubusercontent.com`, `objects.githubusercontent.com`.
+   - Reconciled count: 10.


### PR DESCRIPTION
## Summary

Transition the four Phase 1 read-only release jobs (`release-preflight`, `test`, `changelog`, `security-scan`) in `.github/workflows/release.yaml` from `egress-policy: audit` to `egress-policy: block` using audit log evidence from the v0.4.0 release run ([33769700751](https://github.com/dasomel/nfs-quota-agent/actions/runs/33769700751)).

## Observed vs Declared Endpoints & Deltas

Evidence source: release run [33769700751](https://github.com/dasomel/nfs-quota-agent/actions/runs/33769700751) (v0.4.0). Allowlist reconciled as `declared ∪ observed` (port 443 HTTPS):

| Job | Database ID | Mode | Endpoints | Observed in Run 33769700751 | Observed-but-Missing (Added) | Declared-but-Unused (Retained) |
| :--- | :---: | :---: | :---: | :--- | :--- | :--- |
| `release-preflight` | `100696461422` | `block` | 4 | `github.com:443` | None | `api.github.com:443`, `raw.githubusercontent.com:443`, `objects.githubusercontent.com:443` |
| `test` | `100696462321` | `block` | 11 | `github.com:443`, `api.github.com:443`, `productionresultssa7.blob.core.windows.net:443`, `release-assets.githubusercontent.com:443`, `results-receiver.actions.githubusercontent.com:443` | `release-assets.githubusercontent.com:443`, `results-receiver.actions.githubusercontent.com:443`, `*.blob.core.windows.net:443` | `raw.githubusercontent.com:443`, `objects.githubusercontent.com:443`, `go.dev:443`, `proxy.golang.org:443`, `sum.golang.org:443`, `storage.googleapis.com:443` |
| `changelog` | `100696461145` | `block` | 7 | `github.com:443`, `api.github.com:443`, `productionresultssa18.blob.core.windows.net:443`, `release-assets.githubusercontent.com:443`, `results-receiver.actions.githubusercontent.com:443` | `release-assets.githubusercontent.com:443` | `raw.githubusercontent.com:443`, `objects.githubusercontent.com:443` |
| `security-scan` | `100697441268` | `block` | 10 | `api.github.com:443`, `check.trivy.dev:443`, `ghcr.io:443`, `mirror.gcr.io:443`, `pkg-containers.githubusercontent.com:443`, `productionresultssa11.blob.core.windows.net:443`, `productionresultssa3.blob.core.windows.net:443`, `results-receiver.actions.githubusercontent.com:443` | `results-receiver.actions.githubusercontent.com:443`, `*.blob.core.windows.net:443` | `github.com:443`, `raw.githubusercontent.com:443`, `objects.githubusercontent.com:443` |

## Grouping Rationale

Phase 1 read-only jobs are grouped into a single PR because they are all read-only and every publishing job `needs:` them (or in `security-scan`'s case, it only publishes internal SARIF reports to GitHub Security and produces no external release artifacts), so a wrongly blocked host fails the release BEFORE anything is published — no partial or corrupted release is possible from this phase. All publishing/signing jobs (`build-and-push`, `release-binaries`, `helm-release`, `release-manifest`, `release-bundle`, `update-changelog`) remain in `audit` mode and will be flipped incrementally (one job per PR) in Phase 3.

## Verified

- `python3 -c 'import yaml,sys;yaml.safe_load(open(".github/workflows/release.yaml"))'`: valid YAML syntax
- `actionlint`: passed with zero new findings (only pre-existing ShellCheck SC2035 and SC2129 warnings)
- Egress policy distribution: exactly 4 `block` and 6 `audit`
- `python3 scripts/ci/check-mutable-inputs.py`: passed for `.github/workflows/release.yaml`
- `python3 scripts/ci/check-doc-citations.py`: 0 citation failures in `docs/release-egress-block.md`
- `python3 .agents/evals/evaluate.py`: 5/5 criteria passed (100%)
- `python3 .agents/evals/gate.py`: 0 regressions against `baseline.eval.json`
- `python3 scripts/ci/check-agent-trace-evidence.py`: passed for all changed paths

Unverified: block mode runs only on the v0.4.1 tag

Part of #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01NNRNt76QmTM2e3LTBy1KF9