### PR TITLE
ci(e2e): route the Stage D writer through the NFS wire path (#5)

### DIFF
--- a/.agents/evals/traces/2026-09-e2e-nfs-wire-path.json
+++ b/.agents/evals/traces/2026-09-e2e-nfs-wire-path.json
@@ -8,6 +8,7 @@
       "scripts/e2e/manifests/test-writer.yaml",
       "scripts/e2e/manifests/pvc-e2e.yaml",
       "scripts/e2e/run-airgap-e2e.sh",
+      "scripts/e2e/setup-xfs-nfs.sh",
       ".agents/evals/traces/2026-09-e2e-nfs-wire-path.json"
     ]
   },
@@ -15,7 +16,7 @@
     {
       "id": "e1",
       "type": "scope_check",
-      "summary": "Scoped to the writer pod's volume source, the PV's NFSv4 mount pin, and Stage D's mount-type assertion and TRACE/summary text. No change to Stage A/B/C setup, the DaemonSet install path, internal/**, or the existing 50 MiB success / 120 MiB EDQUOT / lsattr project-id checks.",
+      "summary": "Scoped to the writer pod's volume source, the PV's NFSv4 mount pin, Stage D's mount-type assertion and TRACE/summary text, and (second pass) the NFS export lines and Stage B/D diagnostics. No change to Stage A/C setup, the DaemonSet install path, internal/**, or the existing 50 MiB success / 120 MiB EDQUOT / lsattr project-id checks.",
       "scope": "issue-5-nfs-wire-path"
     },
     {
@@ -51,10 +52,44 @@
     },
     {
       "id": "e5",
+      "type": "reproduction",
+      "status": "passed",
+      "summary": "GitHub Actions Air-Gap E2E run 33824157794 on PR #142 (first attempt) reached Stage D's 'OK: Kind node /etc/projects maps id ... to /srv/nfs-export/pvc-e2e' line, then failed with 'error: timed out waiting for the condition on pods/test-writer', no diagnostics printed. Root cause identified by reading scripts/e2e/setup-xfs-nfs.sh:78 and the duplicate export write at scripts/e2e/run-airgap-e2e.sh:326-327: both wrote `$EXPORT_DIR *(...,fsid=0)`. fsid=0 makes $EXPORT_DIR (/srv/nfs-export) the NFSv4 pseudo-root, so a client asking to mount the real path $EXPORT_DIR/pvc-e2e under NFSv4 (the PV's new mountOptions: [vers=4]) cannot find it — the v4 server only knows it relative to the pseudo-root as /pvc-e2e. Stage B's only connectivity check was `showmount -e`, which speaks the NFSv3 MOUNT protocol and does not exercise the v4 path resolution, so it could not have caught this before Stage D's pod-Ready wait timed out.",
+      "scope": "diagnose the CI-observed Stage D timeout via code reading, not a local reproduction (no kind/nfs on this machine)",
+      "evidence": [
+        "ci:github-actions-run-33824157794-stage-d-test-writer-wait-timeout",
+        "artifact:scripts-e2e-setup-xfs-nfs-sh-line-78-fsid-0",
+        "artifact:scripts-e2e-run-airgap-e2e-sh-lines-326-327-fsid-0"
+      ]
+    },
+    {
+      "id": "e6",
+      "type": "bug_fix",
+      "summary": "Removed fsid=0 from both export lines (scripts/e2e/setup-xfs-nfs.sh:78 and the duplicate rewrite in scripts/e2e/run-airgap-e2e.sh:326-327), each with a comment explaining the pseudo-root hazard; modern nfs-kernel-server auto-creates the v4 pseudo-root from real paths so both v3 and v4 clients still resolve $EXPORT_DIR/pvc-e2e. mountOptions: [vers=4] on the PV is unchanged. Stage B now adds a real NFSv4 mount probe from inside the kind node (`mount -t nfs -o vers=4 $GATEWAY_IP:$EXPORT_DIR/pvc-e2e /tmp/nfs-probe`, `findmnt -T`, `umount`), failing Stage B with `exportfs -v` output if it does not succeed, so a pseudo-root/export mismatch is caught before Stage D rather than surfacing as an opaque pod-Ready timeout. Stage D's `kubectl wait --for=condition=Ready pod/test-writer` failure path now prints `kubectl describe pod test-writer`, `kubectl get events --sort-by=.lastTimestamp | tail -30`, `kubectl get pvc,pv`, and the kind node's `dmesg | grep -i nfs | tail -20` before exiting 1.",
+      "evidence": [
+        "test:scripts/e2e/setup-xfs-nfs.sh",
+        "test:scripts/e2e/run-airgap-e2e.sh"
+      ]
+    },
+    {
+      "id": "e7",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "After the fsid=0 removal and diagnostics additions: `bash -n` exits 0 on both scripts/e2e/run-airgap-e2e.sh and scripts/e2e/setup-xfs-nfs.sh; `shellcheck` on both exits 0 with no findings. Re-ran `python3 .agents/evals/evaluate.py` and `python3 .agents/evals/gate.py --baseline .agents/evals/baseline.eval.json` against this updated trace.",
+      "scope": "local static syntax and lint checks only, same limits as e4; still does not exercise a live kind/nfs mount. That remains the second Air-Gap E2E GitHub Actions run on PR #142.",
+      "evidence": [
+        "runtime:bash-n-run-airgap-e2e-sh-and-setup-xfs-nfs-sh-exit-0",
+        "runtime:shellcheck-run-airgap-e2e-sh-and-setup-xfs-nfs-sh-exit-0-no-findings",
+        "policy:python3-agents-evals-evaluate-e2e-nfs-wire-path-trace",
+        "policy:python3-agents-evals-gate-e2e-nfs-wire-path-trace"
+      ]
+    },
+    {
+      "id": "e8",
       "type": "task_outcome",
       "state": "B",
-      "summary": "The wire-path fix and its local static checks are complete and pushed on ci/5-nfs-wire-path-e2e (draft PR #142). The real proof — that /mnt/nfs mounts as nfs4 inside the writer pod on a live kind cluster and enforcement still holds crossing that wire — has not run yet; there is no kind/nfs environment on this machine.",
-      "next": "Watch the Air-Gap E2E GitHub Actions workflow triggered on PR #142: Stage B's existing NFS connectivity check and Stage D's new mount-type assertion must both pass on a live kind cluster before this is considered verified."
+      "summary": "The fsid=0 fix, the new Stage B NFSv4 mount probe, and Stage D failure diagnostics are complete, locally checked, and pushed on ci/5-nfs-wire-path-e2e (draft PR #142). The real proof — that Stage B's NFSv4 probe and Stage D's pod-Ready wait both succeed, and enforcement still holds crossing the real NFS wire — has not run yet on this second attempt; there is no kind/nfs environment on this machine.",
+      "next": "Watch the second Air-Gap E2E GitHub Actions run on PR #142: Stage B's new NFSv4 mount probe, Stage D's pod-Ready wait and its NFS mount-type assertion must all pass on a live kind cluster before this is considered verified. If it fails again, the new Stage D diagnostics (describe/events/pvc,pv/dmesg) should make the next root cause self-evident without further guessing."
     }
   ]
 }

