### PR TITLE
refactor(agent): canonicalize project verification skill

### DIFF
--- a/.agents/evals/traces/2026-09-agent-skill-canonicalization.json
+++ b/.agents/evals/traces/2026-09-agent-skill-canonicalization.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": "openforge-agent-trace/v1",
+  "traceId": "nfs-quota-agent-skill-canonicalization-2026-09",
+  "task": "Canonicalize the repository verification skill without losing the existing real-filesystem evidence contract",
+  "consistencyMode": "strict",
+  "changeContext": {
+    "paths": [
+      ".agents/**"
+    ]
+  },
+  "events": [
+    {
+      "id": "e1",
+      "type": "scope_check",
+      "summary": "Scoped the change to agent-skill naming, canonical ownership, Claude compatibility routing, and preservation of the existing verification contract"
+    },
+    {
+      "id": "e2",
+      "type": "reproduction",
+      "summary": "Confirmed the project verification workflow was exposed under the globally generic name verification even though its rules are specific to nfs-quota-agent filesystem, chart, UI, and dependency evidence",
+      "evidence": [
+        "policy:openforge-project-prefixed-skill-naming",
+        "artifact:legacy-verification-skill"
+      ]
+    },
+    {
+      "id": "e3",
+      "type": "bug_fix",
+      "summary": "Moved the canonical workflow to nfs-quota-verification and retained the old Claude skill only as a deprecated compatibility adapter"
+    },
+    {
+      "id": "e4",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "Repository CI remained green after the instruction-only canonicalization",
+      "scope": "Go tests, build/lint/project CI behavior unaffected by skill naming and routing changes",
+      "evidence": [
+        "ci:ci-run-34295336425"
+      ]
+    },
+    {
+      "id": "e5",
+      "type": "verification",
+      "status": "verified",
+      "summary": "The canonical skill preserves the existing distinction between stub/unit evidence and real filesystem enforcement evidence, while the legacy skill no longer owns a divergent copy",
+      "scope": "nfs-quota-agent project verification policy and compatibility routing",
+      "evidence": [
+        "policy:openforge-agent-skills-standard",
+        "artifact:existing-runtime-filesystem-trace"
+      ]
+    },
+    {
+      "id": "e6",
+      "type": "completion_claim",
+      "summary": "Skill canonicalization is complete without changing runtime behavior or weakening the repository verification contract"
+    },
+    {
+      "id": "e7",
+      "type": "task_outcome",
+      "state": "A",
+      "summary": "Canonical project-prefixed verification skill and deprecated compatibility adapter are recorded with passing repository evidence"
+    }
+  ]
+}

--- a/.agents/skills/nfs-quota-verification/SKILL.md
+++ b/.agents/skills/nfs-quota-verification/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: nfs-quota-verification
+description: Verify nfs-quota-agent changes with evidence appropriate to Go logic, real quota filesystems, embedded UI, Helm/RBAC, and dependency bumps. Use before claiming a repository change is complete, fixed, or safe to merge.
+license: Apache-2.0
+compatibility: Requires the nfs-quota-agent checkout, Go toolchain, Make targets, and optional real XFS/ext4/Btrfs quota host for runtime evidence.
+metadata:
+  openforge-scope: project
+  openforge-owner: dasomel/nfs-quota-agent
+  openforge-maturity: verified
+  openforge-version: "1"
+---
+
+# nfs-quota-agent Verification
+
+## Use When
+
+- Finishing any code, chart, UI, dependency, or quota-behavior change in this repository.
+- Deciding whether current evidence proves the requested behavior.
+- Preparing a commit or PR that claims a bug is fixed or a feature is complete.
+
+## Do Not Use When
+
+- You only need generic Go formatting/lint advice unrelated to this repository.
+- A task has not changed behavior and no completion claim is being made.
+
+## Inputs
+
+- The changed paths and requested behavior.
+- Current repository state and relevant issue/spec.
+- Whether a real quota-enabled host is available.
+
+## Workflow
+
+1. Identify what the change can invalidate instead of blindly running every check.
+2. For ordinary Go changes, run:
+
+```bash
+make test && make vet && gofmt -l .
+```
+
+`gofmt -l .` must print nothing. Run `make lint` for a material code diff or before merge when CI lint failures would be costly.
+
+3. Apply the path-specific evidence below.
+
+### Quota implementation (`internal/quota/**`)
+
+Tests stub OS quota binaries through `quota.CommandRunner`; they prove argv shape and parsing, not real enforcement. When a real host is available, confirm the mounted filesystem and actual quota state:
+
+```bash
+findmnt -o OPTIONS /path
+xfs_quota -x -c "report -p -b" /path
+repquota -P /path
+btrfs qgroup show -re --raw /path
+```
+
+Only run the command appropriate to the tested filesystem. If no real quota host is available, report that runtime enforcement remains unverified.
+
+### Embedded dashboard (`internal/ui/dashboard.html`)
+
+A Go build only proves the embedded file compiled. For visual/interaction changes:
+
+```bash
+make build && ./bin/nfs-quota-agent ui --path=<dir> --addr=:8080
+```
+
+Open the UI and exercise the changed behavior.
+
+### Helm / manifest / RBAC
+
+Run `make helm-lint`. If RBAC verbs, host access, or `privileged` changed, report the new privilege surface separately; lint does not prove the widening is justified.
+
+### Dependency / Go version bump
+
+Run:
+
+```bash
+make build && make test && make docker-build
+```
+
+Confirm all version sites documented by `AGENTS.md` move together, including the Docker builder stage.
+
+## Verification
+
+Report:
+
+- exact commands run and pass/fail result;
+- whether evidence is unit/stub, build/static, UI/manual, or real filesystem/runtime;
+- important paths not exercised;
+- any privilege/API behavior that changed.
+
+Do not present stubbed quota tests as proof of a real filesystem property.
+
+## Stop / Escalate When
+
+- Real filesystem behavior is required but no suitable quota-enabled host is available.
+- The fix requires permission/RBAC widening or destructive filesystem operations beyond the approved scope.
+- Current evidence contradicts the intended behavior or repeated patches stop converging.
+
+## References
+
+- `AGENTS.md`
+- `Makefile` / `make help`
+- quota implementation under `internal/quota/`
+- Helm/chart manifests and repository CI configuration

