### PR TITLE
release(chart): align Chart.yaml version and appVersion to 0.4.3-rc2 for the second rc verification tag

### DIFF
--- a/.agents/evals/traces/2026-09-release-0.4.3-rc2-chart-version.json
+++ b/.agents/evals/traces/2026-09-release-0.4.3-rc2-chart-version.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": "openforge-agent-trace/v1",
+  "consistencyMode": "strict",
+  "traceId": "nfs-quota-agent-release-0.4.3-rc2-chart-version",
+  "task": "Align Chart.yaml version and appVersion to 0.4.3-rc2 for the second rc tag that re-proves the Verify Published Digests job after the docker-fallback fix (#5, PR #146)",
+  "changeContext": {
+    "paths": [
+      "charts/nfs-quota-agent/Chart.yaml",
+      ".agents/evals/traces/2026-09-release-0.4.3-rc2-chart-version.json"
+    ]
+  },
+  "events": [
+    {
+      "id": "e1",
+      "type": "external_input",
+      "summary": "v0.4.3-rc1 (run 33867414069) published correctly but its Verify Published Digests job failed on a script bug fixed in PR #146; decision 2026-09-05: cut v0.4.3-rc2 to prove the job on a real runner before closing #5.",
+      "provenance": "user decision 2026-09-05, release run 33867414069, PR #146",
+      "reviewed": true
+    },
+    {
+      "id": "e2",
+      "type": "scope_check",
+      "summary": "Only Chart.yaml version/appVersion change to the SemVer prerelease 0.4.3-rc2 (valid for Helm and for the release-preflight guard, which preserves the -rc suffix). CHANGELOG is generated on tag. No template, values, RBAC or code change."
+    },
+    {
+      "id": "e3",
+      "type": "reproduction",
+      "summary": "runtime: `make release-preflight TAG=v0.4.3-rc2` on origin/main (Chart 0.4.3-rc1) fails: version and appVersion must match the tag."
+    },
+    {
+      "id": "e4",
+      "type": "bug_fix",
+      "summary": "Set version: 0.4.3-rc2 and appVersion: \"0.4.3-rc2\" in charts/nfs-quota-agent/Chart.yaml; default helm template renders image tag 0.4.3-rc2."
+    },
+    {
+      "id": "e5",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "`make release-preflight TAG=v0.4.3-rc2` exits 0; helm lint clean; helm template default renders :0.4.3-rc2; trace evaluated and gated.",
+      "scope": "Chart metadata, release-preflight guard, helm lint/render, behavior-contract trace validation. The release workflow itself only runs on the v* tag and is not exercised here.",
+      "evidence": [
+        "runtime:make-release-preflight-tag-v0.4.3-rc2-exit-0",
+        "ci:helm-lint-charts-nfs-quota-agent",
+        "ci:helm-template-default-image-tag-0.4.3-rc2",
+        "policy:python3-agents-evals-evaluate-release-0.4.3-rc2-trace",
+        "policy:python3-agents-evals-gate-release-0.4.3-rc2-trace"
+      ]
+    },
+    {
+      "id": "e6",
+      "type": "completion_claim",
+      "summary": "Chart.yaml aligned to 0.4.3-rc2; the rc tag will pass the preflight guard. Unverified: the rc release run itself, including the first CI execution of verify-published-digests, happens on the tag push."
+    },
+    {
+      "id": "e7",
+      "type": "task_outcome",
+      "state": "A",
+      "summary": "Release preparation for the rc verification tag complete; tagging is a separate maintainer action."
+    }
+  ]
+}

--- a/charts/nfs-quota-agent/Chart.yaml
+++ b/charts/nfs-quota-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nfs-quota-agent
 description: A Kubernetes agent that enforces filesystem project quotas for NFS PersistentVolumes
 type: application
-version: 0.4.3-rc1
-appVersion: "0.4.3-rc1"
+version: 0.4.3-rc2
+appVersion: "0.4.3-rc2"
 keywords:
   - nfs
   - quota


### PR DESCRIPTION
Prepares `v0.4.3-rc2` (pre-release). v0.4.3-rc1 published correctly, but its `Verify Published Digests` job failed on a script bug (#146). This tag re-proves that job on a real runner.

## Change
- `charts/nfs-quota-agent/Chart.yaml`: `0.4.3-rc1 → 0.4.3-rc2` (version and appVersion)
- Trace `.agents/evals/traces/2026-09-release-0.4.3-rc2-chart-version.json`

## Verified
```
make release-preflight TAG=v0.4.3-rc2 → exit 0 ; helm lint → 0 failed ; trace evaluate/gate → pass / 0 regressions
```

## Order
Merge #146 first, then this, then tag `v0.4.3-rc2`. Expected: 11 jobs succeed, `verify-published-digests` passes with `latest`/`0.4`/`0` still on v0.4.2. #5 closes after that.

Part of #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNRNt76QmTM2e3LTBy1KF9