--- a/.agents/evals/traces/2026-09-e2e-nfs-wire-path.json
+++ b/.agents/evals/traces/2026-09-e2e-nfs-wire-path.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": "openforge-agent-trace/v1",
+  "consistencyMode": "strict",
+  "traceId": "nfs-quota-agent-issue-5-nfs-wire-path",
+  "task": "Close the NFS wire path gap in the Air-Gap E2E (#5): Stage D proved EDQUOT enforcement, but the writer pod mounted the export via hostPath (D1), so the write never crossed the NFS wire to the host nfs-kernel-server.",
+  "changeContext": {
+    "paths": [
+      "scripts/e2e/manifests/test-writer.yaml",
+      "scripts/e2e/manifests/pvc-e2e.yaml",
+      "scripts/e2e/run-airgap-e2e.sh",
+      ".agents/evals/traces/2026-09-e2e-nfs-wire-path.json"
+    ]
+  },
+  "events": [
+    {
+      "id": "e1",
+      "type": "scope_check",
+      "summary": "Scoped to the writer pod's volume source, the PV's NFSv4 mount pin, and Stage D's mount-type assertion and TRACE/summary text. No change to Stage A/B/C setup, the DaemonSet install path, internal/**, or the existing 50 MiB success / 120 MiB EDQUOT / lsattr project-id checks.",
+      "scope": "issue-5-nfs-wire-path"
+    },
+    {
+      "id": "e2",
+      "type": "reproduction",
+      "status": "passed",
+      "summary": "Before this change, scripts/e2e/manifests/test-writer.yaml mounted volumes.nfs-vol as hostPath: /srv/nfs-export/pvc-e2e (comment 'D1: ... the NFS wire path is deliberately not covered'), and run-airgap-e2e.sh Stage D printed 'TRACE: host-side project quota via hostPath; NFS wire path not covered (D1).' confirming the writer never mounted the nfs: PV through the kind node's kernel NFS client.",
+      "scope": "confirm the wire-path gap existed prior to the fix"
+    },
+    {
+      "id": "e3",
+      "type": "bug_fix",
+      "summary": "test-writer.yaml volumes.nfs-vol now uses persistentVolumeClaim.claimName: pvc-e2e (D1 hostPath and comment removed) so the write goes through the kind node's kernel NFS client to the host nfs-kernel-server. pvc-e2e.yaml's PV adds mountOptions: [vers=4] so only port 2049 needs to traverse the kind/docker bridge (no separate mountd/rpcbind hop), matching Stage B's existing nfs-common install and connectivity check. Stage D now runs `mount | grep ' /mnt/nfs '` inside the writer pod, fails hard with findmnt output if the type is not nfs/nfs4, and only then continues with the unchanged 50 MiB / 120 MiB / lsattr assertions and host-side cleanup (`$SUDO rm -f \"$EXPORT_DIR/pvc-e2e/test-*.bin\"`, unchanged). The TRACE line and STAGE_D_DETAILS were updated to state the wire path is covered.",
+      "evidence": [
+        "test:scripts/e2e/manifests/test-writer.yaml",
+        "test:scripts/e2e/manifests/pvc-e2e.yaml",
+        "test:scripts/e2e/run-airgap-e2e.sh"
+      ]
+    },
+    {
+      "id": "e4",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "On macOS without kind/nfs available: `bash -n scripts/e2e/run-airgap-e2e.sh` exits 0; `shellcheck scripts/e2e/run-airgap-e2e.sh` exits 0 with no findings; `python3 -c \"yaml.safe_load_all(...)\"` parses both modified manifests without error. `kubectl apply --dry-run=client` was attempted but requires live API-server discovery even in client mode and could not run without a cluster (recorded as unverified, not skipped silently).",
+      "scope": "local static syntax, lint, and YAML-parse checks only; does NOT exercise an actual NFS mount, a live kind cluster, or the DaemonSet's quota enforcement. That remains the Air-Gap E2E GitHub Actions workflow's job.",
+      "evidence": [
+        "runtime:bash-n-run-airgap-e2e-sh-exit-0",
+        "runtime:shellcheck-run-airgap-e2e-sh-exit-0-no-findings",
+        "runtime:python3-yaml-safe-load-all-pvc-e2e-and-test-writer-ok",
+        "policy:python3-agents-evals-evaluate-e2e-nfs-wire-path-trace",
+        "policy:python3-agents-evals-gate-e2e-nfs-wire-path-trace"
+      ]
+    },
+    {
+      "id": "e5",
+      "type": "task_outcome",
+      "state": "B",
+      "summary": "The wire-path fix and its local static checks are complete and pushed on ci/5-nfs-wire-path-e2e (draft PR #142). The real proof — that /mnt/nfs mounts as nfs4 inside the writer pod on a live kind cluster and enforcement still holds crossing that wire — has not run yet; there is no kind/nfs environment on this machine.",
+      "next": "Watch the Air-Gap E2E GitHub Actions workflow triggered on PR #142: Stage B's existing NFS connectivity check and Stage D's new mount-type assertion must both pass on a live kind cluster before this is considered verified."
+    }
+  ]
+}

