### PR TITLE
ci(agent): canary immutable OpenForge reusable gate

### DIFF
--- a/.agents/evals/traces/2026-09-openforge-reusable-canary.json
+++ b/.agents/evals/traces/2026-09-openforge-reusable-canary.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "openforge-agent-trace/v1",
+  "consistencyMode": "strict",
+  "traceId": "nfs-quota-agent-openforge-reusable-canary-2026-09",
+  "task": "Canary the immutable OpenForge reusable AGENT-005 gate without changing privileged quota behavior",
+  "changeContext": {"paths": [".github/workflows/agent-behavior.yml", ".agents/evals/traces/**"]},
+  "events": [
+    {"id":"e1","type":"scope_check","summary":"Limit change to Agent Behavior CI and evidence only; privileged quota/runtime paths remain untouched"},
+    {"id":"e2","type":"reproduction","summary":"Local AGENT-005 gate is the existing decision baseline","evidence":["ci:agent-behavior-local"]},
+    {"id":"e3","type":"bug_fix","summary":"Add immutable OpenForge reusable gate in parallel without removing the local gate"},
+    {"id":"e4","type":"regression_verification","status":"passed","summary":"Local gate remains active while reusable gate is evaluated against the same hydrated trace","scope":"agent evaluation CI only","evidence":["ci:agent-behavior-local","ci:openforge-reusable-canary"]},
+    {"id":"e5","type":"verification","status":"passed","summary":"No internal quota, host filesystem, RBAC, chart privilege, Docker image, or command-runner behavior changed","scope":"workflow/evidence-only canary","evidence":["ci:agent-behavior","policy:no-privileged-runtime-change"]},
+    {"id":"e6","type":"completion_claim","summary":"Reusable gate canary is complete only when local and remote pass/fail semantics are equivalent"},
+    {"id":"e7","type":"task_outcome","state":"A","summary":"Complete when CI demonstrates gate equivalence"}
+  ]
+}

--- a/.github/workflows/agent-behavior.yml
+++ b/.github/workflows/agent-behavior.yml
@@ -71,15 +71,43 @@ jobs:
             --event-id e5 \
             --out .agents/evals/traces/2026-08-runtime-filesystem-tools.json \
             -- bash scripts/ci/check-runtime-filesystem-tools.sh
-      - name: Gate live filesystem runtime behavior
+      - name: Gate live filesystem runtime behavior locally
         shell: bash
         run: |
           set -euo pipefail
           python3 .agents/evals/gate.py \
             --trace .agents/evals/traces/2026-08-runtime-filesystem-tools.json \
             --baseline .agents/evals/baseline.eval.json \
-            --current-out /tmp/filesystem-runtime-eval.json \
-            --comparison-out /tmp/filesystem-runtime-comparison.json
+            --current-out /tmp/filesystem-runtime-local-eval.json \
+            --comparison-out /tmp/filesystem-runtime-local-comparison.json
+      - name: Canary canonical OpenForge reusable gate
+        uses: dasomel/openforge/.github/actions/agent-eval@36b2474951a228338e21196afdeb3fd97d523704
+        with:
+          trace: .agents/evals/traces/2026-08-runtime-filesystem-tools.json
+          baseline: .agents/evals/baseline.eval.json
+          current-out: /tmp/filesystem-runtime-openforge-eval.json
+          comparison-out: /tmp/filesystem-runtime-openforge-comparison.json
+      - name: Require local and reusable gate equivalence
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          def load(path): return json.loads(Path(path).read_text(encoding='utf-8'))
+          def outcomes(data): return {item['behavior']: item['outcome'] for item in data.get('results', [])}
+          local_eval=load('/tmp/filesystem-runtime-local-eval.json')
+          remote_eval=load('/tmp/filesystem-runtime-openforge-eval.json')
+          local_cmp=load('/tmp/filesystem-runtime-local-comparison.json')
+          remote_cmp=load('/tmp/filesystem-runtime-openforge-comparison.json')
+          assert local_eval.get('schemaVersion') == remote_eval.get('schemaVersion')
+          assert local_eval.get('traceId') == remote_eval.get('traceId')
+          assert local_eval.get('summary',{}).get('failed') == remote_eval.get('summary',{}).get('failed')
+          assert outcomes(local_eval) == outcomes(remote_eval)
+          assert local_cmp.get('summary',{}).get('regressions') == remote_cmp.get('summary',{}).get('regressions')
+          assert local_cmp.get('regressions',[]) == remote_cmp.get('regressions',[])
+          print('Local and OpenForge reusable gates are semantically equivalent')
+          PY
       - name: Correlate high-risk changes with trace evidence
         if: github.event_name == 'pull_request'
         shell: bash


### PR DESCRIPTION
Superseded by #168, which implemented the same immutable OpenForge reusable-gate canary on current main, preserved the repository-owned local gate and high-risk evidence contract, passed Agent Behavior + repository CI, and was merged. This duplicate branch is intentionally closed without merge.