### PR TITLE
chore(ci): run the CI governance self-tests and add a verify entry point

### DIFF
--- a/.agents/evals/traces/2026-09-ci-selftests-verify-target.json
+++ b/.agents/evals/traces/2026-09-ci-selftests-verify-target.json
@@ -1,0 +1,71 @@
+{
+  "schemaVersion": "openforge-agent-trace/v1",
+  "traceId": "nfs-quota-agent-ci-selftests-verify-target-2026-09",
+  "task": "Run the CI governance self-tests that no workflow ran, correct a stale egress comment, and give the repository an aggregate verify target",
+  "consistencyMode": "strict",
+  "changeContext": {
+    "paths": [
+      ".github/workflows/**",
+      ".agents/**",
+      "Makefile"
+    ]
+  },
+  "events": [
+    {
+      "id": "e1",
+      "type": "scope_check",
+      "summary": "Three findings surfaced while working #171 and #81, kept out of those changes and landed here instead; no Go, chart, quota, or release behavior is touched"
+    },
+    {
+      "id": "e2",
+      "type": "reproduction",
+      "summary": "scripts/ci/test_apk_closure_drift.py, test_check_agent_trace_requirement.py, test_check_dashboard_metrics.py and test_check_doc_citations.py are referenced by no workflow or Make target, so a regression in a CI gate would surface only as that gate silently passing; separately, ci.yaml's comment claimed release.yaml stays on egress-policy audit while release.yaml has 11 jobs on block and 0 on audit",
+      "evidence": [
+        "ci:grep -rl over .github/workflows and Makefile finds no reference to the four test files",
+        "ci:grep -c 'egress-policy: block' .github/workflows/release.yaml reports 11, audit reports 0"
+      ]
+    },
+    {
+      "id": "e3",
+      "type": "bug_fix",
+      "summary": "Added a Lint-job step running make ci-selftest so every scripts/ci/test_*.py runs, corrected the stale egress comment to what release.yaml actually does, and added make verify (fmt-check, vet, test, ci-selftest) with fmt-check and ci-selftest as its named parts"
+    },
+    {
+      "id": "e4",
+      "type": "regression_verification",
+      "status": "passed",
+      "summary": "make verify passes end to end, and all three gates were shown to fail closed: fmt-check rejects a deliberately unformatted file, ci-selftest fails when a checker function is renamed out from under its tests, and - after review raised it - ci-selftest now also fails when the discovery pattern matches nothing, since unittest discover otherwise exits 0 having run zero tests",
+      "scope": "The new Make targets and the Lint job step; no quota, chart, image, or release behavior is in scope",
+      "evidence": [
+        "test:make verify exits 0, reporting 33 CI governance self-tests and all Go packages ok",
+        "test:make fmt-check exits non-zero on an unformatted probe file",
+        "test:make ci-selftest exits non-zero when check-dashboard-metrics.py is broken",
+        "test:make ci-selftest exits non-zero when the discovery pattern matches no files",
+        "ci:unittest discovery runs on the stdlib with no pip install and no network - PR lookups are stubbed via --mock-pr-states"
+      ]
+    },
+    {
+      "id": "e5",
+      "type": "verification",
+      "status": "passed",
+      "summary": "The self-tests were already green before being wired in, so this change enforces existing behavior rather than hiding a pre-existing failure, and the mutable-input guard still passes over the edited workflow",
+      "scope": "CI wiring correctness and workflow input immutability",
+      "evidence": [
+        "ci:check-mutable-inputs.py passes for ci.yaml, release.yaml and agent-behavior.yml",
+        "ci:release.yaml has 11 jobs, 11 harden-runner steps and 11 egress-policy block, so the corrected comment is accurate",
+        "test:33 self-tests passed before and after wiring"
+      ]
+    },
+    {
+      "id": "e6",
+      "type": "completion_claim",
+      "summary": "The CI governance scripts are now covered by their own tests in CI, the egress comment matches the workflows it describes, and the repository exposes one deterministic verify entry point"
+    },
+    {
+      "id": "e7",
+      "type": "task_outcome",
+      "state": "A",
+      "summary": "All three reported side findings are closed; make verify deliberately excludes golangci-lint, helm and docker so it stays runnable without those tools"
+    }
+  ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,8 @@
 # documented source -- that set tracks go.sum and may need updating when
 # dependencies change; a block here shows up as a License Check failure
 # with the blocked domain in the job log, not a silent skip.
-# release.yaml intentionally stays on egress-policy: audit -- its last
-# successful run predates several since-added jobs (compat-matrix,
-# verify-release), so there is no fresh audit data to build a real
-# allowlist from yet. See #26.
+# release.yaml has since finished the #26 phasing and now runs every job on
+# egress-policy: block with its own allowlist; it no longer trails this file.
 # The Image Build job is new (#26) and has no audit-mode run of its own yet,
 # so its allowed-endpoints was assembled from its known fetches (Docker Hub
 # base image pulls, the Alpine apk index, the Go module proxy/sumdb) rather
@@ -135,6 +133,17 @@ jobs:
 
       - name: Check dashboard metrics
         run: python3 scripts/ci/check-dashboard-metrics.py
+
+      # These guard the CI governance scripts themselves. They shipped with
+      # self-tests that no workflow ran, so a regression in a gate would only
+      # show up as that gate silently passing. Discovery keeps new
+      # scripts/ci/test_*.py covered without another workflow edit, needs no
+      # pip install, and reaches no network (PR lookups are stubbed through
+      # --mock-pr-states). The count guard matters: `unittest discover` exits 0
+      # when it matches nothing, so a rename would otherwise turn this green
+      # with zero coverage.
+      - name: Test CI governance scripts
+        run: make ci-selftest
 
   build:
     name: Build

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ PLATFORMS?=linux/amd64,linux/arm64,linux/arm/v7
 RELEASE_DIR?=.
 CHART_FILE?=charts/$(BINARY_NAME)/Chart.yaml
 
-.PHONY: all build build-linux clean test test-coverage fmt vet tidy lint \
+.PHONY: all build build-linux clean test test-coverage fmt fmt-check vet tidy lint verify ci-selftest \
 	license sbom generate compat-matrix compat-matrix-validate verify-release verify-published-digests \
 	docker-build docker-push docker-buildx \
 	helm-lint helm-rbac-check helm-package helm-install helm-uninstall update-chart-digest \
@@ -61,9 +61,36 @@ test-coverage:
 fmt:
 	go fmt ./...
 
+# Report unformatted files without rewriting them, so CI and `verify` fail
+# instead of silently fixing the tree the way `fmt` would.
+fmt-check:
+	@unformatted=$$(gofmt -l .); \
+	if [ -n "$$unformatted" ]; then \
+		echo "gofmt needed:"; echo "$$unformatted"; exit 1; \
+	fi
+
 # Run go vet
 vet:
 	go vet ./...
+
+# Self-tests for the CI governance scripts under scripts/ci. Stdlib unittest,
+# so this needs no pip install here or on a runner, and it reaches no network
+# (PR lookups are stubbed via --mock-pr-states). The count guard is load
+# bearing: `unittest discover` exits 0 when it matches nothing, so a renamed
+# file or a broken pattern would report success having run no tests at all.
+ci-selftest:
+	@count=$$(python3 -c "import unittest; print(unittest.defaultTestLoader.discover('scripts/ci', pattern='test_*.py').countTestCases())"); \
+	if [ "$$count" -le 0 ]; then echo "discovered no scripts/ci self-tests"; exit 1; fi; \
+	echo "Running $$count CI governance self-tests"; \
+	python3 -m unittest discover -s scripts/ci -p 'test_*.py'
+
+# The deterministic baseline to pass before claiming a change is complete.
+# Deliberately dependency-light -- no docker, helm, or golangci-lint -- so it
+# runs anywhere the repo is checked out. Run `make lint`, `make helm-lint` and
+# `make docker-build` separately when the change reaches those surfaces, and
+# see .agents/skills/nfs-quota-verification/SKILL.md for which evidence a
+# given change actually needs.
+verify: fmt-check vet test ci-selftest
 
 # Tidy dependencies
 tidy:
@@ -394,6 +421,9 @@ help:
 	@echo "  test-coverage    - Run tests with coverage report"
 	@echo "  fmt              - Format code"
 	@echo "  vet              - Run go vet"
+	@echo "  fmt-check        - Fail if any file needs gofmt (does not rewrite)"
+	@echo "  ci-selftest      - Run the self-tests for scripts/ci governance scripts"
+	@echo "  verify           - Deterministic baseline: fmt-check + vet + test + ci-selftest"
 	@echo "  tidy             - Tidy go modules"
 	@echo "  lint             - Run golangci-lint"
 	@echo "  generate         - Regenerate CRD deepcopy code and manifest (controller-gen)"


### PR DESCRIPTION
Three findings reported while working #171 (PR #173) and #81 (PR #174), kept out of those changes and landed together here. No Go, chart, quota, or release behavior is touched.

## 1. Four CI self-tests that nothing ran

`scripts/ci` shipped self-tests for four of its governance scripts that **no workflow or Make target ever invoked**:

```
test_apk_closure_drift.py                ORPHANED
test_check_agent_trace_requirement.py    ORPHANED
test_check_dashboard_metrics.py          ORPHANED
test_check_doc_citations.py              ORPHANED
```

(The three shell self-tests — egress-block, provenance-meta, third-party-licenses — were already wired.)

A regression in one of those gates would have surfaced only as that gate silently passing, which is the exact failure mode they exist to prevent. The Lint job now runs them. All 33 cases already passed, so this **enforces existing behavior rather than papering over a break**. They run on stdlib `unittest` (no `pip install` on the runner) and reach no network — PR lookups are stubbed through `--mock-pr-states`.

**Review caught a hole in the first version:** `unittest discover` exits 0 when it matches nothing, so a renamed file or a broken pattern would have turned the new step green with zero coverage. `make ci-selftest` now counts the discovered cases first and fails when there are none.

## 2. Stale egress comment

`.github/workflows/ci.yaml` claimed `release.yaml` intentionally stays on `egress-policy: audit`. Left behind by the #26 phasing — `release.yaml` today has **11 jobs, 11 harden-runner steps, 11 on `block`, 0 on `audit`**. Comment corrected to what the file does.

## 3. No aggregate verify target

The Makefile had `verify-release` and `verify-published-digests` but no plain `verify`, which is why the OpenForge portfolio audit records this repo's canonical verify command as `—` while sibling repos show one.

`make verify` = `fmt-check` + `vet` + `test` + `ci-selftest`. Dependency-light on purpose — no docker, helm, or golangci-lint — so it runs wherever the repo is checked out; run `make lint`, `make helm-lint` and `make docker-build` separately when a change reaches those surfaces. `fmt-check` reports unformatted files without rewriting them the way `fmt` would.

## Evidence

| Check | Result |
|---|---|
| `make verify` | exit 0 — 33 CI self-tests + all Go packages ok |
| `make fmt-check` on a deliberately unformatted file | fails closed |
| `make ci-selftest` with a checker function renamed out from under its tests | fails closed |
| `make ci-selftest` with a discovery pattern matching nothing | fails closed |
| `check-mutable-inputs.py` over the edited workflow | passes |
| `gate.py` over all 57 traces | 0 regressions |
| trace `2026-09-ci-selftests-verify-target.json` | 4 passed, 1 n/a, 100% |

Stacking note: PR #173 adds its own dedicated step for `test_check_agent_skill_evidence.py`. Once both land, discovery here also picks that file up. The overlap is a second run of a one-second test, and the dedicated step gives a clearer failure name, so it is left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvcQiYZjd13Ac9MfPsjkdT