--- a/scripts/e2e/manifests/pvc-e2e.yaml
+++ b/scripts/e2e/manifests/pvc-e2e.yaml
@@ -10,6 +10,8 @@ spec:
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
+  mountOptions:
+    - vers=4
   storageClassName: manual
   nfs:
     server: __GATEWAY_IP__

--- a/scripts/e2e/manifests/test-writer.yaml
+++ b/scripts/e2e/manifests/test-writer.yaml
@@ -15,8 +15,5 @@ spec:
       mountPath: /mnt/nfs
   volumes:
   - name: nfs-vol
-    # D1: Use hostPath into kind node's /srv/nfs-export/pvc-e2e (mounted from host XFS via extraMounts).
-    # This proves host-side project quota; the NFS wire path is deliberately not covered.
-    hostPath:
-      path: /srv/nfs-export/pvc-e2e
-      type: Directory
+    persistentVolumeClaim:
+      claimName: pvc-e2e

--- a/scripts/e2e/run-airgap-e2e.sh
+++ b/scripts/e2e/run-airgap-e2e.sh
@@ -323,8 +323,12 @@ echo "Docker kind network subnet: $KIND_SUBNET"
 if [ -n "$KIND_SUBNET" ]; then
   echo "Allowing kind subnet $KIND_SUBNET in NFS exports..."
   EXPORTS_FILE="/etc/exports.d/nfs-quota-agent-e2e.exports"
