### PR TITLE
ci(release): verify published image digests against release-manifest.json on the live registry (#5)

### DIFF
--- a/.agents/evals/traces/2026-09-registry-digest-verify.json
+++ b/.agents/evals/traces/2026-09-registry-digest-verify.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": "openforge-agent-trace/v1",
+  "consistencyMode": "strict",
+  "traceId": "nfs-quota-agent-registry-digest-verify",
+  "task": "Verify release-manifest image pins and supported multi-architecture index against GHCR as the final release job (Part of #5)",
+  "changeContext": {
+    "paths": [
+      ".github/workflows/release.yaml",
+      "scripts/ci/verify-published-digests.sh",
+      "Makefile",
+      "docs/release-egress-block.md",
+      ".agents/evals/traces/2026-09-registry-digest-verify.json"
+    ]
+  },
+  "events": [
+    {
+      "id": "e1",
+      "type": "reproduction",
+      "summary": "artifact:release-manifest.json records a pushed image digest, while hack/verify-release.py intentionally verifies downloaded assets offline and does not resolve the image tag against the live registry. Thus a moved tag or incomplete registry index is not detected."
+    },
+    {
+      "id": "e2",
+      "type": "bug_fix",
+      "summary": "Add scripts/ci/verify-published-digests.sh and the final Verify Published Digests release job. It downloads the published manifest, verifies the release tag and stable floating tags (or confirms RCs did not move them), and requires linux/amd64, linux/arm64, and linux/arm/v7 in the registry index."
+    },
+    {
+      "id": "e3",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "runtime: local runs against v0.4.2 and v0.4.2-rc1 resolve their real GHCR manifests; ci: actionlint validates the workflow when available; policy: trace evaluation and baseline gate validate this strict triad.",
+      "scope": "Live registry tag-to-digest, stable/RC floating-tag behavior, multi-arch index shape, workflow syntax, and trace policy.",
+      "evidence": [
+        "runtime:verify-published-digests-v0.4.2",
+        "runtime:verify-published-digests-v0.4.2-rc1",
+        "ci:actionlint-release-workflow",
+        "policy:trace-evaluate-registry-digest-verify",
+        "policy:trace-gate-registry-digest-verify"
+      ]
+    },
+    {
+      "id": "e4",
+      "type": "completion_claim",
+      "summary": "The live-registry verification is implemented and exercised against the stable and RC releases. Unverified: the new block-mode GitHub Actions job will first execute on the next release tag."
+    },
+    {
+      "id": "e5",
+      "type": "task_outcome",
+      "state": "A",
+      "summary": "Part of #5 is complete: release-manifest image pins, floating-tag policy, and required multi-architecture index entries are checked against the live registry after publication."
+    }
+  ]
+}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -935,6 +935,42 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-rc') }}
           make_latest: ${{ contains(github.ref_name, '-rc') && 'false' || 'true' }}
 
+  verify-published-digests:
+    name: Verify Published Digests
+    runs-on: ubuntu-latest
+    needs: [release-manifest, build-and-push]
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: block
+          # gh release download fetches the published manifest; Docker Buildx
+          # resolves GHCR tags without installing another registry client.
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            # D4: see docs/release-egress-block.md "Wildcard exceptions".
+            *.actions.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download published release manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "${{ github.ref_name }}" --repo "${{ github.repository }}" -p release-manifest.json --dir .
+
+      - name: Verify manifest pin and multi-arch registry index
+        run: TAG="${{ github.ref_name }}" MANIFEST=release-manifest.json REPOSITORY="${{ needs.build-and-push.outputs.image }}" scripts/ci/verify-published-digests.sh
+
   update-changelog:
     name: Update CHANGELOG.md
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ RELEASE_DIR?=.
 CHART_FILE?=charts/$(BINARY_NAME)/Chart.yaml
 
 .PHONY: all build build-linux clean test test-coverage fmt vet tidy lint \
-	license sbom generate compat-matrix compat-matrix-validate verify-release \
+	license sbom generate compat-matrix compat-matrix-validate verify-release verify-published-digests \
 	docker-build docker-push docker-buildx \
 	helm-lint helm-rbac-check helm-package helm-install helm-uninstall update-chart-digest \
-	release-bundle release-manifest-local release-preflight
+release-bundle release-manifest-local release-preflight
 
 # values.yaml to write image.digest into -- see update-chart-digest below.
 VALUES_FILE?=charts/$(BINARY_NAME)/values.yaml
