### PR TITLE
ci(security): scan the built image with Trivy and add the OpenSSF Scorecard workflow (#150)

### DIFF
--- a/.agents/evals/traces/2026-09-image-scan-scorecard.json
+++ b/.agents/evals/traces/2026-09-image-scan-scorecard.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": "openforge-agent-trace/v1",
+  "consistencyMode": "strict",
+  "traceId": "nfs-quota-agent-image-scan-scorecard",
+  "task": "Scan the built container image with Trivy and add the OpenSSF Scorecard workflow (#150)",
+  "changeContext": {
+    "paths": [
+      ".github/workflows/ci.yaml",
+      ".github/workflows/scorecard.yml",
+      "README.md",
+      "README-ko.md",
+      "docs/release-egress-block.md",
+      ".agents/evals/traces/2026-09-image-scan-scorecard.json"
+    ]
+  },
+  "events": [
+    {
+      "id": "e1",
+      "type": "external_input",
+      "summary": "Issue #150 requested (1) Trivy container image scanning for the built OCI image in CI, with harden-runner egress-policy: block and SARIF upload under category trivy-image, and (2) OpenSSF Scorecard workflow pinned by commit SHA on main push, weekly cron, and workflow_dispatch with publish_results: true, harden-runner block mode, and badge added to README.",
+      "provenance": "gh issue view 150",
+      "reviewed": true
+    },
+    {
+      "id": "e2",
+      "type": "scope_check",
+      "summary": "Only .github/workflows/ci.yaml (Image Build OCI export + Image Scan job), .github/workflows/scorecard.yml, README badges, docs/release-egress-block.md, and evaluation trace touched. No application logic, Helm templates, or existing workflows modified beyond scope."
+    },
+    {
+      "id": "e3",
+      "type": "reproduction",
+      "summary": "policy: `ci.yaml` previously only executed `trivy fs` (filesystem scan); the built multi-arch container image was never scanned for OS package or binary vulnerabilities in CI. Additionally, no `scorecard.yml` workflow existed to evaluate repository supply-chain posture, and no OpenSSF Scorecard badge was present in README."
+    },
+    {
+      "id": "e4",
+      "type": "bug_fix",
+      "summary": "Configured linux/amd64 OCI archive export in `ci.yaml`'s `image-build` job and added `image-scan` job running Trivy image scan on the unpacked OCI layout with HIGH/CRITICAL failure and SARIF upload; created `.github/workflows/scorecard.yml` with pinned `ossf/scorecard-action` and documented egress block allowlist; added OpenSSF Scorecard badges to README and documented allowlists in docs/release-egress-block.md."
+    },
+    {
+      "id": "e5",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "actionlint on ci.yaml and scorecard.yml exits 0; check-doc-citations.py verifies all 153 doc citations; trace evaluated and gated clean. Workflow jobs themselves will execute and verify on the PR and on main.",
+      "scope": "Workflow syntax, actionlint static analysis, doc citations, and trace evaluation. Live runner egress enforcement and SARIF security tab publishing are verified on PR and main runs.",
+      "evidence": [
+        "ci:actionlint-ci-and-scorecard-workflows",
+        "ci:check-doc-citations-passed",
+        "policy:python3-agents-evals-evaluate-trace",
+        "policy:python3-agents-evals-gate-trace"
+      ]
+    },
+    {
+      "id": "e6",
+      "type": "task_outcome",
+      "state": "B",
+      "summary": "CI image scan job and OpenSSF Scorecard workflow implemented with egress-policy block and minimal allowlists; static verification and doc citations verified clean.",
+      "next": "Observe CI Image Scan job succeed on PR #150; after merge, observe OpenSSF Scorecard execute on main with published results and update readiness rows in docs/cncf-readiness-draft.md with live run IDs."
+    }
+  ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -410,6 +410,84 @@ jobs:
           name: os-packages-manifest
           path: os-packages-manifest.txt
 
+      # Export linux/amd64 OCI archive for the Image Scan job (#150).
+      # Reuses the BuildKit cache populated by the multi-arch build step above.
+      - name: Build linux/amd64 OCI image archive for scanning
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          load: false
+          outputs: type=oci,dest=/tmp/image-amd64-oci.tar
+          cache-from: type=gha
+
+      - name: Upload image OCI archive artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: image-oci
+          path: /tmp/image-amd64-oci.tar
+
+  image-scan:
+    name: Image Scan
+    runs-on: ubuntu-latest
+    needs: image-build
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: block
+          # Assembled for Trivy image scan and GitHub SARIF upload (#150):
+          # actions/download-artifact and upload-sarif communicate with GitHub APIs and blob storage,
+          # aquasecurity/setup-trivy fetches from github.com/api.github.com/objects.githubusercontent.com,
+          # Trivy downloads its vulnerability database from ghcr.io/pkg-containers.githubusercontent.com
+          # with mirror.gcr.io fallback, checks release notice at check.trivy.dev,
+          # and actions results / Azure blob storage accounts for SARIF upload.
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            mirror.gcr.io:443
+            check.trivy.dev:443
+            results-receiver.actions.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            *.blob.core.windows.net:443
+
+      - name: Download image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: image-oci
+          path: /tmp/image-oci
+
+      # Trivy's OCI image scanner requires an unpacked OCI layout directory (containing index.json)
+      # rather than an unextracted OCI tarball (which fails with 'stat <tar>/index.json: not a directory').
+      - name: Extract OCI image archive
+        run: |
+          mkdir -p /tmp/oci-layout
+          tar -xf /tmp/image-oci/image-amd64-oci.tar -C /tmp/oci-layout
+
+      - name: Run Trivy vulnerability scanner (image)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          input: /tmp/oci-layout
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-image-results.sarif'
+
+      - name: Upload Trivy image scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: always()
+        with:
+          sarif_file: 'trivy-image-results.sarif'
+          category: 'trivy-image'
 
   security:
     name: Security Scan

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,62 @@
+name: OpenSSF Scorecard
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly on Saturdays at 01:30 UTC.
+    - cron: '30 1 * * 6'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      security-events: write
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: block
+          # Endpoints documented by ossf/scorecard-action and step-security (#150):
+          # Scorecard queries GitHub, OSV, OpenSSF Scorecards API, OSS-Fuzz, OpenSSF Best Practices,
+          # and deps.dev, with actions runner results-receiver and Azure blob storage for SARIF upload.
+          allowed-endpoints: >
+            api.deps.dev:443
+            api.github.com:443
+            api.osv.dev:443
+            api.securityscorecards.dev:443
+            github.com:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
+            results-receiver.actions.githubusercontent.com:443
+            www.bestpractices.dev:443
+            *.actions.githubusercontent.com:443
+            *.blob.core.windows.net:443
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: results.sarif

--- a/README-ko.md
+++ b/README-ko.md
@@ -2,6 +2,8 @@
 
 [English](README.md) | 한국어
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/dasomel/nfs-quota-agent/badge)](https://scorecard.dev/viewer/?uri=github.com/dasomel/nfs-quota-agent)
+
 NFS 기반 PersistentVolume에 대해 파일시스템 프로젝트 쿼타를 자동으로 적용하는 Kubernetes 에이전트입니다. NFS 서버 노드에서 실행되며 파일시스템 레벨에서 스토리지 제한을 적용합니다. **XFS**, **ext4**, **Btrfs** 파일시스템을 지원합니다.
 
 ## 개요

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 English | [한국어](README-ko.md)
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/dasomel/nfs-quota-agent/badge)](https://scorecard.dev/viewer/?uri=github.com/dasomel/nfs-quota-agent)
+
 A Kubernetes agent that automatically enforces filesystem project quotas for NFS-based PersistentVolumes. This agent runs on NFS server nodes and ensures storage limits are enforced at the filesystem level. Supports **XFS**, **ext4**, and **Btrfs** filesystems.
 
 ## Overview

--- a/docs/release-egress-block.md
+++ b/docs/release-egress-block.md
@@ -75,6 +75,15 @@ However, the four **Phase 1 read-only jobs** (`release-preflight`, `test`, `chan
 | `update-changelog` | `block` | 5 | `github.com`, `api.github.com`, `raw/objects.githubusercontent.com`, `release-assets.githubusercontent.com` | Phase 3 | block (verified on v0.4.2-rc1, run 33815273613) |
 | `verify-published-digests` | `block` | 9 | GitHub release APIs/assets, GHCR/package CDN, Actions results + D4 wildcards | Phase 3 | block (new; unverified until next tag) |
 
+### CI Scan Jobs (#150)
+
+Security scan jobs added to `.github/workflows/ci.yaml` and `.github/workflows/scorecard.yml` run in `egress-policy: block` mode from inception:
+
+| Job | Workflow | Current Mode | Endpoints Count | Key Hosts / Destinations | Status |
+| :--- | :--- | :---: | :---: | :--- | :---: |
+| `image-scan` | `.github/workflows/ci.yaml` | `block` | 11 | `github.com`, `api.github.com`, `objects/release-assets.githubusercontent.com`, `ghcr.io`, `pkg-containers.githubusercontent.com`, `mirror.gcr.io`, `check.trivy.dev`, `results-receiver`, `*.actions.githubusercontent.com`, `*.blob.core.windows.net` | block (unverified until PR run) |
+| `analysis` (Scorecard) | `.github/workflows/scorecard.yml` | `block` | 10 | `api.deps.dev`, `api.github.com`, `api.osv.dev`, `api.securityscorecards.dev`, `github.com`, `oss-fuzz-build-logs.storage.googleapis.com`, `results-receiver`, `www.bestpractices.dev`, `*.actions.githubusercontent.com`, `*.blob.core.windows.net` | block (unverified until main run) |
+
 > **If `verify-published-digests` fails after publication:** every artifact is already published (images, floating tags, release assets, signatures) and none of them can be re-pointed under the repo's immutable-tag policy. Treat the failure as a verification finding, not a rollback trigger: first re-run the failed job (a GHCR read blocked by the allowlist or a registry propagation delay looks identical to a real mismatch), then run `make verify-published-digests TAG=<tag>` locally with the release's `release-manifest.json`. A confirmed mismatch means the release is marked pre-release with the discrepancy recorded in its body and the next tag carries the fix, exactly as v0.4.0 was handled.
 
 ### Phase 1 Audit Evidence & Deltas (Evidence Run ID: 33769700751, v0.4.0)


### PR DESCRIPTION
Closes #150.

### Summary
1. **Image Scan CI Job**:
   - Added linux/amd64 single-architecture OCI archive export to `image-build` in `.github/workflows/ci.yaml` and uploaded it as an artifact (`image-oci`).
   - Added `image-scan` job in `.github/workflows/ci.yaml` that runs `step-security/harden-runner` in `egress-policy: block` mode, downloads the image artifact, extracts the OCI image layout, and runs `aquasecurity/trivy-action` with severity HIGH,CRITICAL, exit-code 1, ignore-unfixed true, and SARIF upload with category `trivy-image`.
2. **OpenSSF Scorecard Workflow**:
   - Created `.github/workflows/scorecard.yml` running `ossf/scorecard-action` (pinned by commit SHA `2d1146689b8cda280b9bc96326124645441f03bc` # v2.4.4) on push to `main`, weekly cron (`30 1 * * 6`), and `workflow_dispatch`.
   - Enabled `publish_results: true` with required permissions (`id-token: write`, `security-events: write`, `contents: read`).
   - Enforced `step-security/harden-runner` in `egress-policy: block` mode using the action's documented allowlist.
   - Uploaded SARIF results to GitHub Security.
3. **Badges & Documentation**:
   - Added the OpenSSF Scorecard badge to `README.md` and `README-ko.md`.
   - Documented the CI scan jobs and egress allowlists in `docs/release-egress-block.md`.
4. **Operational Trace**:
   - Added `.agents/evals/traces/2026-09-image-scan-scorecard.json` (state B with `next`), evaluated and gated clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNRNt76QmTM2e3LTBy1KF9