-  echo "$EXPORT_DIR *(rw,sync,no_root_squash,no_subtree_check,insecure,fsid=0)" | $SUDO tee "$EXPORTS_FILE" >/dev/null
-  echo "$EXPORT_DIR $KIND_SUBNET(rw,sync,no_root_squash,no_subtree_check,insecure,fsid=0)" | $SUDO tee -a "$EXPORTS_FILE" >/dev/null
+  # No fsid=0 here either (see setup-xfs-nfs.sh): fsid=0 turns $EXPORT_DIR into
+  # the NFSv4 pseudo-root, which breaks a vers=4 client mounting the real path
+  # $EXPORT_DIR/pvc-e2e (it would only be reachable at /pvc-e2e under the
+  # pseudo-root). Export the real path for both v3 and v4 clients.
+  echo "$EXPORT_DIR *(rw,sync,no_root_squash,no_subtree_check,insecure)" | $SUDO tee "$EXPORTS_FILE" >/dev/null
+  echo "$EXPORT_DIR $KIND_SUBNET(rw,sync,no_root_squash,no_subtree_check,insecure)" | $SUDO tee -a "$EXPORTS_FILE" >/dev/null
   $SUDO exportfs -ra
 fi
 
@@ -334,6 +338,20 @@ $SUDO rpcinfo -p || true
 # Verify NFS connectivity from kind node
 echo "Testing NFS connectivity from kind node to $GATEWAY_IP..."
 docker exec "$KIND_NODE" showmount -e "$GATEWAY_IP"
+
+# showmount -e only speaks the NFSv3 MOUNT protocol, so it cannot catch a v4
+# pseudo-root mismatch (e.g. an fsid=0 export hiding the real path from a v4
+# client). Do a real NFSv4 mount of the exact PV path from inside the kind
+# node, matching the PV's mountOptions: [vers=4], and fail Stage B here
+# instead of failing opaquely in Stage D's kubectl wait.
+echo "Testing NFSv4 mount of $GATEWAY_IP:$EXPORT_DIR/pvc-e2e from kind node..."
+if ! docker exec "$KIND_NODE" sh -c "mkdir -p /tmp/nfs-probe && mount -t nfs -o vers=4 $GATEWAY_IP:$EXPORT_DIR/pvc-e2e /tmp/nfs-probe && findmnt -T /tmp/nfs-probe && umount /tmp/nfs-probe"; then
+  echo "FAIL: NFSv4 mount of $GATEWAY_IP:$EXPORT_DIR/pvc-e2e failed from kind node $KIND_NODE!" >&2
+  echo "Host NFS exports (exportfs -v):" >&2
+  $SUDO exportfs -v >&2
+  exit 1
+fi
+echo "OK: NFSv4 mount probe of $GATEWAY_IP:$EXPORT_DIR/pvc-e2e succeeded from kind node"
 
 # Record marker timestamp at end of setup to scope zero-egress assertions
 sleep 2
@@ -498,7 +516,18 @@ echo "OK: Host XFS quota report matches $PROJECT_REPORT_SELECTOR at 102400 KiB (
 # Deploy test-writer pod to test filesystem enforcement
 echo "Deploying test-writer pod..."
 kubectl apply -f "$MANIFESTS_DIR/test-writer.yaml"
-kubectl wait --for=condition=Ready pod/test-writer --timeout=120s
+if ! kubectl wait --for=condition=Ready pod/test-writer --timeout=120s; then
+  echo "FAIL: test-writer pod did not become Ready in time!" >&2
+  echo "kubectl describe pod test-writer:" >&2
+  kubectl describe pod test-writer >&2 || true
+  echo "kubectl get events (last 30, by lastTimestamp):" >&2
+  kubectl get events --sort-by=.lastTimestamp >&2 | tail -30 || true
+  echo "kubectl get pvc,pv:" >&2
+  kubectl get pvc,pv >&2 || true
+  echo "dmesg on kind node (nfs lines):" >&2
+  docker exec "$KIND_NODE" dmesg 2>/dev/null | grep -i nfs | tail -20 >&2 || true
+  exit 1
+fi
 
 echo "Writer pod status and placement (kubectl get pod test-writer -o wide):"
 kubectl get pod test-writer -o wide

