### PR TITLE
ci(release): Phase 3 egress block for publishing and signing jobs (#26)

### DIFF
--- a/.agents/evals/traces/2026-09-release-egress-block-phase3.json
+++ b/.agents/evals/traces/2026-09-release-egress-block-phase3.json
@@ -1,0 +1,82 @@
+{
+  "schemaVersion": "openforge-agent-trace/v1",
+  "consistencyMode": "strict",
+  "traceId": "nfs-quota-agent-issue-26-release-egress-block-phase3",
+  "task": "Transition Phase 3 publishing and signing release jobs to egress-policy: block using v0.4.1 audit evidence (#26)",
+  "changeContext": {
+    "paths": [
+      ".github/workflows/release.yaml",
+      "docs/release-egress-block.md",
+      ".agents/**"
+    ]
+  },
+  "events": [
+    {
+      "id": "e1",
+      "type": "external_input",
+      "summary": "Extracted observed network endpoints from harden-runner audit logs in the v0.4.1 release run (ID: 33772050837) across the six Phase 3 publishing and signing jobs (build-and-push, release-binaries, helm-release, release-manifest, release-bundle, update-changelog).",
+      "provenance": "harden-runner audit log of run 33772050837",
+      "reviewed": true
+    },
+    {
+      "id": "e2",
+      "type": "scope_check",
+      "summary": "Scoped strictly to transitioning the six Phase 3 publishing and signing jobs in .github/workflows/release.yaml from egress-policy: audit to block, reconciling allowed-endpoints = declared ∪ observed, applying normalisation decisions D1-D3, adding rc-tag safety to prevent release pollution during verification, updating docs/release-egress-block.md, and creating this behavioral evaluation trace without modifying unrelated workflows, actions, or permissions."
+    },
+    {
+      "id": "e3",
+      "type": "reproduction",
+      "summary": "v0.4.1 audit shows timestamp.sigstore.dev, get.helm.sh, regional actions hosts and apt mirrors used but undeclared; publishing jobs still audit-only. Specifically, Cosign signing contacted timestamp.sigstore.dev:443 in all signing jobs, GHA runners contacted regional backends such as run-actions-2-azure-eastus.actions.githubusercontent.com:443, git-cliff binary download contacted release-assets.githubusercontent.com:443, and release-bundle contacted Ubuntu ESM/MOTD and Microsoft package mirrors while leaving publishing and signing jobs in audit mode.",
+      "evidence": [
+        "ci:audit-run-33772050837-unlisted-endpoints",
+        "policy:release-phase3-audit-allowlist-gap"
+      ]
+    },
+    {
+      "id": "e4",
+      "type": "bug_fix",
+      "summary": "Transitioned all six Phase 3 publishing and signing jobs to egress-policy: block with allowed-endpoints reconciled to declared ∪ observed. Normalised endpoints: wildcard *.actions.githubusercontent.com:443 for dynamic runner hosts, *.blob.core.windows.net:443 for runner cache/artifact storage, purged preinstalled Google Chrome apt repo to avoid allowlisting dl.google.com:443. Enforced rc-tag safety via release-preflight prerelease validation, softprops/action-gh-release prerelease/make_latest flags, and docker/metadata-action floating tag gating (!contains(github.ref_name, '-rc')). Updated docs/release-egress-block.md with Phase 3 audit evidence, decisions, and RC verification procedure.",
+      "evidence": [
+        "artifact:.github/workflows/release.yaml-phase3-egress-block",
+        "artifact:docs/release-egress-block.md-phase3-evidence-and-deltas"
+      ]
+    },
+    {
+      "id": "e5",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "Validated static YAML syntax, actionlint static analysis, mutable input check, doc citations, preflight rc validation, and egress-policy counts. python3 -c 'import yaml; yaml.safe_load(...)' passed cleanly. actionlint showed only pre-existing shellcheck SC2035/SC2129 findings. python3 scripts/ci/check-mutable-inputs.py passed with 100% SHA pins. python3 scripts/ci/check-doc-citations.py passed with 0 citation failures. make release-preflight and workflow preflight verified with scratch Chart.yaml version 0.4.2-rc1. Egress policy counts: 10 block, 0 audit.",
+      "scope": "YAML syntax, actionlint static analysis, commit SHA pins, doc citations, release preflight verification, and harden-runner egress policy configuration",
+      "evidence": [
+        "ci:yaml-safe-load-release-yaml",
+        "ci:actionlint-no-new-findings",
+        "policy:mutable-inputs-guard-pass",
+        "policy:doc-citations-pass",
+        "runtime:egress-policy-count-10-block-0-audit",
+        "artifact:scratch-preflight-rc1-verified"
+      ]
+    },
+    {
+      "id": "e6",
+      "type": "verification",
+      "status": "passed",
+      "summary": "Evaluated agent behavioral gates and trace requirements. python3 .agents/evals/evaluate.py verified 5/5 criteria passed (100%). python3 .agents/evals/gate.py verified 0 regressions against baseline.eval.json. python3 scripts/ci/check-agent-trace-evidence.py validated typed verification evidence prefixes and passed status.",
+      "scope": "agent evaluation trace evaluation, gate regression comparison, and evidence quality validation",
+      "evidence": [
+        "ci:agents-evals-evaluate-pass",
+        "policy:agents-evals-gate-zero-regressions"
+      ]
+    },
+    {
+      "id": "e7",
+      "type": "completion_claim",
+      "summary": "All six Phase 3 publishing and signing release jobs in .github/workflows/release.yaml have been transitioned to egress-policy: block with reconciled allowed-endpoints based on real audit log evidence from run 33772050837, protected by rc-tag safety controls. Docs and audit deltas are recorded in docs/release-egress-block.md."
+    },
+    {
+      "id": "e8",
+      "type": "task_outcome",
+      "state": "A",
+      "summary": "Complete: six Phase 3 publishing and signing jobs flipped to block mode with reconciled endpoints based on run 33772050837 audit logs, rc safety gates verified. Static checks, actionlint, doc citations, and agent evaluation gates pass. As noted honestly, live block behaviour for these jobs is proven only by the next rc tag run."
+    }
+  ]
+}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,7 @@
-# Every job's first step is step-security/harden-runner (#26). Egress policy
-# is currently kept on audit mode while declaring an explicit per-job
-# allowed-endpoints list derived from each job's tooling and external calls.
-# In audit mode, harden-runner does not block connections at runtime, but its
-# run summary highlights the DELTA between observed traffic and the declared
-# allowlist. This allows reconciling actual endpoints on the next tag run
-# before flipping jobs to block mode incrementally (one job per PR, publish
-# and signing jobs last; see docs/release-egress-block.md).
+# Every job's first step is step-security/harden-runner (#26). All jobs
+# run in block mode with explicit per-job allowed-endpoints lists
+# reconciled from v0.4.0 (Phase 1 read-only jobs) and v0.4.1 (Phase 3
+# publishing/signing jobs) audit logs. See docs/release-egress-block.md.
 name: Release
 
 on:
@@ -140,14 +136,18 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit
+          egress-policy: block
           # *.blob.core.windows.net kept because the GHA cache / artifact storage account name varies per run (PR #108 observed productionresultssa2/10/12.blob.core.windows.net)
+          # *.actions.githubusercontent.com kept because runner backend hostnames vary by region (e.g. run-actions-2-azure-eastus)
           allowed-endpoints: >
             github.com:443
             api.github.com:443
             raw.githubusercontent.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             token.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
             docker.io:443
@@ -164,7 +164,7 @@ jobs:
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
             oauth2.sigstore.dev:443
-            results-receiver.actions.githubusercontent.com:443
+            timestamp.sigstore.dev:443
             *.blob.core.windows.net:443
 
       - name: Checkout code
@@ -271,16 +271,20 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit
+          egress-policy: block
           # setup-go dist fallback
           # *.blob.core.windows.net kept because the artifact storage account name varies per run (PR #108 observed productionresultssa2/10/12.blob.core.windows.net)
+          # *.actions.githubusercontent.com kept because runner backend hostnames vary by region (e.g. run-actions-2-azure-eastus)
           allowed-endpoints: >
             github.com:443
             api.github.com:443
             uploads.github.com:443
             raw.githubusercontent.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             token.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
             go.dev:443
             proxy.golang.org:443
             sum.golang.org:443
@@ -289,7 +293,7 @@ jobs:
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
             oauth2.sigstore.dev:443
-            results-receiver.actions.githubusercontent.com:443
+            timestamp.sigstore.dev:443
             *.blob.core.windows.net:443
 
       - name: Checkout code
@@ -480,15 +484,19 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit
+          egress-policy: block
           # *.blob.core.windows.net kept because the artifact storage account name varies per run (PR #108 observed productionresultssa2/10/12.blob.core.windows.net)
+          # *.actions.githubusercontent.com kept because runner backend hostnames vary by region (e.g. run-actions-2-azure-eastus)
           allowed-endpoints: >
             github.com:443
             api.github.com:443
             uploads.github.com:443
             raw.githubusercontent.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             token.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
             get.helm.sh:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
@@ -496,7 +504,7 @@ jobs:
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
             oauth2.sigstore.dev:443
-            results-receiver.actions.githubusercontent.com:443
+            timestamp.sigstore.dev:443
             *.blob.core.windows.net:443
 
       - name: Checkout code
@@ -606,20 +614,24 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit
+          egress-policy: block
           # *.blob.core.windows.net kept because the artifact storage account name varies per run (PR #108 observed productionresultssa2/10/12.blob.core.windows.net)
+          # *.actions.githubusercontent.com kept because runner backend hostnames vary by region (e.g. run-actions-2-azure-eastus)
           allowed-endpoints: >
             github.com:443
             api.github.com:443
             uploads.github.com:443
             raw.githubusercontent.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             token.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
             oauth2.sigstore.dev:443
-            results-receiver.actions.githubusercontent.com:443
+            timestamp.sigstore.dev:443
             *.blob.core.windows.net:443
 
       - name: Checkout code
@@ -757,41 +769,43 @@ jobs:
       id-token: write # needed for keyless cosign signing (Fulcio OIDC token)
     steps:
       - name: Harden Runner
-        # audit, not block: this job needs egress to the Ubuntu package
-        # archive (installing skopeo) and to ghcr.io (pulling the just-
-        # published multi-arch image by digest) -- see ci.yaml:16-19 for
-        # why "audit" rather than "block" is this repo's current default
-        # for release.yaml until an allowlist exists for these plus the
-        # existing jobs' hosts (GHCR, Sigstore Fulcio/Rekor, GitHub
-        # Releases).
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          # *.actions.githubusercontent.com kept because runner backend hostnames vary by region (e.g. run-actions-2-azure-eastus)
           allowed-endpoints: >
             github.com:443
             api.github.com:443
             uploads.github.com:443
             raw.githubusercontent.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             token.actions.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
             archive.ubuntu.com:80
             azure.archive.ubuntu.com:80
             security.ubuntu.com:80
             archive.ubuntu.com:443
             azure.archive.ubuntu.com:443
             security.ubuntu.com:443
+            esm.ubuntu.com:443
+            motd.ubuntu.com:443
+            packages.microsoft.com:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
             oauth2.sigstore.dev:443
+            timestamp.sigstore.dev:443
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install skopeo
         run: |
+          # Remove foreign repos (e.g. Google Chrome) not permitted under harden-runner egress policy
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google*.list /etc/apt/sources.list.d/*google* /etc/apt/sources.list.d/*chrome* || true
           sudo apt-get update
           # Pin the exact Candidate reported by `apt-cache policy skopeo` for
           # this runner image; the candidate is logged for release provenance.
@@ -889,12 +903,14 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          # orhun/git-cliff-action downloads binary from release-assets.githubusercontent.com
           allowed-endpoints: >
             github.com:443
             api.github.com:443
             raw.githubusercontent.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -191,11 +191,15 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Gate floating tags (latest, 0.4, 0) so an rc tag (e.g. v0.4.2-rc1) does
+          # not move floating production tags to an unverified release candidate.
+          flavor: |
+            latest=${{ !contains(github.ref_name, '-rc') }}
           tags: |
             type=ref,event=tag
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref_name, '-rc') }}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref_name, '-rc') }}
             type=sha
 
       - name: Build and push multi-arch image
@@ -459,6 +463,8 @@ jobs:
             dist/checksums.txt.bundle
             dist/sbom.spdx.json
           generate_release_notes: false
+          prerelease: ${{ contains(github.ref_name, '-rc') }}
+          make_latest: ${{ contains(github.ref_name, '-rc') && 'false' || 'true' }}
 
       - name: Upload binary checksums for manifest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -572,6 +578,8 @@ jobs:
             .helm-releases/${{ steps.package.outputs.chart_file }}.sha256
             .helm-releases/${{ steps.package.outputs.chart_file }}.bundle
           generate_release_notes: false
+          prerelease: ${{ contains(github.ref_name, '-rc') }}
+          make_latest: ${{ contains(github.ref_name, '-rc') && 'false' || 'true' }}
 
       - name: Log in to GHCR for Helm OCI push
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
@@ -749,6 +757,8 @@ jobs:
             release-manifest.json.bundle
             hack/compatibility-matrix.json
           generate_release_notes: false
+          prerelease: ${{ contains(github.ref_name, '-rc') }}
+          make_latest: ${{ contains(github.ref_name, '-rc') && 'false' || 'true' }}
 
   release-bundle:
     name: Publish Offline Install Bundle
@@ -892,6 +902,8 @@ jobs:
             ${{ env.BUNDLE_FILE }}.sha256
             ${{ env.BUNDLE_FILE }}.bundle
           generate_release_notes: false
+          prerelease: ${{ contains(github.ref_name, '-rc') }}
+          make_latest: ${{ contains(github.ref_name, '-rc') && 'false' || 'true' }}
 
   update-changelog:
     name: Update CHANGELOG.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,6 +147,12 @@ jobs:
             release-assets.githubusercontent.com:443
             token.actions.githubusercontent.com:443
             results-receiver.actions.githubusercontent.com:443
+            # D4: harden-runner (agent v0.16.3) matches wildcards by suffix, so this
+            # also admits deeper subdomains. Kept deliberately: the Actions results
+            # host is region-specific (observed run-actions-2-azure-eastus.actions.
+            # githubusercontent.com on run 33772050837) and enumerating it would
+            # break releases scheduled onto another region. Accepted exception, see
+            # docs/release-egress-block.md "Wildcard exceptions".
             *.actions.githubusercontent.com:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
@@ -288,6 +294,12 @@ jobs:
             release-assets.githubusercontent.com:443
             token.actions.githubusercontent.com:443
             results-receiver.actions.githubusercontent.com:443
+            # D4: harden-runner (agent v0.16.3) matches wildcards by suffix, so this
+            # also admits deeper subdomains. Kept deliberately: the Actions results
+            # host is region-specific (observed run-actions-2-azure-eastus.actions.
+            # githubusercontent.com on run 33772050837) and enumerating it would
+            # break releases scheduled onto another region. Accepted exception, see
+            # docs/release-egress-block.md "Wildcard exceptions".
             *.actions.githubusercontent.com:443
             go.dev:443
             proxy.golang.org:443
@@ -502,6 +514,12 @@ jobs:
             release-assets.githubusercontent.com:443
             token.actions.githubusercontent.com:443
             results-receiver.actions.githubusercontent.com:443
+            # D4: harden-runner (agent v0.16.3) matches wildcards by suffix, so this
+            # also admits deeper subdomains. Kept deliberately: the Actions results
+            # host is region-specific (observed run-actions-2-azure-eastus.actions.
+            # githubusercontent.com on run 33772050837) and enumerating it would
+            # break releases scheduled onto another region. Accepted exception, see
+            # docs/release-egress-block.md "Wildcard exceptions".
             *.actions.githubusercontent.com:443
             get.helm.sh:443
             ghcr.io:443
@@ -634,6 +652,12 @@ jobs:
             release-assets.githubusercontent.com:443
             token.actions.githubusercontent.com:443
             results-receiver.actions.githubusercontent.com:443
+            # D4: harden-runner (agent v0.16.3) matches wildcards by suffix, so this
+            # also admits deeper subdomains. Kept deliberately: the Actions results
+            # host is region-specific (observed run-actions-2-azure-eastus.actions.
+            # githubusercontent.com on run 33772050837) and enumerating it would
+            # break releases scheduled onto another region. Accepted exception, see
+            # docs/release-egress-block.md "Wildcard exceptions".
             *.actions.githubusercontent.com:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
@@ -791,6 +815,12 @@ jobs:
             objects.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             token.actions.githubusercontent.com:443
+            # D4: harden-runner (agent v0.16.3) matches wildcards by suffix, so this
+            # also admits deeper subdomains. Kept deliberately: the Actions results
+            # host is region-specific (observed run-actions-2-azure-eastus.actions.
+            # githubusercontent.com on run 33772050837) and enumerating it would
+            # break releases scheduled onto another region. Accepted exception, see
+            # docs/release-egress-block.md "Wildcard exceptions".
             *.actions.githubusercontent.com:443
             archive.ubuntu.com:80
             azure.archive.ubuntu.com:80

--- a/docs/release-egress-block.md
+++ b/docs/release-egress-block.md
@@ -156,3 +156,12 @@ Because Phase 3 involves irrevocable actions (pushing container tags to GHCR, pu
 1. **Preflight Guard**: `release-preflight` and `make release-preflight` support SemVer prereleases (`vX.Y.Z-rcN`) matching Chart.yaml `version: X.Y.Z-rcN` and `appVersion: "X.Y.Z-rcN"`.
 2. **Release Marking**: All `softprops/action-gh-release` steps configure `prerelease: ${{ contains(github.ref_name, '-rc') }}` and `make_latest: ${{ contains(github.ref_name, '-rc') && 'false' || 'true' }}`, ensuring RC runs never become the repository's "Latest" release.
 3. **Floating Tag Protection**: `docker/metadata-action` gates `latest`, `{{major}}.{{minor}}` (`0.4`), and `{{major}}` (`0`) on `!contains(github.ref_name, '-rc')`, guaranteeing that only the specific RC tag (`v0.4.2-rc1`, `0.4.2-rc1`) and sha tags are published.
+
+## Wildcard exceptions (accepted, D4)
+
+harden-runner's allowlist wildcards match by **suffix** (step-security/agent v0.16.3 `dnsproxy.go`), not by a single DNS label. Two wildcards are kept on purpose:
+
+- `*.blob.core.windows.net:443` — the Actions artifact storage account name varies per run (`productionresultssa1..19` observed on run 33772050837).
+- `*.actions.githubusercontent.com:443` — the Actions results host is region-specific (`run-actions-2-azure-eastus.actions.githubusercontent.com` observed on run 33772050837); enumerating it would fail releases scheduled onto another region.
+
+Both admit deeper subdomains than intended. They are limited to GitHub- and Azure-operated infrastructure and were reviewed as an accepted exception (Codex critic review of PR #137). Revisit if harden-runner adds single-label wildcard semantics.

--- a/docs/release-egress-block.md
+++ b/docs/release-egress-block.md
@@ -67,12 +67,12 @@ However, the four **Phase 1 read-only jobs** (`release-preflight`, `test`, `chan
 | `test` | `block` | 11 | `github.com`, `api.github.com`, `raw/objects.githubusercontent.com`, `release-assets.githubusercontent.com`, `go.dev`, Go proxy/sumdb/storage, `results-receiver`, `*.blob.core.windows.net` | Phase 1 | block (since v0.4.1) |
 | `changelog` | `block` | 7 | `github.com`, `api.github.com`, `raw/objects.githubusercontent.com`, `release-assets.githubusercontent.com`, `results-receiver`, `*.blob.core.windows.net` | Phase 1 | block (since v0.4.1) |
 | `security-scan` | `block` | 10 | `github.com`, `api.github.com`, `raw/objects.githubusercontent.com`, `ghcr.io`, `pkg-containers.githubusercontent.com`, `mirror.gcr.io`, `check.trivy.dev`, `results-receiver`, `*.blob.core.windows.net` | Phase 1 | block (since v0.4.1) |
-| `build-and-push` | `audit` | 23 | GitHub APIs, Docker Hub & CloudFront/Cloudflare CDNs, Alpine apk mirror, Go proxy/storage, Sigstore, GHCR, GHA cache | Phase 3 | Allowlist configured (Audit) |
-| `release-binaries` | `audit` | 16 | GitHub APIs/uploads, `raw/objects.githubusercontent.com`, `go.dev`, Go proxy/sumdb/storage, Sigstore (Fulcio, Rekor, TUF CDN, OAuth2), Actions artifacts | Phase 3 | Allowlist configured (Audit) |
-| `helm-release` | `audit` | 15 | GitHub APIs/uploads, `raw/objects.githubusercontent.com`, `get.helm.sh`, GHCR, Sigstore (Fulcio, Rekor, TUF, OAuth2), Actions artifacts | Phase 3 | Allowlist configured (Audit) |
-| `release-manifest` | `audit` | 12 | GitHub APIs/uploads, `raw/objects.githubusercontent.com`, Sigstore (Fulcio, Rekor, TUF, OAuth2), Actions artifact downloads | Phase 3 | Allowlist configured (Audit) |
-| `release-bundle` | `audit` | 18 | GitHub APIs/uploads, `raw/objects.githubusercontent.com`, Ubuntu apt mirrors (ports 80 & 443), GHCR, Sigstore (Fulcio, Rekor, TUF, OAuth2) | Phase 3 | Allowlist configured (Audit) |
-| `update-changelog` | `audit` | 4 | `github.com`, `api.github.com`, `raw.githubusercontent.com`, `objects.githubusercontent.com` | Phase 3 | Allowlist configured (Audit) |
+| `build-and-push` | `block` | 26 | GitHub APIs, `release-assets`, `*.actions.githubusercontent.com`, Docker Hub & CDNs, Alpine apk, Go proxy, Sigstore (incl. `timestamp`), GHCR, `*.blob.core.windows.net` | Phase 3 | block (pending verification on the next rc tag) |
+| `release-binaries` | `block` | 19 | GitHub APIs/uploads, `release-assets`, `*.actions.githubusercontent.com`, `go.dev`, Go proxy/sumdb/storage, Sigstore (incl. `timestamp`), `*.blob.core.windows.net` | Phase 3 | block (pending verification on the next rc tag) |
+| `helm-release` | `block` | 18 | GitHub APIs/uploads, `release-assets`, `*.actions.githubusercontent.com`, `get.helm.sh`, GHCR, Sigstore (incl. `timestamp`), `*.blob.core.windows.net` | Phase 3 | block (pending verification on the next rc tag) |
+| `release-manifest` | `block` | 15 | GitHub APIs/uploads, `release-assets`, `*.actions.githubusercontent.com`, Sigstore (incl. `timestamp`), `*.blob.core.windows.net` | Phase 3 | block (pending verification on the next rc tag) |
+| `release-bundle` | `block` | 24 | GitHub APIs/uploads, `release-assets`, `*.actions.githubusercontent.com`, Ubuntu apt mirrors (ports 80 & 443; archive, esm, motd, packages.microsoft.com), GHCR, Sigstore (incl. `timestamp`) | Phase 3 | block (pending verification on the next rc tag) |
+| `update-changelog` | `block` | 5 | `github.com`, `api.github.com`, `raw/objects.githubusercontent.com`, `release-assets.githubusercontent.com` | Phase 3 | block (pending verification on the next rc tag) |
 
 ### Phase 1 Audit Evidence & Deltas (Evidence Run ID: 33769700751, v0.4.0)
 
@@ -101,3 +101,58 @@ Audit logs from the v0.4.0 release run ([33769700751](https://github.com/dasomel
    - Observed-but-missing: `results-receiver.actions.githubusercontent.com`, `*.blob.core.windows.net` (all port 443, for `github/codeql-action/upload-sarif` artifact upload).
    - Declared-but-unused: `github.com`, `raw.githubusercontent.com`, `objects.githubusercontent.com`.
    - Reconciled count: 10.
+
+### Phase 3 Audit Evidence & Deltas (Evidence Run ID: 33772050837, v0.4.1)
+
+Audit logs from the v0.4.1 release run ([33772050837](https://github.com/dasomel/nfs-quota-agent/actions/runs/33772050837)) were analyzed to reconcile allowed endpoints across the six publishing and signing jobs before flipping them to `block` mode:
+
+1. **`build-and-push`**:
+   - Observed (26): `api.github.com`, `auth.docker.io`, `fulcio.sigstore.dev`, `ghcr.io`, `github.com`, `production.cloudfront.docker.com`, `productionresultssa1..19.blob.core.windows.net` (13 distinct accounts, matching `*.blob.core.windows.net`), `registry-1.docker.io`, `rekor.sigstore.dev`, `release-assets.githubusercontent.com`, `results-receiver.actions.githubusercontent.com`, `run-actions-2-azure-eastus.actions.githubusercontent.com`, `timestamp.sigstore.dev`, `tuf-repo-cdn.sigstore.dev` (all port 443).
+   - Observed-but-missing: `release-assets.githubusercontent.com`, `timestamp.sigstore.dev`, and `run-actions-2-azure-eastus.actions.githubusercontent.com` (normalised to `*.actions.githubusercontent.com` port 443 per D2).
+   - Declared-but-unused: `raw.githubusercontent.com`, `objects.githubusercontent.com`, `token.actions.githubusercontent.com`, `pkg-containers.githubusercontent.com`, `docker.io`, `index.docker.io`, `production.cloudflare.docker.com`, `dl-cdn.alpinelinux.org`, `proxy.golang.org`, `sum.golang.org`, `storage.googleapis.com`, `oauth2.sigstore.dev` (retained defensively for buildx caching, APK mirrors, and Go modules).
+   - Reconciled count: 26.
+
+2. **`release-binaries`**:
+   - Observed (13): `api.github.com`, `fulcio.sigstore.dev`, `github.com`, `productionresultssa6..7.blob.core.windows.net`, `raw.githubusercontent.com`, `rekor.sigstore.dev`, `release-assets.githubusercontent.com`, `results-receiver.actions.githubusercontent.com`, `run-actions-2-azure-eastus.actions.githubusercontent.com`, `timestamp.sigstore.dev`, `tuf-repo-cdn.sigstore.dev`, `uploads.github.com` (all port 443).
+   - Observed-but-missing: `release-assets.githubusercontent.com`, `timestamp.sigstore.dev`, `run-actions-2-azure-eastus.actions.githubusercontent.com` (normalised to `*.actions.githubusercontent.com` port 443 per D2).
+   - Declared-but-unused: `objects.githubusercontent.com`, `token.actions.githubusercontent.com`, `go.dev`, `proxy.golang.org`, `sum.golang.org`, `storage.googleapis.com`, `oauth2.sigstore.dev`.
+   - Reconciled count: 19.
+
+3. **`helm-release`**:
+   - Observed (13): `api.github.com`, `fulcio.sigstore.dev`, `get.helm.sh`, `ghcr.io`, `github.com`, `productionresultssa6.blob.core.windows.net`, `rekor.sigstore.dev`, `release-assets.githubusercontent.com`, `results-receiver.actions.githubusercontent.com`, `run-actions-2-azure-eastus.actions.githubusercontent.com`, `timestamp.sigstore.dev`, `tuf-repo-cdn.sigstore.dev`, `uploads.github.com` (all port 443).
+   - Observed-but-missing: `release-assets.githubusercontent.com`, `timestamp.sigstore.dev`, `run-actions-2-azure-eastus.actions.githubusercontent.com` (normalised to `*.actions.githubusercontent.com` port 443 per D2). (`get.helm.sh` confirmed in audit and retained).
+   - Declared-but-unused: `raw.githubusercontent.com`, `objects.githubusercontent.com`, `token.actions.githubusercontent.com`, `pkg-containers.githubusercontent.com`, `oauth2.sigstore.dev`.
+   - Reconciled count: 18.
+
+4. **`release-manifest`**:
+   - Observed (11): `api.github.com`, `fulcio.sigstore.dev`, `github.com`, `productionresultssa6.blob.core.windows.net`, `rekor.sigstore.dev`, `release-assets.githubusercontent.com`, `results-receiver.actions.githubusercontent.com`, `run-actions-2-azure-eastus.actions.githubusercontent.com`, `timestamp.sigstore.dev`, `tuf-repo-cdn.sigstore.dev`, `uploads.github.com` (all port 443).
+   - Observed-but-missing: `release-assets.githubusercontent.com`, `timestamp.sigstore.dev`, `run-actions-2-azure-eastus.actions.githubusercontent.com` (normalised to `*.actions.githubusercontent.com` port 443 per D2).
+   - Declared-but-unused: `raw.githubusercontent.com`, `objects.githubusercontent.com`, `token.actions.githubusercontent.com`, `oauth2.sigstore.dev`.
+   - Reconciled count: 15.
+
+5. **`release-bundle`**:
+   - Observed (16): `api.github.com` (port 443), `azure.archive.ubuntu.com` (port 80), `dl.google.com` (port 443; runner Chrome apt repo, excluded per D3), `esm.ubuntu.com` (port 443), `fulcio.sigstore.dev` (port 443), `ghcr.io` (port 443), `github.com` (port 443), `motd.ubuntu.com` (port 443), `packages.microsoft.com` (port 443), `pkg-containers.githubusercontent.com` (port 443), `rekor.sigstore.dev` (port 443), `release-assets.githubusercontent.com` (port 443), `run-actions-2-azure-eastus.actions.githubusercontent.com` (port 443; normalised to `*.actions.githubusercontent.com` per D2), `timestamp.sigstore.dev` (port 443), `tuf-repo-cdn.sigstore.dev` (port 443), `uploads.github.com` (port 443).
+   - Observed-but-missing: `esm.ubuntu.com`, `motd.ubuntu.com`, `packages.microsoft.com`, `release-assets.githubusercontent.com`, `timestamp.sigstore.dev`, `run-actions-2-azure-eastus.actions.githubusercontent.com` (all port 443).
+   - Normalisation: `dl.google.com` is explicitly NOT allowlisted. Instead, the runner's preinstalled Google Chrome apt sources are removed before `apt-get update` (matching `.github/workflows/e2e-airgap.yaml` pattern), eliminating unwanted third-party browser traffic.
+   - Declared-but-unused: `raw.githubusercontent.com`, `objects.githubusercontent.com`, `token.actions.githubusercontent.com`, `archive.ubuntu.com` (ports 80 & 443), `security.ubuntu.com` (ports 80 & 443), `azure.archive.ubuntu.com` (port 443), `oauth2.sigstore.dev`.
+   - Reconciled count: 24.
+
+6. **`update-changelog`**:
+   - Observed (3): `api.github.com`, `github.com`, `release-assets.githubusercontent.com` (all port 443).
+   - Observed-but-missing: `release-assets.githubusercontent.com` (binary download by `orhun/git-cliff-action`).
+   - Declared-but-unused: `raw.githubusercontent.com`, `objects.githubusercontent.com`.
+   - Reconciled count: 5.
+
+### Normalisation Decisions (D1–D3)
+
+- **D1 (Azure Blob Wildcard)**: Use `*.blob.core.windows.net` (port 443) rather than pinning individual `productionresultssa<N>` accounts, as runner artifact and cache storage account names vary arbitrarily by region and run.
+- **D2 (Actions Runner Backend Wildcard)**: Use `*.actions.githubusercontent.com` (port 443) and drop specific regional hostnames like `run-actions-2-azure-eastus.actions.githubusercontent.com` because runner backend assignments depend on dynamic runner pool routing.
+- **D3 (Foreign APT Repository Removal)**: In `release-bundle`, remove Google Chrome apt source files (`sudo rm -f /etc/apt/sources.list.d/*chrome*`) prior to `apt-get update` instead of adding `dl.google.com` to `allowed-endpoints`, adhering to the principle of least privilege.
+
+### RC Verification Procedure
+
+Because Phase 3 involves irrevocable actions (pushing container tags to GHCR, publishing GitHub release assets), verifying the transition to `block` mode is decoupled from production releases via release candidate tags (e.g. `v0.4.2-rc1`):
+
+1. **Preflight Guard**: `release-preflight` and `make release-preflight` support SemVer prereleases (`vX.Y.Z-rcN`) matching Chart.yaml `version: X.Y.Z-rcN` and `appVersion: "X.Y.Z-rcN"`.
+2. **Release Marking**: All `softprops/action-gh-release` steps configure `prerelease: ${{ contains(github.ref_name, '-rc') }}` and `make_latest: ${{ contains(github.ref_name, '-rc') && 'false' || 'true' }}`, ensuring RC runs never become the repository's "Latest" release.
+3. **Floating Tag Protection**: `docker/metadata-action` gates `latest`, `{{major}}.{{minor}}` (`0.4`), and `{{major}}` (`0`) on `!contains(github.ref_name, '-rc')`, guaranteeing that only the specific RC tag (`v0.4.2-rc1`, `0.4.2-rc1`) and sha tags are published.


### PR DESCRIPTION
### Summary

This PR transitions the six Phase 3 publishing, uploading, and signing release jobs in `.github/workflows/release.yaml` to `egress-policy: block` using empirical audit evidence from release v0.4.1 (run 33772050837). In addition, it establishes release candidate (`-rc`) safety mechanisms to verify the egress block policy on the next RC tag without polluting stable production releases.

Part of #26

### Observed vs Declared Allowlist Reconciliation (v0.4.1 Evidence)

| Job | Declared Endpoints | Observed Endpoints | Reconciled Count | Key Added / Normalized Endpoints |
| :--- | :---: | :---: | :---: | :--- |
| `build-and-push` | 23 | 26 | 26 | `release-assets.githubusercontent.com:443`, `*.actions.githubusercontent.com:443`, `timestamp.sigstore.dev:443` |
| `release-binaries` | 16 | 13 | 19 | `release-assets.githubusercontent.com:443`, `*.actions.githubusercontent.com:443`, `timestamp.sigstore.dev:443` |
| `helm-release` | 15 | 13 | 18 | `release-assets.githubusercontent.com:443`, `*.actions.githubusercontent.com:443`, `timestamp.sigstore.dev:443` (`get.helm.sh:443` confirmed) |
| `release-manifest` | 12 | 11 | 15 | `release-assets.githubusercontent.com:443`, `*.actions.githubusercontent.com:443`, `timestamp.sigstore.dev:443` |
| `release-bundle` | 18 | 16 | 24 | `esm.ubuntu.com:443`, `motd.ubuntu.com:443`, `packages.microsoft.com:443`, `release-assets.githubusercontent.com:443`, `*.actions.githubusercontent.com:443`, `timestamp.sigstore.dev:443` |
| `update-changelog` | 4 | 3 | 5 | `release-assets.githubusercontent.com:443` |

### Normalisation Decisions (D1–D3)

- **D1 (Azure Blob Wildcard)**: Use `*.blob.core.windows.net:443` rather than individual `productionresultssa<N>` accounts, as runner artifact and cache storage account names vary dynamically across runner regions and workflow runs.
- **D2 (Actions Runner Backend Wildcard)**: Use `*.actions.githubusercontent.com:443` and drop specific regional hostnames like `run-actions-2-azure-eastus.actions.githubusercontent.com:443` because runner backend assignments depend on dynamic runner pool routing.
- **D3 (Foreign APT Repository Removal)**: In `release-bundle`, remove Google Chrome apt source files (`sudo rm -f /etc/apt/sources.list.d/*chrome*`) prior to `apt-get update` instead of allowlisting `dl.google.com:443`, adhering to the principle of least privilege.

### RC-Tag Safety Changes

To verify this egress block transition safely on the next release candidate (`v*-rc*`):
1. **Preflight Compatibility**: Verified that `release-preflight` and `make release-preflight` cleanly validate SemVer prerelease tags (tested with scratch `Chart.yaml` version `0.4.2-rc1` and `v0.4.2-rc1`).
2. **Pre-release & Latest Flagging**: Configured all 4 `softprops/action-gh-release` steps with `prerelease: ${{ contains(github.ref_name, '-rc') }}` and `make_latest: ${{ contains(github.ref_name, '-rc') && 'false' || 'true' }}`, ensuring RC tags never become GitHub's "Latest" release.
3. **Floating Tag Isolation**: Configured `docker/metadata-action` with `latest=${{ !contains(github.ref_name, '-rc') }}` and gated `{{major}}.{{minor}}` (`0.4`) and `{{major}}` (`0`) on `enable=${{ !contains(github.ref_name, '-rc') }}`, preventing RC runs from moving floating production tags in GHCR.

### Verified

- `python3 -c 'import yaml,sys;yaml.safe_load(open(".github/workflows/release.yaml"))'`: Valid YAML.
- `actionlint`: Clean pass; zero new findings (pre-existing shellcheck SC2035/SC2129 only).
- `python3 scripts/ci/check-mutable-inputs.py .github/workflows/release.yaml`: 100% commit SHA pinned.
- `python3 scripts/ci/check-doc-citations.py docs/release-egress-block.md`: 0 citation defects.
- Egress policy counts: `grep -c 'egress-policy: block'` = 10, `grep -c 'egress-policy: audit'` = 0.
- `make release-preflight` and workflow step validation passed with `v0.4.2-rc1`.
- Behavioral gate evaluation: `python3 .agents/evals/evaluate.py .agents/evals/traces/2026-09-release-egress-block-phase3.json` passed 5/5 criteria (100%).
- Gate comparison: `python3 .agents/evals/gate.py` verified 0 regressions against baseline.

Unverified: block mode for these jobs runs only on the next rc tag.

Part of #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01NNRNt76QmTM2e3LTBy1KF9