--- a/.claude/skills/verification/SKILL.md
+++ b/.claude/skills/verification/SKILL.md
@@ -1,45 +1,19 @@
 ---
 name: verification
-description: Verify a change to nfs-quota-agent before claiming it is done, fixed, or passing. Use when finishing any code change in this repo, before committing or opening a PR, and whenever deciding what counts as evidence for quota, UI, chart, or dependency changes.
+description: Legacy Claude adapter for nfs-quota-agent verification. Use only when an existing Claude workflow invokes `verification`; load the canonical `nfs-quota-verification` skill instead for all verification work.
+license: Apache-2.0
+compatibility: Claude adapter; canonical workflow is repository-local under .agents/skills/nfs-quota-verification/.
+metadata:
+  openforge-scope: project
+  openforge-owner: dasomel/nfs-quota-agent
+  openforge-maturity: deprecated
+  openforge-version: "2"
 ---
 
-# Verifying a change to nfs-quota-agent
+# Legacy verification adapter
 
-Run what the change can actually invalidate, paste the output, and name what you did not verify. `make help` lists every target; the notes below are about which ones prove what.
+The canonical workflow is:
 
-## Baseline for any Go change
+`../../../.agents/skills/nfs-quota-verification/SKILL.md`
 
-```bash
-make test && make vet && gofmt -l .
-```
-
-`gofmt -l .` printing nothing is the pass condition. `make lint` runs the same golangci-lint config CI does — run it when the diff is large enough that a style failure would be an annoying round trip.
-
-## What each kind of change needs beyond the baseline
-
-**`internal/quota/**`** — the OS binaries are stubbed through `quota.CommandRunner`, so tests can only prove argv shape and output parsing. Report that distinction explicitly. Real enforcement needs a host with the filesystem mounted `prjquota`; if you don't have one, say the change is unverified against a real filesystem rather than implying coverage.
-
-Useful on a real host:
-
-```bash
-findmnt -o OPTIONS /path                     # must include prjquota
-xfs_quota -x -c "report -p -b" /path
-repquota -P /path
-btrfs qgroup show -re --raw /path
-```
-
-**`internal/ui/dashboard.html`** — the file is `go:embed`-ed, so a build proves it compiled in, not that it renders. Launch it and look:
-
-```bash
-make build && ./bin/nfs-quota-agent ui --path=<dir> --addr=:8080
-```
-
-Then open it in a browser and exercise the part you changed. A passing build is not evidence for this file.
-
-**Chart or manifest changes** — `make helm-lint`. If RBAC verbs or `privileged` changed, state the new privilege surface in your report; a lint pass says nothing about whether the widening was warranted.
-
-**Dependency or Go version bumps** — `make build && make test && make docker-build`. The Docker build is the step that catches a `Dockerfile` builder-stage version left behind. Confirm all four version sites moved together (see `AGENTS.md`).
-
-## Reporting
-
-State the commands you ran with their output, then the gap: which parts are covered by stubbed tests, which need a real NFS host, which were not exercised at all. A completion claim without that split is not verification.
+Read and follow that file. Do not maintain a second copy of the verification procedure here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 @AGENTS.md
 
-## Verification
+## Project skill routing
 
-Use the `verification` skill before claiming a change is complete.
+Before claiming a change is complete, load and follow `.agents/skills/nfs-quota-verification/SKILL.md`.
+
+The old `.claude/skills/verification` entry is a compatibility adapter only; do not add workflow rules there.


### PR DESCRIPTION
## Summary

Applies the OpenForge Agent Skills layering model without losing the repository's high-value real-filesystem verification guidance.

- adds canonical project-prefixed `.agents/skills/nfs-quota-verification/SKILL.md`
- preserves the critical distinction between stub/unit evidence and real quota-filesystem evidence
- converts the generic Claude `verification` skill into a deprecated compatibility adapter
- keeps `CLAUDE.md` thin and routes Claude to the canonical project skill
- adds OpenForge scope/owner/maturity/version metadata while remaining Agent Skills-compatible

## Why

`verification` is too generic for globally installed skills and creates a collision/drift risk. The new canonical name is repository-specific, while the old Claude entry remains available for existing invocations during migration.

## Verification notes

This change only restructures agent instructions; it does not change Go/runtime behavior. Existing verification commands are preserved in the canonical skill.