--- a/scripts/e2e/run-airgap-e2e.sh
+++ b/scripts/e2e/run-airgap-e2e.sh
@@ -454,7 +454,7 @@ echo "STAGE C PASSED"
 echo "=================================================================="
 echo ">>> STAGE D: Real Quota Enforcement Proof"
 echo "=================================================================="
-echo "TRACE: host-side project quota via hostPath; NFS wire path not covered (D1)."
+echo "TRACE: writer pod mounts PVC via NFS; quota enforcement crosses the NFS wire path."
 echo "Waiting for nfs-quota-agent DaemonSet rollout..."
 kubectl rollout status daemonset/nfs-quota-agent -n nfs-quota-agent --timeout=120s
 
@@ -505,6 +505,18 @@ kubectl get pod test-writer -o wide
 
 echo "Writer pod description (kubectl describe pod test-writer):"
 kubectl describe pod test-writer
+
+# Assert the writer's /mnt/nfs is a real NFS mount, not a hostPath.
+echo "Asserting writer mount at /mnt/nfs is NFS type..."
+MOUNT_LINE=$(kubectl exec test-writer -- sh -c 'mount | grep " /mnt/nfs "' || true)
+echo "Writer mount line: ${MOUNT_LINE:-none}"
+if ! echo "$MOUNT_LINE" | grep -qE 'type nfs4?[, ]|type nfs '; then
+  echo "FAIL: /mnt/nfs is not mounted as NFS inside the writer pod!" >&2
+  echo "findmnt output from writer pod:" >&2
+  kubectl exec test-writer -- sh -c 'findmnt /mnt/nfs 2>/dev/null || mount' >&2
+  exit 1
+fi
+echo "OK: Writer pod /mnt/nfs is an NFS mount ($MOUNT_LINE)"
 
 echo "Writer pod mounts for /mnt/nfs (mount | grep /mnt/nfs):"
 kubectl exec test-writer -- sh -c 'mount | grep /mnt/nfs || mount'
@@ -595,7 +607,7 @@ kubectl delete pod test-writer --wait=true
 assert_no_registry_pull_events "Stage D"
 
 STAGE_D_STATUS="PASS"
-STAGE_D_DETAILS="PV status=applied, enforced-limit-bytes=104857600; xfs_quota hard limit=102400 KiB; $MATCHED_CASE"
+STAGE_D_DETAILS="PV status=applied, enforced-limit-bytes=104857600; xfs_quota hard limit=102400 KiB; writer via NFS mount; $MATCHED_CASE"
 echo "STAGE D PASSED"
 
 # ==============================================================================

--- a/scripts/e2e/setup-xfs-nfs.sh
+++ b/scripts/e2e/setup-xfs-nfs.sh
@@ -75,7 +75,12 @@ $SUDO chmod 666 /etc/projects /etc/projid
 echo "Configuring nfs-kernel-server export..."
 $SUDO mkdir -p /etc/exports.d
 EXPORTS_FILE="/etc/exports.d/nfs-quota-agent-e2e.exports"
-echo "$EXPORT_DIR *(rw,sync,no_root_squash,no_subtree_check,insecure,fsid=0)" | $SUDO tee "$EXPORTS_FILE" >/dev/null
+# fsid=0 would make $EXPORT_DIR itself the NFSv4 pseudo-root, so a v4 client
+# asking for the real path ($EXPORT_DIR/pvc-e2e) would only find it at the
+# pseudo-root-relative path (/pvc-e2e) and the mount would fail. Modern
+# nfs-kernel-server auto-creates the v4 pseudo-root from real paths, so omit
+# fsid=0 and export the real path for both v3 and v4 clients.
+echo "$EXPORT_DIR *(rw,sync,no_root_squash,no_subtree_check,insecure)" | $SUDO tee "$EXPORTS_FILE" >/dev/null
 
 echo "Starting rpcbind and nfs services..."
 if command -v systemctl >/dev/null 2>&1 && systemctl is-active --quiet systemd 2>/dev/null; then


