### PR TITLE
ci(agent): canary OpenForge reusable evaluation gate

### DIFF
--- a/.agents/evals/traces/2026-08-runtime-filesystem-tools.json
+++ b/.agents/evals/traces/2026-08-runtime-filesystem-tools.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "openforge-agent-trace/v1",
   "traceId": "nfs-quota-agent-runtime-filesystem-tools-2026-08",
-  "task": "Verify that every filesystem backend implemented by the agent has its required command available in the shipped container image.",
+  "task": "Verify that every filesystem backend implemented by the agent has its required command available in the shipped container image and that the canonical OpenForge reusable gate preserves the local evaluation result.",
   "consistencyMode": "strict",
   "changeContext": {
     "paths": [
@@ -17,9 +17,9 @@
     {
       "id": "e1",
       "type": "scope_check",
-      "summary": "Limit the maintenance task to the shipped image runtime dependencies and their compatibility evidence.",
-      "scope": "Dockerfile runtime packages, compatibility matrix evidence, and Agent Behavior verification wiring",
-      "evidence": ["policy:filesystem-runtime-boundary"]
+      "summary": "Limit the maintenance task to shipped-image runtime dependencies and Agent Behavior evaluation wiring; do not widen quota, filesystem, or runtime privileges.",
+      "scope": "Dockerfile runtime packages, compatibility evidence, Agent Behavior verification wiring, and reusable-gate equivalence",
+      "evidence": ["policy:filesystem-runtime-boundary", "policy:openforge-reusable-gate-canary"]
     },
     {
       "id": "e2",
@@ -31,40 +31,40 @@
     {
       "id": "e3",
       "type": "bug_fix",
-      "summary": "Make the shipped runtime image provide every command required by its implemented filesystem backends.",
-      "scope": "container filesystem runtime dependencies",
-      "evidence": ["artifact:Dockerfile"]
+      "summary": "Make the shipped runtime image provide every command required by its implemented filesystem backends while preserving the repository-owned verification boundary.",
+      "scope": "container filesystem runtime dependencies and verification contract",
+      "evidence": ["artifact:Dockerfile", "workflow:.github/workflows/agent-behavior.yml"]
     },
     {
       "id": "e4",
       "type": "verification",
-      "summary": "Build the shipped image and verify required filesystem commands from inside the container.",
+      "summary": "Build the shipped image and verify required filesystem commands from inside the container before both local and OpenForge gates evaluate the hydrated trace.",
       "scope": "container runtime command availability",
       "status": "pending",
-      "evidence": ["test:scripts/ci/check-runtime-filesystem-tools.sh"]
+      "evidence": ["test:scripts/ci/check-runtime-filesystem-tools.sh", "gate:local+openforge"]
     },
     {
       "id": "e5",
       "type": "regression_verification",
-      "summary": "The same runtime image check must pass after the dependency repair.",
-      "scope": "container runtime filesystem tooling regression",
+      "summary": "The same runtime image check must pass and local/OpenForge evaluations must remain semantically equivalent.",
+      "scope": "container runtime filesystem tooling and evaluation regression",
       "status": "pending",
-      "evidence": ["test:scripts/ci/check-runtime-filesystem-tools.sh"]
+      "evidence": ["test:scripts/ci/check-runtime-filesystem-tools.sh", "gate:semantic-equivalence"]
     },
     {
       "id": "e6",
       "type": "completion_claim",
-      "summary": "Filesystem runtime dependency coverage is complete only when the shipped image passes the live command check.",
-      "scope": "filesystem runtime dependency repair",
-      "evidence": ["runtime:container-filesystem-tools"]
+      "summary": "Filesystem runtime dependency coverage and reusable-gate rollout are complete only when live verification passes and both evaluation paths agree.",
+      "scope": "filesystem runtime dependency repair and evaluation canary",
+      "evidence": ["runtime:container-filesystem-tools", "gate:openforge-reusable-action"]
     },
     {
       "id": "e7",
       "type": "task_outcome",
       "state": "A",
-      "summary": "Complete after the live runtime verification and regression verification pass.",
-      "scope": "filesystem runtime dependency repair",
-      "evidence": ["policy:strict-live-verification"]
+      "summary": "Complete after live runtime verification, regression verification, and reusable-gate equivalence pass.",
+      "scope": "filesystem runtime dependency repair and evaluation canary",
+      "evidence": ["policy:strict-live-verification", "policy:reusable-gate-equivalence"]
     }
   ]
 }

--- a/.github/workflows/agent-behavior.yml
+++ b/.github/workflows/agent-behavior.yml
@@ -69,21 +69,21 @@ jobs:
             --trace .agents/evals/traces/2026-08-runtime-filesystem-tools.json \
             --event-id e4 \
             --event-id e5 \
-            --out /tmp/nfs-live-trace.json \
+            --out .agents/evals/traces/2026-08-runtime-filesystem-tools.json \
             -- bash scripts/ci/check-runtime-filesystem-tools.sh
       - name: Gate live filesystem runtime behavior locally
         shell: bash
         run: |
           set -euo pipefail
           python3 .agents/evals/gate.py \
-            --trace /tmp/nfs-live-trace.json \
+            --trace .agents/evals/traces/2026-08-runtime-filesystem-tools.json \
             --baseline .agents/evals/baseline.eval.json \
             --current-out /tmp/nfs-local-eval.json \
             --comparison-out /tmp/nfs-local-comparison.json
       - name: Canary canonical OpenForge reusable gate
         uses: dasomel/openforge/.github/actions/agent-eval@36b2474951a228338e21196afdeb3fd97d523704
         with:
-          trace: /tmp/nfs-live-trace.json
+          trace: .agents/evals/traces/2026-08-runtime-filesystem-tools.json
           baseline: .agents/evals/baseline.eval.json
           current-out: /tmp/nfs-openforge-eval.json
           comparison-out: /tmp/nfs-openforge-comparison.json

--- a/.github/workflows/agent-behavior.yml
+++ b/.github/workflows/agent-behavior.yml
@@ -69,17 +69,51 @@ jobs:
             --trace .agents/evals/traces/2026-08-runtime-filesystem-tools.json \
             --event-id e4 \
             --event-id e5 \
-            --out .agents/evals/traces/2026-08-runtime-filesystem-tools.json \
+            --out /tmp/nfs-live-trace.json \
             -- bash scripts/ci/check-runtime-filesystem-tools.sh
-      - name: Gate live filesystem runtime behavior
+      - name: Gate live filesystem runtime behavior locally
         shell: bash
         run: |
           set -euo pipefail
           python3 .agents/evals/gate.py \
-            --trace .agents/evals/traces/2026-08-runtime-filesystem-tools.json \
+            --trace /tmp/nfs-live-trace.json \
             --baseline .agents/evals/baseline.eval.json \
-            --current-out /tmp/filesystem-runtime-eval.json \
-            --comparison-out /tmp/filesystem-runtime-comparison.json
+            --current-out /tmp/nfs-local-eval.json \
+            --comparison-out /tmp/nfs-local-comparison.json
+      - name: Canary canonical OpenForge reusable gate
+        uses: dasomel/openforge/.github/actions/agent-eval@36b2474951a228338e21196afdeb3fd97d523704
+        with:
+          trace: /tmp/nfs-live-trace.json
+          baseline: .agents/evals/baseline.eval.json
+          current-out: /tmp/nfs-openforge-eval.json
+          comparison-out: /tmp/nfs-openforge-comparison.json
+      - name: Require local and reusable gate equivalence
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          def load(path):
+              return json.loads(Path(path).read_text(encoding='utf-8'))
+
+          local_eval = load('/tmp/nfs-local-eval.json')
+          remote_eval = load('/tmp/nfs-openforge-eval.json')
+          local_cmp = load('/tmp/nfs-local-comparison.json')
+          remote_cmp = load('/tmp/nfs-openforge-comparison.json')
+
+          def outcomes(data):
+              return {item['behavior']: item['outcome'] for item in data.get('results', [])}
+
+          assert local_eval.get('schemaVersion') == remote_eval.get('schemaVersion')
+          assert local_eval.get('traceId') == remote_eval.get('traceId')
+          assert local_eval.get('summary', {}).get('failed') == remote_eval.get('summary', {}).get('failed')
+          assert outcomes(local_eval) == outcomes(remote_eval), (outcomes(local_eval), outcomes(remote_eval))
+          assert local_cmp.get('summary', {}).get('regressions') == remote_cmp.get('summary', {}).get('regressions')
+          assert local_cmp.get('regressions', []) == remote_cmp.get('regressions', [])
+          print('Local and OpenForge reusable gates are semantically equivalent')
+          PY
       - name: Correlate high-risk changes with trace evidence
         if: github.event_name == 'pull_request'
         shell: bash


### PR DESCRIPTION
## Summary

Canary the merged OpenForge AGENT-005 reusable evaluation action in nfs-quota-agent without removing the repository-owned local gate.

- pin OpenForge action to immutable SHA `36b2474951a228338e21196afdeb3fd97d523704`
- hydrate one live filesystem-runtime trace once
- evaluate the same trace through the local gate and OpenForge reusable action
- require semantic equivalence for behavior outcomes and regression results
- preserve repository-owned risk policy, live runtime command verification, evidence correlation, and same-diff high-risk trace requirements
- update the scoped operational trace in the same PR because `.github` is classified high-risk

No quota implementation, filesystem privilege, runtime permission, or controller behavior is changed.

Tracking: dasomel/openforge#34.