### PR TITLE
release(chart): align Chart.yaml version and appVersion to 0.4.3-rc1 for the rc verification tag

### DIFF
--- a/.agents/evals/traces/2026-09-release-0.4.3-rc1-chart-version.json
+++ b/.agents/evals/traces/2026-09-release-0.4.3-rc1-chart-version.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": "openforge-agent-trace/v1",
+  "consistencyMode": "strict",
+  "traceId": "nfs-quota-agent-release-0.4.3-rc1-chart-version",
+  "task": "Align Chart.yaml version and appVersion to 0.4.3-rc1 for the v0.4.3-rc1 pre-release tag that first exercises the Verify Published Digests job (#5, PR #143)",
+  "changeContext": {
+    "paths": [
+      "charts/nfs-quota-agent/Chart.yaml",
+      ".agents/evals/traces/2026-09-release-0.4.3-rc1-chart-version.json"
+    ]
+  },
+  "events": [
+    {
+      "id": "e1",
+      "type": "external_input",
+      "summary": "Decision 2026-09-04: cut v0.4.3-rc1 as a pre-release so the new block-mode Verify Published Digests release job (PR #143) and the rc floating-tag rule are exercised on a real tag before the next stable release; #5 closes after that run succeeds.",
+      "provenance": "user decision 2026-09-04 and PR #143",
+      "reviewed": true
+    },
+    {
+      "id": "e2",
+      "type": "scope_check",
+      "summary": "Only Chart.yaml version/appVersion change to the SemVer prerelease 0.4.3-rc1 (valid for Helm and for the release-preflight guard, which preserves the -rc suffix). CHANGELOG is generated on tag. No template, values, RBAC or code change."
+    },
+    {
+      "id": "e3",
+      "type": "reproduction",
+      "summary": "runtime: `make release-preflight TAG=v0.4.3-rc1` on origin/main (Chart 0.4.2/0.4.2) fails: version and appVersion must match the tag."
+    },
+    {
+      "id": "e4",
+      "type": "bug_fix",
+      "summary": "Set version: 0.4.3-rc1 and appVersion: \"0.4.3-rc1\" in charts/nfs-quota-agent/Chart.yaml; default helm template renders image tag 0.4.3-rc1."
+    },
+    {
+      "id": "e5",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "`make release-preflight TAG=v0.4.3-rc1` exits 0; helm lint clean; helm template default renders :0.4.3-rc1; trace evaluated and gated.",
+      "scope": "Chart metadata, release-preflight guard, helm lint/render, behavior-contract trace validation. The release workflow itself only runs on the v* tag and is not exercised here.",
+      "evidence": [
+        "runtime:make-release-preflight-tag-v0.4.3-rc1-exit-0",
+        "ci:helm-lint-charts-nfs-quota-agent",
+        "ci:helm-template-default-image-tag-0.4.3-rc1",
+        "policy:python3-agents-evals-evaluate-release-0.4.3-rc1-trace",
+        "policy:python3-agents-evals-gate-release-0.4.3-rc1-trace"
+      ]
+    },
+    {
+      "id": "e6",
+      "type": "completion_claim",
+      "summary": "Chart.yaml aligned to 0.4.3-rc1; the rc tag will pass the preflight guard. Unverified: the rc release run itself, including the first CI execution of verify-published-digests, happens on the tag push."
+    },
+    {
+      "id": "e7",
+      "type": "task_outcome",
+      "state": "A",
+      "summary": "Release preparation for the rc verification tag complete; tagging is a separate maintainer action."
+    }
+  ]
+}

--- a/charts/nfs-quota-agent/Chart.yaml
+++ b/charts/nfs-quota-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nfs-quota-agent
 description: A Kubernetes agent that enforces filesystem project quotas for NFS PersistentVolumes
 type: application
-version: 0.4.2
-appVersion: "0.4.2"
+version: 0.4.3-rc1
+appVersion: "0.4.3-rc1"
 keywords:
   - nfs
   - quota


### PR DESCRIPTION
Prepares the `v0.4.3-rc1` **pre-release** tag. Its purpose is to run the new block-mode `Verify Published Digests` release job (#143) for the first time on a real tag, including the rc rule that `latest`/`0.4`/`0` must stay on the stable digest.

## Change
- `charts/nfs-quota-agent/Chart.yaml`: `version: 0.4.2 → 0.4.3-rc1`, `appVersion: "0.4.2" → "0.4.3-rc1"`
- Trace `.agents/evals/traces/2026-09-release-0.4.3-rc1-chart-version.json`

## Verified
```
make release-preflight TAG=v0.4.3-rc1   → exit 0
helm lint charts/nfs-quota-agent         → 0 failed
helm template (defaults)                 → image: ghcr.io/dasomel/nfs-quota-agent:0.4.3-rc1
evaluate.py / gate.py                    → pass / 0 regressions
```

## Order
Merge, then tag `v0.4.3-rc1`. Expected: 11 release jobs succeed in block mode, `verify-published-digests` passes with floating tags still on v0.4.2's digest, release marked pre-release. #5 closes after that run.

Part of #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNRNt76QmTM2e3LTBy1KF9