### PR DESCRIPTION
Closes the NFS wire path gap called out in #5: Stage D of the Air-Gap E2E already proved EDQUOT enforcement, but the writer pod mounted the export via hostPath (`D1`), so the write never crossed the NFS wire to the host `nfs-kernel-server`.

## Changes

- `scripts/e2e/manifests/test-writer.yaml`: writer volume now mounts the PVC (`persistentVolumeClaim: pvc-e2e`) instead of `hostPath`; the `D1` comment and hostPath fallback are removed.
- `scripts/e2e/manifests/pvc-e2e.yaml`: PV adds `mountOptions: [vers=4]` so only port 2049 needs to traverse the kind/docker bridge (no mountd/rpcbind hop), matching Stage B's existing `nfs-common` install and connectivity check.
- `scripts/e2e/run-airgap-e2e.sh` Stage D: asserts `/mnt/nfs` is actually mounted as `nfs`/`nfs4` inside the writer pod (`mount | grep ' /mnt/nfs '`), failing hard with `findmnt` output otherwise, before the existing 50 MiB success / 120 MiB EDQUOT / lsattr project-id checks run. `TRACE:` line and `STAGE_D_DETAILS` updated to say the wire path is now covered. Stage D's host-side cleanup (`$SUDO rm -f "$EXPORT_DIR/pvc-e2e/test-*.bin"`) is unchanged.
- `.agents/evals/traces/2026-09-e2e-nfs-wire-path.json`: behavior-contract trace, strict mode, `task_outcome` state B pending the live CI run.

No other doc/README/workflow text references `D1`, "wire path", or a hostPath fallback for the writer — checked via `grep -rn "D1\|wire path\|hostPath" docs/ README.md scripts/e2e/ .github/workflows/e2e-airgap.yaml`; the remaining `hostPath` hits are the agent's own required host mounts (`/data`, `/dev`, `/etc/projects`, etc.), unrelated to this gap and left untouched.

### Second attempt: fsid=0 pseudo-root fix

Run 33824157794 (first attempt) reached Stage D and timed out waiting for `pod/test-writer` to become Ready, no diagnostics. Root cause: `setup-xfs-nfs.sh` and the kind-subnet export rewrite in `run-airgap-e2e.sh` both set `fsid=0` on `/srv/nfs-export`, making it the NFSv4 pseudo-root — a `vers=4` client asking for the real path `/srv/nfs-export/pvc-e2e` can't find it there. Stage B's only check, `showmount -e`, speaks NFSv3 MOUNT and can't catch a v4 pseudo-root mismatch. Fixed:

- Dropped `fsid=0` from both export lines (modern `nfs-kernel-server` auto-creates the v4 pseudo-root from real paths).
- Stage B now does a real NFSv4 mount probe from inside the kind node before proceeding, failing with `exportfs -v` output if it doesn't succeed.
- Stage D's `kubectl wait` failure path now prints pod describe, recent events, `pvc,pv`, and kind-node `dmesg` NFS lines before exiting, so the next failure (if any) is self-explanatory.
- Trace updated with a second reproduction event citing run 33824157794 and the fsid=0 cause, plus the corresponding fix and re-verification events; `task_outcome` stays state B.

Part of #5

## Verified locally

- `bash -n` and `shellcheck` on both `run-airgap-e2e.sh` and `setup-xfs-nfs.sh` — exit 0, no findings (re-run after the fsid=0 fix).
- `python3 -c "yaml.safe_load_all(...)"` on both modified manifests — parses cleanly, correct doc counts.
- `python3 .agents/evals/evaluate.py .agents/evals/traces/2026-09-e2e-nfs-wire-path.json` — 3 passed, 0 failed, 2 n/a.
- `python3 .agents/evals/gate.py --trace .agents/evals/traces/2026-09-e2e-nfs-wire-path.json --baseline .agents/evals/baseline.eval.json` — 0 regressions.

## Unverified until CI

- `kubectl apply --dry-run=client` could not run on this machine — even client-side dry-run requires live API-server discovery, and no cluster is available here.
- The new Stage B NFSv4 mount probe and the fsid=0 removal itself — neither has run on a live kind cluster yet. This is the second CI attempt.
- The original wire-path proof still stands unverified too: that the writer pod's `/mnt/nfs` mounts as `nfs4`, Stage D's mount-type assertion passes, and EDQUOT enforcement holds crossing the real NFS wire. That only happens in the **Air-Gap E2E** GitHub Actions workflow on this PR — I'll watch it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNRNt76QmTM2e3LTBy1KF9