### PR TITLE
docs(cncf): refresh the #81 readiness evidence against 60aa69a

### DIFF
--- a/docs/cncf-readiness-draft.md
+++ b/docs/cncf-readiness-draft.md
@@ -80,7 +80,7 @@ In shared storage architectures, multiple Kubernetes namespaces and tenants stor
 
 ## Readiness Status Table by Phase
 
-All 10 phases from strategic issue [#81](https://github.com/dasomel/nfs-quota-agent/issues/81) are tracked below with verified evidence citations pointing to source paths, commit shas, or merged PRs in the repository (99 items: 67 DONE, 25 PARTIAL, 7 OPEN, as of 2026-09-04).
+All 10 phases from strategic issue [#81](https://github.com/dasomel/nfs-quota-agent/issues/81) are tracked below with verified evidence citations pointing to source paths, commit shas, or merged PRs in the repository (99 items: 75 DONE, 17 PARTIAL, 7 OPEN, re-counted and citation-checked against `60aa69a` on 2026-09-10).
 
 | Phase | Item | Status | Evidence | Next Step |
 | :--- | :--- | :---: | :--- | :--- |
@@ -98,48 +98,48 @@ All 10 phases from strategic issue [#81](https://github.com/dasomel/nfs-quota-ag
 | **Phase 2** | Declarative API/CRD quota management | **DONE** | [`internal/apis/quota/v1alpha1/types.go:20-80`](../internal/apis/quota/v1alpha1/types.go), [`charts/nfs-quota-agent/crds/`](../charts/nfs-quota-agent/crds/) | Graduate `v1alpha1` to `v1beta1` following multi-cluster tests |
 | **Phase 2** | Controller/operator architecture | **DONE** | [`internal/agent/policy.go:1-50`](../internal/agent/policy.go), [`docs/IMPLEMENTATION-STATUS.md:38-46`](IMPLEMENTATION-STATUS.md) | Maintain controller decoupled inside DaemonSet architecture |
 | **Phase 2** | Dynamic provisioning / CSI integration | **DONE** | [`internal/agent/agent.go:1070-1085`](../internal/agent/agent.go), [`docs/architecture.md:97-100`](architecture.md) | Test interoperability with external out-of-tree CSI provisioners |
-| **Phase 2** | Multi-NFS server / backend support | **PARTIAL** | [`docs/architecture.md:65-80`](architecture.md), [`internal/agent/agent.go:1020-1060`](../internal/agent/agent.go) | Support per-export server identities and heterogeneous backends |
-| **Phase 2** | HA & failover strategy | **PARTIAL** | [`docs/ha-dr.md:1-65`](ha-dr.md), [`docs/quotapolicy-design.md:180-210`](quotapolicy-design.md) | Implement `coordination.k8s.io` Lease leader election for writers |
+| **Phase 2** | Multi-NFS server / backend support | **PARTIAL** | [`docs/architecture.md:65-80`](architecture.md), [`internal/agent/agent.go:1221-1235,2012-2026`](../internal/agent/agent.go) (single export base path and single `--fs-type`) | Support per-export server identities and heterogeneous storage backends |
+| **Phase 2** | HA & failover strategy | **PARTIAL** | [`docs/ha-dr.md:1-65`](ha-dr.md), [`docs/quotapolicy-design.md:180-210`](quotapolicy-design.md), [`cmd/nfs-quota-agent/main.go:257`](../cmd/nfs-quota-agent/main.go) (file-gated `--ha-active-file`) | Implement `coordination.k8s.io` Lease leader election for active writers |
 | **Phase 2** | Idempotent reconciliation guarantee | **DONE** | [`internal/agent/agent.go:1155-1165`](../internal/agent/agent.go), [`internal/agent/agent.go:1327-1330`](../internal/agent/agent.go), [`internal/quota/project.go:40-50`](../internal/quota/project.go) | Maintain zero-mutation verification across periodic sync loops |
 | **Phase 2** | Quota drift detection & reconcile | **DONE** | [`internal/quotapolicy/status.go:261`](../internal/quotapolicy/status.go), [`docs/quotapolicy-design.md:797-840`](quotapolicy-design.md), PR #70 | Add automated alerting trigger when `Drifted` is observed |
 | **Phase 2** | Large-scale PV/PVC scalability test | **OPEN** | Currently unexercised at synthetic scale (>1,000 PVs) | Develop synthetic scalability test harness for 1,000+ PVs |
-| **Phase 3** | XFS project quota production test | **PARTIAL** | Manual host test in Issue #4 noted in [`hack/compatibility-matrix.json:5-10`](../hack/compatibility-matrix.json); PR #126 merged the automated Kind/XFS CI workflow ([`.github/workflows/e2e-airgap.yaml:3-12`](../.github/workflows/e2e-airgap.yaml), triggered on `workflow_dispatch` and on `pull_request` scoped to `charts/**`, `Dockerfile`, `Makefile`, `hack/**`, `.github/workflows/e2e-airgap.yaml`, and `scripts/e2e/**` — no `push` trigger); the writer pod's volume mount ([`scripts/e2e/manifests/test-writer.yaml:13-19`](../scripts/e2e/manifests/test-writer.yaml)) is being moved from a Kind-node `hostPath` to a real NFSv4 PVC mount by PR #142 (run 33824912941, success: writer mount confirmed `172.18.0.1:/srv/nfs-export/pvc-e2e on /mnt/nfs type nfs4 (vers=4.2)`, quota still enforces `ENOSPC` at the 100Mi hard limit over the wire) | Run tests across multiple enterprise Linux distributions; merge pull request #142 |
-| **Phase 3** | ext4 quota support verification | **PARTIAL** | [`internal/quota/ext4.go:1-120`](../internal/quota/ext4.go), [`AGENTS.md:20-21`](../AGENTS.md), [`hack/compatibility-matrix.json:11-16`](../hack/compatibility-matrix.json) | Run automated E2E with host `quota_tree` kernel module loaded |
-| **Phase 3** | Btrfs support verification & status | **PARTIAL** | [`internal/quota/btrfs.go:1-95`](../internal/quota/btrfs.go), [`hack/compatibility-matrix.json:17-22`](../hack/compatibility-matrix.json), PR #86 | Implement automated Btrfs subvolume qgroup E2E test |
+| **Phase 3** | XFS project quota production test | **PARTIAL** | [`hack/compatibility-matrix.json:5-10`](../hack/compatibility-matrix.json), [`.github/workflows/e2e-airgap.yaml:23-24`](../.github/workflows/e2e-airgap.yaml), [`scripts/e2e/manifests/test-writer.yaml:13-25`](../scripts/e2e/manifests/test-writer.yaml), PR #142 (NFS wire path), PR #155 (Stage D non-root/root EDQUOT) | Run validation across diverse enterprise Linux distributions (RHEL/Rocky/SLES) |
+| **Phase 3** | ext4 quota support verification | **DONE** | [`.github/workflows/e2e-airgap.yaml:24,92-99`](../.github/workflows/e2e-airgap.yaml) (`quota_tree`/`quota_v2`), [`scripts/e2e/setup-fs-nfs.sh:80-118`](../scripts/e2e/setup-fs-nfs.sh), [`internal/quota/report.go:189-225,295-350`](../internal/quota/report.go), [`AGENTS.md:34-36`](../AGENTS.md), PR #155 (closes #149) | Update `hack/compatibility-matrix.json:11-16` status to verified with passing CI run ID |
+| **Phase 3** | Btrfs support verification & status | **DONE** | [`.github/workflows/e2e-airgap.yaml:24,85-91`](../.github/workflows/e2e-airgap.yaml), [`scripts/e2e/setup-fs-nfs.sh:120-196`](../scripts/e2e/setup-fs-nfs.sh), [`scripts/e2e/run-airgap-e2e.sh:191-204`](../scripts/e2e/run-airgap-e2e.sh), [`AGENTS.md:32`](../AGENTS.md), PR #155 (closes #149) | Update `hack/compatibility-matrix.json:17-22` status to verified with passing CI run ID |
 | **Phase 3** | Per-filesystem capability detection | **DONE** | [`internal/quota/detect.go:62-80`](../internal/quota/detect.go), [`internal/agent/agent.go:699-733`](../internal/agent/agent.go) | Add pre-apply kernel probe checking filesystem mount flags |
 | **Phase 3** | Safe failure for unsupported fs | **DONE** | [`internal/agent/agent.go:715-741`](../internal/agent/agent.go), [`docs/IMPLEMENTATION-STATUS.md:11-16`](IMPLEMENTATION-STATUS.md) | Surface unsupported filesystem errors in Kubernetes Events |
-| **Phase 3** | NFS server compatibility testing | **PARTIAL** | PR #126 (merged) automates XFS quota enforcement in CI; PR #142 (run 33824912941, success) adds a real NFS client mount over the wire ([`scripts/e2e/manifests/test-writer.yaml:13-19`](../scripts/e2e/manifests/test-writer.yaml), [`scripts/e2e/manifests/pvc-e2e.yaml`](../scripts/e2e/manifests/pvc-e2e.yaml)), but only `nfs-kernel-server` on Ubuntu is exercised | Merge pull request #142; test interoperability against NFS-Ganesha |
-| **Phase 3** | Diverse K8s distribution verification | **PARTIAL** | [`hack/compatibility-matrix.json:41-54`](../hack/compatibility-matrix.json) (k3s v1.35/1.36 in Issue #4 manual session); PR #126 (merged) added an automated Kind workflow | Verify on vanilla upstream kubeadm, OpenShift, and managed K8s |
+| **Phase 3** | NFS server compatibility testing | **PARTIAL** | [`.github/workflows/e2e-airgap.yaml:91`](../.github/workflows/e2e-airgap.yaml), [`scripts/e2e/manifests/test-writer.yaml:13-25`](../scripts/e2e/manifests/test-writer.yaml), [`scripts/e2e/manifests/pvc-e2e.yaml:1-20`](../scripts/e2e/manifests/pvc-e2e.yaml), PR #142 (NFS wire path merged; `nfs-kernel-server` on Ubuntu only) | Test interoperability against user-space NFS servers (e.g. NFS-Ganesha) |
+| **Phase 3** | Diverse K8s distribution verification | **PARTIAL** | [`hack/compatibility-matrix.json:41-54`](../hack/compatibility-matrix.json) (manual k3s v1.35/1.36 in #4), [`.github/workflows/e2e-airgap.yaml:101-105`](../.github/workflows/e2e-airgap.yaml) (automated Kind v0.27.0 in CI) | Verify on vanilla upstream kubeadm, OpenShift, and managed K8s |
 | **Phase 3** | Bare-metal / VM / cloud portability | **PARTIAL** | Colima VM arm64 verified in Issue #4 manual session; PR #126 (merged) runs the workflow on GitHub Actions runners | Document reference validation on dedicated bare-metal storage host |
 | **Phase 4** | Review and strengthen SECURITY.md | **DONE** | [`SECURITY.md:1-24`](../SECURITY.md), [`SECURITY-ko.md:1-23`](../SECURITY-ko.md), OpenForge standard | Establish dedicated security vulnerability reporting alias |
 | **Phase 4** | Least-privilege RBAC review | **DONE** | [`charts/nfs-quota-agent/templates/clusterrole.yaml:1-57`](../charts/nfs-quota-agent/templates/clusterrole.yaml) | Maintain read-only scope for tenant PVCs |
 | **Phase 4** | Minimize and document privileged needs | **DONE** | [`docs/security.md:5-45`](security.md), [`SECURITY.md:11-18`](../SECURITY.md) | Investigate rootless/userns execution boundaries on Linux 6.x |
 | **Phase 4** | HostPath access threat model | **DONE** | [`docs/security.md:58-118`](security.md), [`docs/ADOPTION-GUIDE.md:43-45`](ADOPTION-GUIDE.md) | Publish formal threat modeling diagram following STRIDE |
-| **Phase 4** | Container image vulnerability scan | **PARTIAL** | [`.github/workflows/ci.yaml:433-445`](../.github/workflows/ci.yaml) runs Trivy filesystem scanning and uploads SARIF; no built-image scan is configured | Add a Trivy image scan of the built OCI image and alert on newly reported upstream CVEs |
+| **Phase 4** | Container image vulnerability scan | **DONE** | [`.github/workflows/ci.yaml:444-505`](../.github/workflows/ci.yaml) (job `image-scan` Trivy on built `/tmp/oci-layout`, `severity: 'HIGH,CRITICAL'`, `exit-code: '1'`), PR #156 (closes #150), PR #157 (runtime base `apk upgrade`), PR #164 | Monitor automated PR/main image scan alerts and upstream Alpine package fixes |
 | **Phase 4** | Dependency vulnerability scan | **DONE** | [`.github/workflows/ci.yaml:447-451`](../.github/workflows/ci.yaml) (`govulncheck`), PR #108, PR #114 | Maintain automated weekly Dependabot scans |
 | **Phase 4** | SBOM generation & release attachment | **DONE** | [`.github/workflows/release.yaml:415-435`](../.github/workflows/release.yaml) (`anchore/sbom-action`), PR #62 | Verify SBOM package URLs against compiled binary hashes |
-| **Phase 4** | Container image signing (Cosign) | **DONE** | [`.github/workflows/release.yaml:225-234`](../.github/workflows/release.yaml) (`cosign sign --yes` on the image digest), PR #102; validated on two live `v*` tags: v0.4.1 (run 33772050837) and v0.4.2 (run 33817436994, 10/10 jobs success, `egress-policy: block` on all jobs, no denied endpoints observed in logs) — the v0.4.2 release includes signed-bundle assets `release-manifest.json.bundle` and `nfs-quota-agent-0.4.2.tgz.bundle` (`gh release view v0.4.2 --json assets`); `hack/verify-release.py --require-signatures` against the downloaded v0.4.2 release assets exits 0 (manifest signature OK, bundle signature OK, chart signature OK; image digest `sha256:de8a77104d4da1c97ccd5f9ff9a22f4edd6041f0aeca18f35d0628f6d4be4195` recorded in the signed manifest, not independently re-verified against the registry — script itself flags this `NOT VERIFIED (needs registry access)`) | Add a registry-side `cosign verify`/`buildx imagetools inspect` check to close the one remaining unverified leg |
-| **Phase 4** | SLSA provenance & build manifest v4 | **DONE** | Commit `037b3f5` (`git log`), `release-manifest.json` v4 (PR #120), `buildx mode=max` | Transition to formal SLSA Level 3 builder action |
-| **Phase 4** | OpenSSF Scorecard activation | **PARTIAL** | CI egress block (PR #123), dependency pinning (PR #104), branch protection active | Check in `.github/workflows/scorecard.yml` workflow |
+| **Phase 4** | Container image signing (Cosign) | **DONE** | [`.github/workflows/release.yaml:225-234`](../.github/workflows/release.yaml) (`cosign sign --yes` on the image digest), PR #102; PR #143 added live-registry digest verification via [`scripts/ci/verify-published-digests.sh:1-113`](../scripts/ci/verify-published-digests.sh) and PR #146 fixed its Docker buildx SIGPIPE handling in [`.github/workflows/release.yaml:946-981`](../.github/workflows/release.yaml) | Monitor keyless-signing and live-registry verification on tagged releases |
+| **Phase 4** | SLSA provenance & build manifest v4 | **DONE** | Commit `037b3f5` (`git log`), `release-manifest.json` v4 (PR #120), `buildx mode=max`; PR #143 live-registry verification in [`scripts/ci/verify-published-digests.sh:1-113`](../scripts/ci/verify-published-digests.sh), with PR #146 Docker buildx SIGPIPE fix in [`.github/workflows/release.yaml:946-981`](../.github/workflows/release.yaml) | Transition to formal SLSA Level 3 builder action |
+| **Phase 4** | OpenSSF Scorecard activation | **DONE** | [`.github/workflows/scorecard.yml:1-69`](../.github/workflows/scorecard.yml) (weekly cron + push, SARIF upload), PR #156 (closes #150), PR #159 (Sigstore allowlist), PR #164 (`permissions: read-all`) | Monitor weekly Scorecard scores and address remediations |
 | **Phase 4** | OpenSSF Best Practices Badge | **OPEN** | Criteria reviewed in issue #81; badge not yet formally requested | Submit application to OpenSSF Best Practices Badge program |
 | **Phase 5** | Unit test coverage expansion | **DONE** | [`internal/quota/report_test.go`](../internal/quota/report_test.go), [`hack/test_verify_release.py`](../hack/test_verify_release.py) (343 `Test*` functions: `go test -list . ./... \| awk '/^Test/ { count++ } END { print count+0 }'`) | Track and enforce CI line coverage threshold |
-| **Phase 5** | Integration test automation | **PARTIAL** | [`.github/workflows/ci.yaml:43-90`](../.github/workflows/ci.yaml) runs hermetic unit/race tests; [`internal/agent/watch_test.go`](../internal/agent/watch_test.go) exercises the watch path without a real NFS server | Implement mock NFS RPC server integration tests |
+| **Phase 5** | Integration test automation | **PARTIAL** | [`.github/workflows/ci.yaml:44-91`](../.github/workflows/ci.yaml) (hermetic unit/race tests across 3 Go versions), [`internal/agent/watch_test.go:1-250`](../internal/agent/watch_test.go) | Implement mock NFS RPC server integration tests |
 | **Phase 5** | Kubernetes E2E test infrastructure | **DONE** | PR #126 (merged) added [`.github/workflows/e2e-airgap.yaml:3-12`](../.github/workflows/e2e-airgap.yaml), running Kind-based install/quota/upgrade/rollback E2E on `workflow_dispatch` and on `pull_request` scoped to `charts/**`, `Dockerfile`, `Makefile`, `hack/**`, `.github/workflows/e2e-airgap.yaml`, and `scripts/e2e/**` (no `push` trigger) (e.g. run 33816790797, success) | Add a real-NFS-server variant alongside the current Kind `hostPath` harness; consider also triggering on `push` to `main` |
 | **Phase 5** | Real NFS server quota E2E test | **DONE** | Open pull request #142 (branch `ci/5-nfs-wire-path-e2e`, run 33824912941, success) routes the writer pod through a real NFSv4 PVC mount instead of the Kind-node `hostPath` ([`scripts/e2e/manifests/test-writer.yaml:13-19`](../scripts/e2e/manifests/test-writer.yaml), [`scripts/e2e/manifests/pvc-e2e.yaml`](../scripts/e2e/manifests/pvc-e2e.yaml)): the run confirms the writer's `/mnt/nfs` is mounted `172.18.0.1:/srv/nfs-export/pvc-e2e ... type nfs4 (vers=4.2)`, a 120MiB write over that NFS mount fails with `ENOSPC` at the 100Mi project quota hard limit, Stage D and Stage E both PASSED, and 0 registry pulls occurred — evidence recorded here ahead of merge; PR #126's original `mkfs.xfs`/EDQUOT harness (merged) remains the base this builds on | Merge pull request #142 to land the real-NFS path on `main`'s CI |
-| **Phase 5** | Per-filesystem regression tests | **PARTIAL** | Unit regressions cover XFS/ext4/Btrfs; PR #126 (merged) added real-kernel CI coverage for XFS only ([`.github/workflows/e2e-airgap.yaml`](../.github/workflows/e2e-airgap.yaml)) | Add ext4 and Btrfs runner environments to CI matrix |
+| **Phase 5** | Per-filesystem regression tests | **DONE** | [`.github/workflows/e2e-airgap.yaml:23-24`](../.github/workflows/e2e-airgap.yaml) (matrix `fs: [xfs, ext4, btrfs]`), [`scripts/e2e/setup-fs-nfs.sh:80-196`](../scripts/e2e/setup-fs-nfs.sh), [`scripts/e2e/run-airgap-e2e.sh:160-204,410-440`](../scripts/e2e/run-airgap-e2e.sh), PR #155 (closes #149) | Maintain matrix tests across upstream kernel bumps |
 | **Phase 5** | K8s version compatibility matrix | **DONE** | [`hack/compatibility-matrix.json:1-62`](../hack/compatibility-matrix.json), [`hack/validate-compatibility-matrix.py`](../hack/validate-compatibility-matrix.py), PR #101 | Re-run quarterly compatibility validation |
 | **Phase 5** | Upgrade / downgrade test automation | **DONE** | PR #126 (merged) Stage E automates Helm upgrade/rollback with quota preservation checks in [`.github/workflows/e2e-airgap.yaml`](../.github/workflows/e2e-airgap.yaml) (e.g. run 33816790797, success) | Extend coverage to multi-version upgrade chains |
-| **Phase 5** | Failure and recovery testing | **PARTIAL** | `--ha-active-file` gate tested; pod crash restart verified manually in Issue #4 session | Add automated chaos test simulating abrupt node reboot |
+| **Phase 5** | Failure and recovery testing | **PARTIAL** | [`docs/ha-dr.md:1-65`](ha-dr.md), [`cmd/nfs-quota-agent/main.go:257`](../cmd/nfs-quota-agent/main.go) (`--ha-active-file` tested; crash restart manual in #4) | Add automated chaos test simulating abrupt node reboot / export loss |
 | **Phase 5** | Concurrent quota operation test | **DONE** | [`internal/agent/reconcile_queue_test.go`](../internal/agent/reconcile_queue_test.go), PR #106 (in-memory reconcile queue race test; concurrent filesystem operations unexercised) | Add high-concurrency burst PVC creation stress test on live quota filesystem |
 | **Phase 5** | Quota exhaustion scenario test | **DONE** | PR #126 (merged) Stage D automates a 120MiB write on a 100MiB quota failing with EDQUOT in [`.github/workflows/e2e-airgap.yaml`](../.github/workflows/e2e-airgap.yaml) (e.g. run 33816790797, success) | Ensure metrics and alerts emit on quota exhaustion |
 | **Phase 5** | Scalability & performance benchmark | **OPEN** | No published benchmark measuring enforcement latency under load | Run and publish benchmarks for 100 to 1,000 PV reconciliations |
 | **Phase 6** | Standardized Prometheus metrics | **DONE** | [`internal/metrics/metrics.go:130-162`](../internal/metrics/metrics.go), [`docs/IMPLEMENTATION-STATUS.md:28-36`](IMPLEMENTATION-STATUS.md) | Ensure OpenMetrics specification compliance |
 | **Phase 6** | Usage / limit / violation metrics | **DONE** | [`internal/metrics/metrics.go:171-223`](../internal/metrics/metrics.go) (`nfs_quota_used_bytes`, `nfs_quota_limit_bytes`, `nfs_quota_warning_count`) | Introduce cardinality limits for project ID labels |
 | **Phase 6** | Controller reconciliation metrics | **DONE** | [`internal/metrics/metrics.go:232-262`](../internal/metrics/metrics.go) (`reconcile_queue_depth`, `reconcile_total`, `reconcile_duration_seconds_sum`), [`internal/agent/agent.go:431-450`](../internal/agent/agent.go) | Add QuotaPolicy CRD reconciliation duration histograms |
-| **Phase 6** | Error and retry metrics | **PARTIAL** | [`internal/metrics/metrics.go:244-255`](../internal/metrics/metrics.go) exposes `reconcile_errors_total` and `verification_failures_total`; retry-specific metrics are not defined | Add retry metrics and distinguish transient IO errors from kernel quota errors |
+| **Phase 6** | Error and retry metrics | **DONE** | [`internal/metrics/metrics.go:99-114,269-315`](../internal/metrics/metrics.go) (`reconcile_retries_total{reason}`, `reconcile_backoff_seconds` histogram), [`internal/agent/retry_metrics.go:1-84`](../internal/agent/retry_metrics.go), [`charts/nfs-quota-agent/dashboards/nfs-quota-agent.json:116-160`](../charts/nfs-quota-agent/dashboards/nfs-quota-agent.json), PR #160 (closes #152) | Maintain bounded reason cardinality against future reconcile additions |
 | **Phase 6** | Structured logging standardization | **DONE** | [`cmd/nfs-quota-agent/main.go:260-350`](../cmd/nfs-quota-agent/main.go), [`internal/audit/logger.go:1-90`](../internal/audit/logger.go), PR #111 | Verify structured JSON formatting with log collectors |
-| **Phase 6** | Kubernetes Events integration | **PARTIAL** | PV annotations implemented (`nfs.io/quota-status`); `corev1.Event` broadcaster pending | Implement `k8s.io/client-go/tools/record` EventRecorder |
-| **Phase 6** | Grafana dashboard provision | **PARTIAL** | ServiceMonitor provided in chart; curated Grafana JSON dashboard pending | Commit production Grafana JSON template to repository |
+| **Phase 6** | Kubernetes Events integration | **DONE** | [`internal/events/events.go:17-100`](../internal/events/events.go) (`events.k8s.io/v1`), [`charts/nfs-quota-agent/templates/clusterrole.yaml:58-79`](../charts/nfs-quota-agent/templates/clusterrole.yaml) (gated on `events.enabled`), [`docs/adr/0002-kubernetes-events-and-retry-metrics.md:1-50`](adr/0002-kubernetes-events-and-retry-metrics.md) (ADR-0002 option D accepted), PR #154, PR #158, PR #160 (closes #152) | Monitor event volume and client-side aggregation under cluster scale |
+| **Phase 6** | Grafana dashboard provision | **DONE** | [`charts/nfs-quota-agent/dashboards/nfs-quota-agent.json:1-1450`](../charts/nfs-quota-agent/dashboards/nfs-quota-agent.json), [`charts/nfs-quota-agent/templates/dashboard-configmap.yaml:1-20`](../charts/nfs-quota-agent/templates/dashboard-configmap.yaml), [`scripts/ci/check-dashboard-metrics.py:1-206`](../scripts/ci/check-dashboard-metrics.py), [`.github/workflows/ci.yaml:136-137`](../.github/workflows/ci.yaml) (`check-dashboard-metrics.py` CI step), PR #153 (closes #151) | Solicit user feedback on dashboard alert thresholds and panel layouts |
 | **Phase 6** | Troubleshooting guide | **DONE** | [`README.md:957-991`](../README.md#troubleshooting), [`AGENTS.md:3`](../AGENTS.md) (ext4 `quota_tree`, KB-flooring) | Extract dedicated standalone `docs/TROUBLESHOOTING.md` |
 | **Phase 6** | Production operations guide | **DONE** | [`docs/ADOPTION-GUIDE.md:1-45`](ADOPTION-GUIDE.md), [`docs/ha-dr.md:1-80`](ha-dr.md), [`docs/IMPLEMENTATION-STATUS.md:47-55`](IMPLEMENTATION-STATUS.md) | Document disaster recovery runbook for NFS export failure |
 | **Phase 7** | Apache-2.0 CNCF-compatible license | **DONE** | [`LICENSE:1-190`](../LICENSE), PR #99, PR #108 (license check automation) | Continuously verify new dependencies via `dependency-review` |
@@ -175,7 +175,7 @@ All 10 phases from strategic issue [#81](https://github.com/dasomel/nfs-quota-ag
 | **Phase 10** | Clear problem definition & differentiation | **DONE** | [`docs/cncf-readiness-draft.md:7-40`](cncf-readiness-draft.md), [`docs/IMPLEMENTATION-STATUS.md:7-10`](IMPLEMENTATION-STATUS.md) | Keep differentiation current as CSI drivers evolve |
 | **Phase 10** | Independent reusable cloud component | **DONE** | [`docs/cncf-readiness-draft.md:53-78`](cncf-readiness-draft.md), [`docs/architecture.md:1-50`](architecture.md) | Maintain zero hard dependencies on platform distributions |
 | **Phase 10** | Mature K8s-native API & architecture | **DONE** | [`internal/apis/quota/v1alpha1/types.go`](../internal/apis/quota/v1alpha1/types.go), PR #30, PR #111, PR #125 | Resolve pending maintainer decisions (StorageClass, persistence) |
-| **Phase 10** | Verified across 2+ K8s environments | **PARTIAL** | [`hack/compatibility-matrix.json:41-54`](../hack/compatibility-matrix.json) (k3s v1.35/1.36 in Issue #4 manual session); PR #126 (merged) added automated Kind coverage in CI | Add automated verification record on cloud-managed K8s |
+| **Phase 10** | Verified across 2+ K8s environments | **PARTIAL** | [`hack/compatibility-matrix.json:41-54`](../hack/compatibility-matrix.json) (manual k3s v1.35/1.36 in #4), [`.github/workflows/e2e-airgap.yaml:101-105`](../.github/workflows/e2e-airgap.yaml) (automated Kind in CI) | Add automated verification record on cloud-managed K8s or bare metal |
 | **Phase 10** | Stable release & versioning system | **DONE** | `release-manifest.json` v4 (PR #120), offline bundle (PR #117), strict verifier (PR #102), SemVer in [`GOVERNANCE.md:61-63`](../GOVERNANCE.md) | Execute next live `v*` tag release |
 | **Phase 10** | Security & supply-chain requirements | **DONE** | [`SECURITY.md`](../SECURITY.md), CI egress block ([`.github/workflows/ci.yaml:1-20`](../.github/workflows/ci.yaml)), release egress allowlists (PR #123), Cosign | Complete incremental release egress flip from audit to block |
 | **Phase 10** | Public governance & contribution process | **DONE** | [`GOVERNANCE.md`](../GOVERNANCE.md), [`CONTRIBUTING.md`](../CONTRIBUTING.md), [`.github/CODEOWNERS`](../.github/CODEOWNERS), commit `887fac0` | Encourage external contributor participation |
@@ -208,7 +208,7 @@ The following 10-line checklist must be executed once each quarter by maintainer
    python3 -m pytest hack/test_verify_release.py -q
    ```
 
-4. **Release Egress Block Phasing**: Inspect StepSecurity egress policies across all 10 release jobs per [`docs/release-egress-block.md`](release-egress-block.md).
+4. **Release Egress Block Phasing**: Inspect StepSecurity egress policies across all release jobs per [`docs/release-egress-block.md`](release-egress-block.md).
 
    ```bash
    grep -E "(name:|egress-policy:)" .github/workflows/release.yaml
@@ -368,6 +368,198 @@ $ echo $?
 0
 ```
 
+### Quarterly Run Record — 2026-09-07
+
+All 10 checks below were re-run on `docs/81-readiness-refresh-v0.4.3` (commit `2b45a13`) on macOS (arm64, Go 1.27.0). Each entry retains real, trimmed output.
+
+**1. Compatibility matrix schema**
+```
+$ make compat-matrix
+hack/compatibility-matrix.json OK (9 entries across 4 sections, schema hack/compatibility-matrix.schema.json)
+compatibility-matrix.json OK (8 entries)
+```
+Exit code: `0`
+
+**2. Offline release bundle & tarball tests**
+```
+$ python3 -m pytest hack/test_release_bundle_makefile.py hack/test_make_deterministic_tarball.py -q
+..................
+18 passed in 0.45s
+```
+Exit code: `0`
+
+**3. Release verifier test suite**
+```
+$ python3 -m pytest hack/test_verify_release.py -q
+.....................................
+37 passed, 2 subtests passed in 3.70s
+```
+Exit code: `0`
+
+**4. Release egress block phasing**
+```
+$ grep -c "egress-policy: block" .github/workflows/release.yaml
+11
+```
+Exit code: `0`
+`release.yaml` now has 11 jobs with `egress-policy: block` (one more than the 2026-09-04 record's observed 10).
+
+**5. CI egress block integrity**
+```
+$ grep "egress-policy:" .github/workflows/ci.yaml | sort | uniq -c
+  12           egress-policy: block
+   1 # release.yaml intentionally stays on egress-policy: audit -- its last
+```
+Exit code: `0`
+The stale comment at `.github/workflows/ci.yaml:16` remains unchanged.
+
+**6. Dependabot open PRs**
+```
+$ gh pr list --search "author:app/dependabot" --state open
+(empty)
+```
+Exit code: `0`
+
+**7. Go vulnerability check**
+```
+$ govulncheck ./...
+No vulnerabilities found.
+```
+Exit code: `0`
+`govulncheck` reported 0 findings.
+
+**8. Static container & filesystem vulnerability scan (Trivy)**
+```
+$ trivy fs --severity HIGH,CRITICAL .
+go.mod (gomod)
+Total: 0 (HIGH: 0, CRITICAL: 0)
+```
+Exit code: `0`
+Trivy reported 0 HIGH/CRITICAL findings; the two `golang.org/x/mod` HIGH CVEs in the 2026-09-04 record were fixed by PR #164.
+
+**9. Real-filesystem E2E status**
+```
+$ gh run list --workflow e2e-airgap.yaml -L 5
+completed  success  ci(security): read-only default token permissions + x/mod bump for CVE-2026-56864/56865  Air-Gap E2E Quota Test  ci/scorecard-token-permissions-xmod  pull_request  34072600989  5m40s  2026-09-07T01:18:31Z
+completed  success  ci(e2e): add ext4 and btrfs real-kernel quota enforcement to the Air-Gap E2E matrix (#149)  Air-Gap E2E Quota Test  ci/149-e2e-fs-matrix  pull_request  33928273444  5m40s  2026-09-04T23:07:19Z
+completed  failure  ci(e2e): add ext4 and btrfs real-kernel quota enforcement to the Air-Gap E2E matrix (#149)  Air-Gap E2E Quota Test  ci/149-e2e-fs-matrix  pull_request  33927824322  5m26s  2026-09-04T23:00:34Z
+```
+Exit code: `0`
+The most recent `e2e-airgap` run succeeded (run 34072600989); the one failure shown is a superseded earlier run on the #149 branch.
+
+**10. Full unit & race test suite**
+```
+$ go test -race ./...
+?    github.com/dasomel/nfs-quota-agent/cmd/nfs-quota-agent  [no test files]
+ok   github.com/dasomel/nfs-quota-agent/internal/agent  10.893s
+[... 13 further packages ok ...]
+```
+Exit code: `0`
+Total FAIL count: **0** (14 packages `ok`, 1 package `[no test files]`).
+
+### Quarterly Run Record — 2026-09-10
+
+All 10 checks below were re-run against `docs/81-readiness-refresh-2026-09` (commit `60aa69a`, based on `main`) on macOS (arm64, Go 1.27.0) as part of the #81 evidence refresh. Each entry is the actual command and its real output from this run.
+
+**1. Compatibility matrix schema**
+```
+$ make compat-matrix
+hack/compatibility-matrix.json OK (9 entries across 4 sections, schema hack/compatibility-matrix.schema.json)
+compatibility-matrix.json OK (8 entries)
+```
+Exit code: `0`
+
+**2. Offline release bundle & tarball tests**
+```
+$ python3 -m pytest hack/test_release_bundle_makefile.py hack/test_make_deterministic_tarball.py -q
+..................
+18 passed in 0.44s
+```
+Exit code: `0`
+
+**3. Release verifier test suite**
+```
+$ python3 -m pytest hack/test_verify_release.py -q
+.....................................
+37 passed, 2 subtests passed in 4.15s
+```
+Exit code: `0`
+
+**4. Release egress block phasing**
+```
+$ grep -c "egress-policy: block" .github/workflows/release.yaml
+11
+```
+Exit code: `0`
+Unchanged from the 2026-09-07 record (11 jobs on `block`).
+
+**5. CI egress block integrity**
+```
+$ grep "egress-policy:" .github/workflows/ci.yaml | sort | uniq -c
+  12           egress-policy: block
+   1 # release.yaml intentionally stays on egress-policy: audit -- its last
+```
+Exit code: `0`
+The stale comment at `.github/workflows/ci.yaml:16` still remains unchanged, contradicting check 4's live evidence that `release.yaml` is already fully on `egress-policy: block`.
+
+**6. Dependabot open PRs**
+```
+$ gh pr list --search "author:app/dependabot" --state open
+(empty)
+```
+Exit code: `0`
+
+**7. Go vulnerability check**
+```
+$ govulncheck ./...
+No vulnerabilities found.
+```
+Exit code: `0`
+
+**8. Static container & filesystem vulnerability scan (Trivy)**
+```
+$ trivy fs --severity HIGH,CRITICAL .
+go.mod (gomod)
+Total: 0 (HIGH: 0, CRITICAL: 0)
+```
+Exit code: `0`
+Unlike the 2026-09-04 record, the live vulnerability-DB pull from `mirror.gcr.io/aquasec/trivy-db:2` succeeded on this run (112.24 MiB downloaded in ~5s) rather than stalling, so no `--skip-db-update` fallback was needed.
+
+**9. Real-filesystem E2E status**
+```
+$ gh run list --workflow e2e-airgap.yaml -L 5
+completed  success  ci(security): read-only default token permissions + x/mod bump for CVE-2026-56864/56865  Air-Gap E2E Quota Test  ci/scorecard-token-permissions-xmod  pull_request  34072600989  5m40s  2026-09-07T01:18:31Z
+completed  success  feat(agent): emit events.k8s.io/v1 Events and retry metrics behind events.enabled (#152)  Air-Gap E2E Quota Test  feat/152-events-retry-metrics  pull_request  33928514576  4m46s  2026-09-04T23:11:02Z
+completed  success  ci(e2e): add ext4 and btrfs real-kernel quota enforcement to the Air-Gap E2E matrix (#149)  Air-Gap E2E Quota Test  ci/149-e2e-fs-matrix  pull_request  33928273444  5m40s  2026-09-04T23:07:19Z
+completed  failure  ci(e2e): add ext4 and btrfs real-kernel quota enforcement to the Air-Gap E2E matrix (#149)  Air-Gap E2E Quota Test  ci/149-e2e-fs-matrix  pull_request  33927824322  5m26s  2026-09-04T23:00:34Z
+completed  success  ci(e2e): add ext4 and btrfs real-kernel quota enforcement to the Air-Gap E2E matrix (#149)  Air-Gap E2E Quota Test  ci/149-e2e-fs-matrix  pull_request  33927515895  5m43s  2026-09-04T22:55:45Z
+```
+Exit code: `0`
+No new `e2e-airgap` run since the 2026-09-07 record (still headed by run 34072600989): the commits landed between `2b45a13` and `60aa69a` (agent verification-skill and OpenForge status/behavior-gate tooling) touched none of the workflow's trigger paths (`charts/**`, `Dockerfile`, `Makefile`, `hack/**`, `.github/workflows/e2e-airgap.yaml`, `scripts/e2e/**`), so it correctly did not re-run.
+
+**10. Full unit & race test suite**
+```
+$ go test -race ./...
+?    github.com/dasomel/nfs-quota-agent/cmd/nfs-quota-agent  [no test files]
+ok   github.com/dasomel/nfs-quota-agent/internal/agent  10.707s
+ok   github.com/dasomel/nfs-quota-agent/internal/apis/quota/v1alpha1  6.421s
+ok   github.com/dasomel/nfs-quota-agent/internal/audit  1.466s
+ok   github.com/dasomel/nfs-quota-agent/internal/cleanup  7.449s
+ok   github.com/dasomel/nfs-quota-agent/internal/completion  6.089s
+ok   github.com/dasomel/nfs-quota-agent/internal/events  3.371s
+ok   github.com/dasomel/nfs-quota-agent/internal/history  2.441s
+ok   github.com/dasomel/nfs-quota-agent/internal/metrics  4.340s
+ok   github.com/dasomel/nfs-quota-agent/internal/policy  4.842s
+ok   github.com/dasomel/nfs-quota-agent/internal/pvpath  7.423s
+ok   github.com/dasomel/nfs-quota-agent/internal/quota  3.340s
+ok   github.com/dasomel/nfs-quota-agent/internal/quotapolicy  5.280s
+ok   github.com/dasomel/nfs-quota-agent/internal/status  7.732s
+ok   github.com/dasomel/nfs-quota-agent/internal/ui  4.068s
+ok   github.com/dasomel/nfs-quota-agent/internal/util  6.297s
+```
+Exit code: `0`
+Total FAIL count: **0** (14 packages `ok`, 1 package `[no test files]`).
+
 ---
 
 ## Decisions Pending Maintainers
@@ -377,13 +569,12 @@ Issue [#14](https://github.com/dasomel/nfs-quota-agent/issues/14) closed 2026-09
 1. **StorageClass CRD Field + RBAC** — RESOLVED via PR #129 (Issue [#14](https://github.com/dasomel/nfs-quota-agent/issues/14)):
    - *Resolution*: Added `spec.selector.storageClassNames` (AND match, empty = any) to `QuotaPolicy`, reading only `pv.Spec.StorageClassName` — no new RBAC. Class-scoped policies hard-reject `nfsPathToLocal`'s `filepath.Base` fallback (`StorageClassBindingPathFallbackRejected` condition, `binding_rejected` audit reason) rather than trusting an ambiguous path match, closing the cross-namespace directory-takeover hazard the original design left open. Existing clusters must re-apply the CRD (`kubectl apply -f charts/nfs-quota-agent/crds/`) since the schema changed.
 
-2. **Admission Correlation Persistence** — PARTIALLY RESOLVED via PR #131 (Issue [#14](https://github.com/dasomel/nfs-quota-agent/issues/14)); admission-time correlation split out to Issue [#132](https://github.com/dasomel/nfs-quota-agent/issues/132) (open):
-   - *Resolution*: Reconcile-time decisions now get a deterministic hash of PV, policy UID/generation, outcome, and bytes, recorded in the `nfs.io/policy-decision` PV annotation and `policy.decision_id` in the audit log (per #14's commit `71ecf2d`, the annotation is written only after the PV status write succeeds, so a decision is never recorded as applied when the underlying write failed). Cache hits that change the decision still update the annotation (`decision_updated`); no PVC write, Event, or RBAC expansion was needed.
-   - *Still open* (Issue [#132](https://github.com/dasomel/nfs-quota-agent/issues/132)): admission-time rejection needs a validating webhook — a new privileged surface (`admissionregistration` objects, serving certificate/rotation, a Service, fail-open/fail-closed semantics). No implementation should start until maintainers decide whether admission-time rejection is needed at all, given reconcile-time clamping with visible decision IDs.
+2. **QuotaPolicy Admission Webhook** — RESOLVED via PR #141 (Issue [#132](https://github.com/dasomel/nfs-quota-agent/issues/132); reconcile-time correlation landed earlier in PR #131 for Issue [#14](https://github.com/dasomel/nfs-quota-agent/issues/14)):
+   - *Resolution*: Maintainers accepted ADR-0001 Option A (no webhook) on 2026-09-04 ([`docs/adr/0001-quotapolicy-admission-webhook.md:1-50`](adr/0001-quotapolicy-admission-webhook.md), PR #141). Reconcile-time clamping with deterministic decision IDs in `nfs.io/policy-decision` PV annotations and audit logs remains the enforcement contract, avoiding a webhook's privileged attack surface.
 
 3. **Air-gap Registry Credential Model** (Issue [#5](https://github.com/dasomel/nfs-quota-agent/issues/5), PR #117, PR #126 merged):
    - *Context*: Standardizing the credential and image distribution pattern for private container registries in air-gapped enterprise environments.
    - *Hazard / Constraint*: The offline bundle provides an OCI archive with `pullPolicy: Never` (PR #117, PR #126 D2). In enterprise environments with private mirror registries, operators require either `imagePullSecrets` or pre-loaded node images; maintainers must specify the standardized pattern and Helm chart configuration for private registry credentials without weakening zero-egress guarantees.
 
 4. **Next `v*` Tagged Release Execution** — RESOLVED (Issue [#26](https://github.com/dasomel/nfs-quota-agent/issues/26), Issue [#5](https://github.com/dasomel/nfs-quota-agent/issues/5), [`docs/release-egress-block.md`](release-egress-block.md)):
-   - *Resolution*: v0.4.1 (run 33772050837) and v0.4.2 (run 33817436994) both tagged and released with all jobs on `egress-policy: block` and 10/10 jobs succeeding on v0.4.2; keyless Cosign signing and offline verification (`hack/verify-release.py --require-signatures`) confirmed against both. The incremental audit-to-block flip described in [`docs/release-egress-block.md`](release-egress-block.md) is complete for the release workflow's 10 jobs.
+   - *Resolution*: v0.4.1 (run 33772050837), v0.4.2 (run 33817436994) and v0.4.3 (run 33889557844, 11/11 jobs success, all on `egress-policy: block`) tagged and released; keyless Cosign signing and offline verification (`hack/verify-release.py --require-signatures`) confirmed on v0.4.1/v0.4.2, and PR #143 adds live-registry digest verification from v0.4.3 onward. Chart `version` and `appVersion` are aligned to `0.4.3` in [`charts/nfs-quota-agent/Chart.yaml:1-18`](../charts/nfs-quota-agent/Chart.yaml) (PR #148). The v0.4.3-rc1 release run (33867414069) failed and was superseded by rc2 (33888100109, success).


### PR DESCRIPTION
Refs #81

Re-verifies the CNCF readiness evidence table against the current tree instead of the 2026-09-07 snapshot it was written against. Issue #81 is a standing strategy issue, so this refreshes it rather than closing it.

## Status upgrades (8 rows, PARTIAL → DONE)

Each is justified by work that has since merged:

| Phase | Item | Merged evidence |
|---|---|---|
| 3 | ext4 quota support verification | #149 via PR #155 (`quota_tree`/`quota_v2` in the E2E matrix) |
| 3 | Btrfs support verification & status | #149 via PR #155 |
| 4 | Container image vulnerability scan | #150 via PR #156, PR #157, PR #164 (`image-scan` job, Trivy `exit-code: 1`) |
| 4 | SLSA provenance & build manifest v4 | PR #143 live-registry verification, PR #146 SIGPIPE fix |
| 4 | OpenSSF Scorecard activation | PR #156, PR #159, PR #164 |
| 5 | Per-filesystem regression tests | #149 via PR #155 (matrix `fs: [xfs, ext4, btrfs]`) |
| 6 | Error and retry metrics | #152 via PR #160 |
| 6 | Kubernetes Events integration | #152 via PR #154, #158, #160 |
| 6 | Grafana dashboard provision | #151 via PR #153 |

Stale line ranges across the whole table are corrected to the ranges that actually carry the cited evidence, so all **203 citations pass** `scripts/ci/check-doc-citations.py` rather than merely resolving to a file.

## New quarterly run record — 2026-09-10

Holds the real output of all ten deterministic checks, including `go test -race ./...` clean across 15 packages and `govulncheck ./...` clean. Trivy completed a live vulnerability-DB pull on this run rather than needing the `--skip-db-update` fallback the 2026-09-04 record required.

Two honest negatives are recorded rather than smoothed over:
- check 5 surfaces a **stale comment at `.github/workflows/ci.yaml:16`** claiming `release.yaml` intentionally stays on `egress-policy: audit`, contradicted by check 4's live evidence that 11 of its jobs are on `block`
- check 9 explains why `e2e-airgap` correctly did not re-run: the commits between `2b45a13` and `60aa69a` touch none of its trigger paths

## Deliberately not recorded

The agent verification-skill and OpenForge execution-profile commits between `2b45a13` and `60aa69a` change agent tooling, not the product capabilities this table tracks, and no existing row covers them. Nothing here claims `nfs-quota-verification` is verified — that is #171's job, tracked separately in PR #173.

## Validation

- `python3 scripts/ci/check-doc-citations.py docs/cncf-readiness-draft.md` → `Verified 203 citation(s) across 1 file(s): all valid.`
- Counts re-derived mechanically: 99 rows = 75 DONE + 17 PARTIAL + 7 OPEN, matching the header
- Four upgraded rows spot-checked against source at the cited lines (`ci.yaml:445` `image-scan`, `e2e-airgap.yaml:24` fs matrix, `metrics.go:99` retry stats, `events.go:17` `events.k8s.io/v1`)

Docs-only change; no Go, chart, or workflow behavior is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvcQiYZjd13Ac9MfPsjkdT