@@ -374,6 +374,16 @@ else
 	$(error Set DIGEST=sha256:<64hex> or IMAGE=<repo:tag> to pin $(VALUES_FILE)'s image.digest)
 endif
 
+# Verify the release manifest's image pin against the live registry. Unlike
+# verify-release, this target deliberately requires network access.
+RELEASE_REPOSITORY?=dasomel/nfs-quota-agent
+verify-published-digests:
+	@test -n "$(TAG)" || { echo "Set TAG=vX.Y.Z (or a prerelease)"; exit 1; }
+	@manifest_dir=$$(mktemp -d); \
+	trap 'rm -rf "$$manifest_dir"' EXIT; \
+	gh release download "$(TAG)" --repo "$(RELEASE_REPOSITORY)" -p release-manifest.json --dir "$$manifest_dir"; \
+	TAG="$(TAG)" MANIFEST="$$manifest_dir/release-manifest.json" scripts/ci/verify-published-digests.sh
+
 # Show help
 help:
 	@echo "Available targets:"
@@ -401,6 +411,7 @@ help:
 	@echo "  helm-uninstall   - Uninstall Helm release"
 	@echo "  update-chart-digest - Pin charts/nfs-quota-agent's image.digest (DIGEST=sha256:<64hex> or IMAGE=<repo:tag>)"
 	@echo "  verify-release   - Offline-verify a downloaded release bundle (RELEASE_DIR=...)"
+	@echo "  verify-published-digests - Verify release-manifest image pins against the live registry (TAG=vX.Y.Z)"
 	@echo "  release-preflight - Require Chart.yaml version/appVersion to match TAG=vX.Y.Z"
 	@echo "  release-manifest-local - Produce a schemaVersion 4 release-manifest.json locally to exercise the schema"
 	@echo "  release-bundle   - Build an offline/air-gap install tar.gz (IMAGE_REF=..., CHART_TGZ=... required)"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CHART_FILE?=charts/$(BINARY_NAME)/Chart.yaml
 	license sbom generate compat-matrix compat-matrix-validate verify-release verify-published-digests \
 	docker-build docker-push docker-buildx \
 	helm-lint helm-rbac-check helm-package helm-install helm-uninstall update-chart-digest \
-release-bundle release-manifest-local release-preflight
+	release-bundle release-manifest-local release-preflight
 
 # values.yaml to write image.digest into -- see update-chart-digest below.
 VALUES_FILE?=charts/$(BINARY_NAME)/values.yaml

--- a/docs/release-egress-block.md
+++ b/docs/release-egress-block.md
@@ -73,6 +73,7 @@ However, the four **Phase 1 read-only jobs** (`release-preflight`, `test`, `chan
 | `release-manifest` | `block` | 15 | GitHub APIs/uploads, `release-assets`, `*.actions.githubusercontent.com`, Sigstore (incl. `timestamp`), `*.blob.core.windows.net` | Phase 3 | block (verified on v0.4.2-rc1, run 33815273613) |
 | `release-bundle` | `block` | 24 | GitHub APIs/uploads, `release-assets`, `*.actions.githubusercontent.com`, Ubuntu apt mirrors (ports 80 & 443; archive, esm, motd, packages.microsoft.com), GHCR, Sigstore (incl. `timestamp`) | Phase 3 | block (verified on v0.4.2-rc1, run 33815273613) |
 | `update-changelog` | `block` | 5 | `github.com`, `api.github.com`, `raw/objects.githubusercontent.com`, `release-assets.githubusercontent.com` | Phase 3 | block (verified on v0.4.2-rc1, run 33815273613) |
+| `verify-published-digests` | `block` | 9 | GitHub release APIs/assets, GHCR/package CDN, Actions results + D4 wildcards | Phase 3 | block (new; unverified until next tag) |
 
 ### Phase 1 Audit Evidence & Deltas (Evidence Run ID: 33769700751, v0.4.0)
 

--- a/docs/release-egress-block.md
+++ b/docs/release-egress-block.md
@@ -75,6 +75,8 @@ However, the four **Phase 1 read-only jobs** (`release-preflight`, `test`, `chan
 | `update-changelog` | `block` | 5 | `github.com`, `api.github.com`, `raw/objects.githubusercontent.com`, `release-assets.githubusercontent.com` | Phase 3 | block (verified on v0.4.2-rc1, run 33815273613) |
 | `verify-published-digests` | `block` | 9 | GitHub release APIs/assets, GHCR/package CDN, Actions results + D4 wildcards | Phase 3 | block (new; unverified until next tag) |
 
+> **If `verify-published-digests` fails after publication:** every artifact is already published (images, floating tags, release assets, signatures) and none of them can be re-pointed under the repo's immutable-tag policy. Treat the failure as a verification finding, not a rollback trigger: first re-run the failed job (a GHCR read blocked by the allowlist or a registry propagation delay looks identical to a real mismatch), then run `make verify-published-digests TAG=<tag>` locally with the release's `release-manifest.json`. A confirmed mismatch means the release is marked pre-release with the discrepancy recorded in its body and the next tag carries the fix, exactly as v0.4.0 was handled.
+
 ### Phase 1 Audit Evidence & Deltas (Evidence Run ID: 33769700751, v0.4.0)
 
 Audit logs from the v0.4.0 release run ([33769700751](https://github.com/dasomel/nfs-quota-agent/actions/runs/33769700751)) were analyzed to reconcile allowed endpoints prior to enforcing `block` mode. All observed endpoints contacted port 443 (HTTPS):

--- a/scripts/ci/verify-published-digests.sh
+++ b/scripts/ci/verify-published-digests.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Verify that release-manifest.json names the multi-arch image actually served
+# by GHCR. Registry lookups are intentionally separate from verify-release.py,
+# whose contract is offline verification of downloaded release assets.
+set -euo pipefail
+
+: "${TAG:?Set TAG to the release tag (for example v0.4.2)}"
+MANIFEST="${MANIFEST:-release-manifest.json}"
+REPOSITORY="${REPOSITORY:-ghcr.io/dasomel/nfs-quota-agent}"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+test -f "$MANIFEST" || fail "manifest not found: $MANIFEST"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+manifest_tag=$(jq -er '.tag | strings' "$MANIFEST") || fail "manifest.tag is missing"
+manifest_repository=$(jq -er '.image.repository | strings' "$MANIFEST") || fail "manifest.image.repository is missing"
+manifest_digest=$(jq -er '.image.digest | strings' "$MANIFEST") || fail "manifest.image.digest is missing"
+
+[[ "$manifest_tag" == "$TAG" ]] || fail "manifest tag $manifest_tag does not match TAG $TAG"
+[[ "$manifest_repository" == "$REPOSITORY" ]] || fail "manifest repository $manifest_repository does not match REPOSITORY $REPOSITORY"
+[[ "$manifest_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || fail "manifest image digest is not sha256:<64 hex>: $manifest_digest"
+
+if command -v crane >/dev/null 2>&1; then
+  resolve_digest() { crane digest "$1"; }
+  inspect_raw() { crane manifest "$1"; }
+  inspector="crane"
+elif docker buildx version >/dev/null 2>&1; then
+  resolve_digest() { docker buildx imagetools inspect "$1" | awk '/^Digest:/ { print $2; exit }'; }
+  inspect_raw() { docker buildx imagetools inspect --raw "$1"; }
+  inspector="docker buildx imagetools"
+else
+  fail "need crane or docker buildx imagetools"
+fi
+
+resolve_tag() {
+  local image_ref="$1"
+  local digest
+  digest=$(resolve_digest "$image_ref") || fail "could not resolve $image_ref with $inspector"
+  [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || fail "invalid digest returned for $image_ref: $digest"
+  printf '%s\n' "$digest"
+}
+
+verify_equals_manifest() {
+  local tag="$1"
+  local actual
+  actual=$(resolve_tag "$REPOSITORY:$tag")
+  echo "tag $REPOSITORY:$tag -> $actual"
+  [[ "$actual" == "$manifest_digest" ]] || fail "$REPOSITORY:$tag resolved to $actual, expected $manifest_digest"
+}
+
+verify_equals_manifest "$TAG"
+
+raw_manifest=$(inspect_raw "$REPOSITORY:$TAG") || fail "could not inspect raw manifest for $REPOSITORY:$TAG"
+if ! jq -e '
+  .manifests | type == "array" and
+  any(.[]; .platform.os == "linux" and .platform.architecture == "amd64") and
+  any(.[]; .platform.os == "linux" and .platform.architecture == "arm64") and
+  any(.[]; .platform.os == "linux" and .platform.architecture == "arm" and .platform.variant == "v7")
+' >/dev/null <<<"$raw_manifest"; then
+  fail "$REPOSITORY:$TAG is not a multi-arch index containing linux/amd64, linux/arm64, and linux/arm/v7"
+fi
+echo "platforms: linux/amd64 linux/arm64 linux/arm/v7"
+
+if [[ "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z.-]+(\+[0-9A-Za-z.-]+)?$ ]]; then
+  # Derive the common floating tags from the release version so this remains
+  # correct after the current 0.x line.
+  version="${TAG#v}"
+  IFS=. read -r major minor _ <<<"$version"
+  for floating_tag in latest "$major.$minor" "$major"; do
+    actual=$(resolve_tag "$REPOSITORY:$floating_tag")
+    echo "floating tag $REPOSITORY:$floating_tag -> $actual"
+    [[ "$actual" != "$manifest_digest" ]] || fail "RC digest $manifest_digest moved floating tag $REPOSITORY:$floating_tag"
+  done
+else
+  version="${TAG#v}"
+  [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\+[0-9A-Za-z.-]+)?$ ]] || fail "TAG is not a SemVer release: $TAG"
+  IFS=. read -r major minor _ <<<"$version"
+  for floating_tag in latest "$major.$minor" "$major"; do
+    verify_equals_manifest "$floating_tag"
+  done
+fi
+
+echo "OK: published digest verification passed for $TAG"

--- a/scripts/ci/verify-published-digests.sh
+++ b/scripts/ci/verify-published-digests.sh
@@ -65,7 +65,12 @@ if ! jq -e '
 fi
 echo "platforms: linux/amd64 linux/arm64 linux/arm/v7"
 
-if [[ "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z.-]+(\+[0-9A-Za-z.-]+)?$ ]]; then
+# Classify rc tags exactly the way the release workflow does (substring "-rc",
+# see docker/metadata-action's `!contains(github.ref_name, '-rc')` gate and the
+# release-manifest prerelease flag). A generic SemVer prerelease test would
+# disagree with the pipeline for a hypothetical v0.4.2-beta1: build-and-push
+# treats it as stable and moves the floating tags, so this check must too.
+if [[ "$TAG" == *-rc* ]]; then
   # Derive the common floating tags from the release version so this remains
   # correct after the current 0.x line.
   version="${TAG#v}"
@@ -77,7 +82,7 @@ if [[ "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z.-]+(\+[0-9A-Za-z.-]+)?$ ]];
   done
 else
   version="${TAG#v}"
-  [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\+[0-9A-Za-z.-]+)?$ ]] || fail "TAG is not a SemVer release: $TAG"
+  [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]] || fail "TAG is not a SemVer release: $TAG"
   IFS=. read -r major minor _ <<<"$version"
   for floating_tag in latest "$major.$minor" "$major"; do
     verify_equals_manifest "$floating_tag"


### PR DESCRIPTION
Part of #5.

Adds a final release job that downloads the published `release-manifest.json` and verifies GHCR: the release tag matches its image digest; stable releases set `latest`, major.minor, and major to that digest; RC releases do not move those floating tags; and the index includes linux/amd64, linux/arm64, and linux/arm/v7.

Real registry output:
```text
tag ghcr.io/dasomel/nfs-quota-agent:v0.4.2 -> sha256:de8a77104d4da1c97ccd5f9ff9a22f4edd6041f0aeca18f35d0628f6d4be4195
platforms: linux/amd64 linux/arm64 linux/arm/v7
tag ghcr.io/dasomel/nfs-quota-agent:latest -> sha256:de8a77104d4da1c97ccd5f9ff9a22f4edd6041f0aeca18f35d0628f6d4be4195
tag ghcr.io/dasomel/nfs-quota-agent:0.4 -> sha256:de8a77104d4da1c97ccd5f9ff9a22f4edd6041f0aeca18f35d0628f6d4be4195
tag ghcr.io/dasomel/nfs-quota-agent:0 -> sha256:de8a77104d4da1c97ccd5f9ff9a22f4edd6041f0aeca18f35d0628f6d4be4195
OK: published digest verification passed for v0.4.2
tag ghcr.io/dasomel/nfs-quota-agent:v0.4.2-rc1 -> sha256:a39c3e879893ca6214dabc6cd725661075a81a890976ff19f2e59e2b825a205a
platforms: linux/amd64 linux/arm64 linux/arm/v7
floating tag ghcr.io/dasomel/nfs-quota-agent:latest -> sha256:de8a77104d4da1c97ccd5f9ff9a22f4edd6041f0aeca18f35d0628f6d4be4195
floating tag ghcr.io/dasomel/nfs-quota-agent:0.4 -> sha256:de8a77104d4da1c97ccd5f9ff9a22f4edd6041f0aeca18f35d0628f6d4be4195
floating tag ghcr.io/dasomel/nfs-quota-agent:0 -> sha256:de8a77104d4da1c97ccd5f9ff9a22f4edd6041f0aeca18f35d0628f6d4be4195
OK: published digest verification passed for v0.4.2-rc1
```

Validation: `make verify-published-digests TAG=v0.4.2`, direct v0.4.2/v0.4.2-rc1 script runs, `bash -n`, `actionlint` (two pre-existing warnings elsewhere), trace evaluate and baseline gate.

Unverified: the new GitHub Actions job has not run until the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNRNt76QmTM2e3LTBy1KF9